### PR TITLE
add -cpp-std option

### DIFF
--- a/lcmgen/emit_cpp.c
+++ b/lcmgen/emit_cpp.c
@@ -4,8 +4,6 @@
 #include <assert.h>
 #include <string.h>
 #include <ctype.h>
-#include <unistd.h>
-#include <stdbool.h>
 #ifdef WIN32
 #define __STDC_FORMAT_MACROS			// Enable integer types
 #endif

--- a/lcmgen/emit_cpp.c
+++ b/lcmgen/emit_cpp.c
@@ -4,6 +4,8 @@
 #include <assert.h>
 #include <string.h>
 #include <ctype.h>
+#include <unistd.h>
+#include <stdbool.h>
 #ifdef WIN32
 #define __STDC_FORMAT_MACROS			// Enable integer types
 #endif
@@ -300,6 +302,12 @@ static void emit_header_start(lcmgen_t *lcmgen, FILE *f, lcm_struct_t *ls)
                 suffix = "LL";
               char* mapped_typename = map_type_name(lc->lctypename);
               char *cpp_std = getopt_get_string(lcmgen->gopt, "cpp-std");
+              if(strcmp("c++98",cpp_std) && strcmp("c++11",cpp_std)) {
+                  printf("%s is not a valid cpp_std. Use --cpp-std=c++98 or --cpp-std=c++11 instead\n\n", cpp_std);
+                  fflush(stdout);
+                  _exit(1);
+              }
+
               if(!strcmp (cpp_std, "c++11")) {
                 emit(2, "static constexpr %-8s %s = %s%s;", mapped_typename,
                   lc->membername, lc->val_str, suffix);

--- a/lcmgen/emit_cpp.c
+++ b/lcmgen/emit_cpp.c
@@ -194,7 +194,7 @@ static void emit_header_start(lcmgen_t *lcmgen, FILE *f, lcm_struct_t *ls)
     char *tn = ls->structname->lctypename;
     char *sn = ls->structname->shortname;
     char *tn_ = dots_to_underscores(tn);
-    
+
     emit_auto_generated_warning(f);
 
     fprintf(f, "#include <lcm/lcm_coretypes.h>\n");
@@ -749,7 +749,7 @@ int emit_cpp(lcmgen_t *lcmgen)
                 getopt_get_string(lcmgen->gopt, "cpp-hpath"),
                 strlen(getopt_get_string(lcmgen->gopt, "cpp-hpath")) > 0 ? G_DIR_SEPARATOR_S : "",
                 tn_);
-                
+
         // generate code if needed
         if (lcm_needs_generation(lcmgen, lr->lcmfile, header_name)) {
             make_dirs_for_file(header_name);

--- a/lcmgen/emit_cpp.c
+++ b/lcmgen/emit_cpp.c
@@ -194,9 +194,6 @@ static void emit_header_start(lcmgen_t *lcmgen, FILE *f, lcm_struct_t *ls)
     char *tn = ls->structname->lctypename;
     char *sn = ls->structname->shortname;
     char *tn_ = dots_to_underscores(tn);
-
-    // get cpp standard
-    char *cpp_std = getopt_get_string(lcmgen->gopt, "cpp-std");
     
     emit_auto_generated_warning(f);
 
@@ -302,6 +299,7 @@ static void emit_header_start(lcmgen_t *lcmgen, FILE *f, lcm_struct_t *ls)
               if (!strcmp(lc->lctypename, "int64_t"))
                 suffix = "LL";
               char* mapped_typename = map_type_name(lc->lctypename);
+              char *cpp_std = getopt_get_string(lcmgen->gopt, "cpp-std");
               if(!strcmp (cpp_std, "c++11")) {
                 emit(2, "static constexpr %-8s %s = %s%s;", mapped_typename,
                   lc->membername, lc->val_str, suffix);


### PR DESCRIPTION
- Added cpp-std option
- Emitting ```static const``` for constants by default, and ```static constexpr``` for c++11. I think ```constexpr``` is more flexible that just ```const```, even though both works.

Let me know if there are any other C++11 issues that need to be resolved in this PR