### PR TITLE
Removes jchart2d jar file from INSTALLED_CLASSPATH

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,7 +81,7 @@ AC_ARG_WITH(jardir,
             [jardir="$with_jardir"], [jardir=$datadir/java])
 
 AC_SUBST(jardir)
-INSTALLED_CLASSPATH=\${jardir}/lcm.jar:\${jardir}/jchart2d-${CHART2D_VERSION}.jar
+INSTALLED_CLASSPATH=\${jardir}/lcm.jar
 AC_SUBST(INSTALLED_CLASSPATH)
 AC_SUBST(java_apiversion)
 


### PR DESCRIPTION
Removes jchart2d jar file from INSTALLED_CLASSPATH variable since it appears to be no longer installed.  It was getting propagated through to the pkg-config file which was causing MATLAB to throw an error when trying to add it to its path (Drake uses the .pc file to find the lcm.jar file).

Albert: can you confirm that the jchart2d jar is not installed anymore with your new build setup?