### PR TITLE
use subprocess module instead of deprecated commands module

### DIFF
--- a/lcm-python/setup.py
+++ b/lcm-python/setup.py
@@ -1,7 +1,8 @@
-import commands
+import subprocess
 from distutils.core import setup, Extension
 from distutils import msvccompiler
 import os
+import sys
 
 sources = [ \
     "module.c",
@@ -64,19 +65,19 @@ else:
     pkg_deps = "glib-2.0 gthread-2.0"
 
     # include path
-    pkgconfig_include_flags = commands.getoutput("pkg-config --cflags-only-I")
+    pkgconfig_include_flags = subprocess.check_output( ["pkg-config", "--cflags-only-I", pkg_deps] ).decode(sys.stdout.encoding)
     include_dirs = [ t[2:] for t in pkgconfig_include_flags.split() ]
 
     # libraries
-    pkgconfig_lflags = commands.getoutput("pkg-config --libs-only-l %s" % pkg_deps)
+    pkgconfig_lflags = subprocess.check_output( ["pkg-config", "--libs-only-l", pkg_deps] ).decode(sys.stdout.encoding)
     libraries = [ t[2:] for t in pkgconfig_lflags.split() ]
 
     # link directories
-    pkgconfig_biglflags = commands.getoutput("pkg-config --libs-only-L %s" % pkg_deps)
+    pkgconfig_biglflags = subprocess.check_output( ["pkg-config", "--libs-only-L", pkg_deps ] ).decode(sys.stdout.encoding)
     library_dirs = [ t[2:] for t in pkgconfig_biglflags.split() ]
 
     # other compiler flags
-    pkgconfig_cflags = commands.getoutput("pkg-config --cflags %s" % pkg_deps).split()
+    pkgconfig_cflags = subprocess.check_output( ["pkg-config", "--cflags", pkg_deps] ).decode(sys.stdout.encoding).split()
     extra_compile_args = [ \
         '-Wno-strict-prototypes',
         "-D_FILE_OFFSET_BITS=64",


### PR DESCRIPTION
`setup.py` in lcm-python should use `subprocess` to run `pkg-config`, instead of using the deprecated `commands` module

This allows installation of lcm in a python 3 `venv` using `pip`, e.g.:
```shell
(some-venv) $ pip install -e ~/Repositories/foss/lcm/lcm-python/
```

The change doesn't prevent the normal `./configure;make;make install` from working correctly with python 2.7 on my Mac. It also doesn't have a problem if you run `sudo python setup.py install` from within the lcm-python directory. 

However, it does seem to have an issue with using `pip` for python 2.7, where the explicit call to `sys.stdout.encoding` is returning `None` from within `pip` for 2.7, and `'UTF-8'` otherwise. This is not a problem with LCM, but may be a bug in `pip`. Removing `sys.stdout.encoding` solves the problem on my system, but I left it in because not having it might cause problems on systems where `stdout` does not return in `UTF-8`.
 