### PR TITLE
Added LogFile::getUnderlyingLogFile() for C++

### DIFF
--- a/lcm/lcm-cpp-impl.hpp
+++ b/lcm/lcm-cpp-impl.hpp
@@ -355,3 +355,9 @@ LogFile::writeEvent(LogEvent* event)
     evt.data = event->data;
     return lcm_eventlog_write_event(eventlog, &evt);
 }
+
+FILE*
+LogFile::getFilePtr()
+{
+    return eventlog->f;
+}

--- a/lcm/lcm-cpp.hpp
+++ b/lcm/lcm-cpp.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdio>  /* needed for FILE* */
 #include "lcm.h"
 
 namespace lcm {
@@ -548,6 +549,18 @@ class LogFile {
          * @sa lcm_eventlog_write_event()
          */
         inline int writeEvent(LogEvent* event);
+
+        /**
+         * @brief retrives the underlying FILE* wrapped by this class.
+         *
+         * This method should be used carefully and sparingly.
+         * An example use-case is borrowing to tweak the behavior of the I/O.
+         * Calls of interest include fflush(), fileno(), setvbuf(), etc
+         * It is a bad idea to attempt reading or writing on the raw FILE*
+         *
+         * @return the FILE* wrapped by this object.
+         */
+         inline FILE* getFilePtr();
 
     private:
         LogEvent curEvent;


### PR DESCRIPTION
This is vital for performing special I/O tuning on the underlying FILE*
Sometimes calls such as fflush(), fileno(), setvbuf(), etc are required for performance reasons.
Without this call, the C++ API is unusable.