### PR TITLE
Fixes an issue with multiple indented types

### DIFF
--- a/lcm-java/lcm/spy/ObjectPanel.java
+++ b/lcm-java/lcm/spy/ObjectPanel.java
@@ -371,8 +371,7 @@ public class ObjectPanel extends JPanel
             }
 
             // if this section is collapsed, resume drawing.
-            if (sections.get(section).collapsed)
-            {
+            if (sections.get(section).collapsed) {
                 collapse_depth --;
             }
 

--- a/lcm-java/lcm/spy/ObjectPanel.java
+++ b/lcm-java/lcm/spy/ObjectPanel.java
@@ -354,8 +354,9 @@ public class ObjectPanel extends JPanel
 
 
             // if this section is collapsed, stop drawing.
-            if (sections.get(section).collapsed)
+            if (sections.get(section).collapsed) {
                 collapse_depth ++;
+            }
 
             return section;
         }
@@ -364,12 +365,17 @@ public class ObjectPanel extends JPanel
         {
             Section cs = sections.get(section);
             cs.y1 = y;
+            
+            if (collapse_depth == 0) {
+                unindent();
+            }
 
             // if this section is collapsed, resume drawing.
             if (sections.get(section).collapsed)
+            {
                 collapse_depth --;
+            }
 
-            unindent();
             spacer();
             endColorBlock();
             spacer();


### PR DESCRIPTION
Collapsing a multiple indented type would cause the indent level to go negative, making the types unreadable.  Thanks to Adam Bry for the help.