### PR TITLE
Fix a dangerous bug in lcm's marshalling and hash functions.

### DIFF
--- a/lcm-java/lcm/spy/ObjectPanel.java
+++ b/lcm-java/lcm/spy/ObjectPanel.java
@@ -322,6 +322,7 @@ public class ObjectPanel extends JPanel
                 g.drawString(tok, tok_pixidx, y);
                 g.drawString(drawtype, type_pixidx, y);
 
+                int y_top = y;
                 // check if type field is too long. put name on new line if yes
                 if (type_pixidx + type_len > x[1])
                     y+= textheight;
@@ -339,12 +340,11 @@ public class ObjectPanel extends JPanel
                 // we are collapsed.
                 cs.x0 = x[0];
                 cs.x1 = getWidth();
-                cs.y0 = y - textheight;
+                cs.y0 = y_top - textheight;
                 cs.y1 = y;
 
                 y += textheight;
 
-                indent();
             }
             else
             {
@@ -356,6 +356,9 @@ public class ObjectPanel extends JPanel
             // if this section is collapsed, stop drawing.
             if (sections.get(section).collapsed) {
                 collapse_depth ++;
+            } else if (collapse_depth == 0) {
+                // Only indent if this section isn't collapsed.
+                indent();
             }
 
             return section;
@@ -364,7 +367,6 @@ public class ObjectPanel extends JPanel
         public void endSection(int section)
         {
             Section cs = sections.get(section);
-            cs.y1 = y;
             
             if (collapse_depth == 0) {
                 unindent();

--- a/lcm/eventlog.c
+++ b/lcm/eventlog.c
@@ -193,7 +193,6 @@ int lcm_eventlog_seek_to_timestamp(lcm_eventlog_t *l, int64_t timestamp)
         if (cur_time < 0)
             return -1;
 
-        frac = (double)ftello (l->f)/file_len;
         if ((frac > frac2) || (frac < frac1) || (frac1>=frac2))
             break;
     

--- a/lcm/ioutils.h
+++ b/lcm/ioutils.h
@@ -21,7 +21,10 @@ static inline int fwrite32(FILE *f, int32_t v)
 
 static inline int fwrite64(FILE *f, int64_t v64)
 {
-    int32_t v = v64>>32;
+    //  See Section 5.8 paragraph 3 of the standard
+    //  http://open-std.org/JTC1/SC22/WG21/docs/papers/2015/n4527.pdf
+    //  use uint for shifting instead if int
+    int32_t v = ((uint64_t)v64)>>32;
     if (0 != fwrite32(f, v)) return -1;
     v = v64 & 0xffffffff;
     return fwrite32(f, v);
@@ -49,7 +52,10 @@ static inline int fread64(FILE *f, int64_t *v64)
     if (fread32(f, &v2))
         return -1;
 
-    *v64 =     (((int64_t) v1)<<32) | (((int64_t) v2)&0xffffffff);
+    //  See Section 5.8 paragraph 3 of the standard
+    //  http://open-std.org/JTC1/SC22/WG21/docs/papers/2015/n4527.pdf
+    //  use uint for shifting instead if int
+    *v64 =     (int64_t)(((uint64_t) v1)<<32) | (((int64_t) v2)&0xffffffff);
 
     return 0;
 }

--- a/lcm/lcm_coretypes.h
+++ b/lcm/lcm_coretypes.h
@@ -144,8 +144,12 @@ static inline int __int16_t_encode_array(void *_buf, int offset, int maxlen, con
     if (maxlen < total_size)
         return -1;
 
+    //  See Section 5.8 paragraph 3 of the standard
+    //  http://open-std.org/JTC1/SC22/WG21/docs/papers/2015/n4527.pdf
+    //  use uint for shifting instead if int
+    const uint16_t *unsigned_p = (uint16_t*)p;
     for (element = 0; element < elements; element++) {
-        int16_t v = p[element];
+        uint16_t v = unsigned_p[element];
         buf[pos++] = (v>>8) & 0xff;
         buf[pos++] = (v & 0xff);
     }
@@ -200,8 +204,12 @@ static inline int __int32_t_encode_array(void *_buf, int offset, int maxlen, con
     if (maxlen < total_size)
         return -1;
 
+    //  See Section 5.8 paragraph 3 of the standard
+    //  http://open-std.org/JTC1/SC22/WG21/docs/papers/2015/n4527.pdf
+    //  use uint for shifting instead if int
+    const uint32_t* unsigned_p = (uint32_t*)p;
     for (element = 0; element < elements; element++) {
-        int32_t v = p[element];
+        const uint32_t v = unsigned_p[element];
         buf[pos++] = (v>>24)&0xff;
         buf[pos++] = (v>>16)&0xff;
         buf[pos++] = (v>>8)&0xff;
@@ -221,8 +229,11 @@ static inline int __int32_t_decode_array(const void *_buf, int offset, int maxle
     if (maxlen < total_size)
         return -1;
 
+    //  See Section 5.8 paragraph 3 of the standard
+    //  http://open-std.org/JTC1/SC22/WG21/docs/papers/2015/n4527.pdf
+    //  use uint for shifting instead if int
     for (element = 0; element < elements; element++) {
-        p[element] = (((int32_t)buf[pos+0])<<24) + (((int32_t)buf[pos+1])<<16) + (((int32_t)buf[pos+2])<<8) + ((int32_t)buf[pos+3]);
+        p[element] = (((uint32_t)buf[pos+0])<<24) + (((uint32_t)buf[pos+1])<<16) + (((uint32_t)buf[pos+2])<<8) + ((uint32_t)buf[pos+3]);
         pos+=4;
     }
 
@@ -258,8 +269,12 @@ static inline int __int64_t_encode_array(void *_buf, int offset, int maxlen, con
     if (maxlen < total_size)
         return -1;
 
+    //  See Section 5.8 paragraph 3 of the standard
+    //  http://open-std.org/JTC1/SC22/WG21/docs/papers/2015/n4527.pdf
+    //  use uint for shifting instead if int
+    const uint64_t * unsigned_p = (uint64_t*)p;
     for (element = 0; element < elements; element++) {
-        int64_t v = p[element];
+        const uint64_t v = unsigned_p[element];
         buf[pos++] = (v>>56)&0xff;
         buf[pos++] = (v>>48)&0xff;
         buf[pos++] = (v>>40)&0xff;
@@ -283,10 +298,13 @@ static inline int __int64_t_decode_array(const void *_buf, int offset, int maxle
     if (maxlen < total_size)
         return -1;
 
+    //  See Section 5.8 paragraph 3 of the standard
+    //  http://open-std.org/JTC1/SC22/WG21/docs/papers/2015/n4527.pdf
+    //  use uint for shifting instead if int
     for (element = 0; element < elements; element++) {
-        int64_t a = (((int32_t)buf[pos+0])<<24) + (((int32_t)buf[pos+1])<<16) + ((int32_t)buf[pos+2]<<8) + (int32_t)buf[pos+3];
+        uint64_t a = (((uint32_t)buf[pos+0])<<24) + (((uint32_t)buf[pos+1])<<16) + (((uint32_t)buf[pos+2])<<8) + (uint32_t)buf[pos+3];
         pos+=4;
-        int64_t b = (((int32_t)buf[pos+0])<<24) + (((int32_t)buf[pos+1])<<16) + ((int32_t)buf[pos+2]<<8) + (int32_t)buf[pos+3];
+        uint64_t b = (((uint32_t)buf[pos+0])<<24) + (((uint32_t)buf[pos+1])<<16) + (((uint32_t)buf[pos+2])<<8) + (uint32_t)buf[pos+3];
         pos+=4;
         p[element] = (a<<32) + (b&0xffffffff);
     }

--- a/lcmgen/emit_c.c
+++ b/lcmgen/emit_c.c
@@ -342,7 +342,7 @@ static void emit_header_prototypes(lcmgen_t *lcmgen, FILE *f, lcm_struct_t *ls)
 
     emit(0,"// LCM support functions. Users should not call these");
     emit(0,"int64_t __%s_get_hash(void);", tn_);
-    emit(0,"int64_t __%s_hash_recursive(const __lcm_hash_ptr *p);", tn_);
+    emit(0,"uint64_t __%s_hash_recursive(const __lcm_hash_ptr *p);", tn_);
     emit(0,"int     __%s_encode_array(void *buf, int offset, int maxlen, const %s *p, int elements);", tn_, tn_);
     emit(0,"int     __%s_decode_array(const void *buf, int offset, int maxlen, %s *p, int elements);", tn_, tn_);
     emit(0,"int     __%s_decode_array_cleanup(%s *p, int elements);", tn_, tn_);
@@ -358,10 +358,10 @@ static void emit_c_struct_get_hash(lcmgen_t *lcm, FILE *f, lcm_struct_t *ls)
     char *tn_ = dots_to_underscores(tn);
 
     emit(0, "static int __%s_hash_computed;", tn_);
-    emit(0, "static int64_t __%s_hash;", tn_);
+    emit(0, "static uint64_t __%s_hash;", tn_);
     emit(0, "");
 
-    emit(0, "int64_t __%s_hash_recursive(const __lcm_hash_ptr *p)", tn_);
+    emit(0, "uint64_t __%s_hash_recursive(const __lcm_hash_ptr *p)", tn_);
     emit(0, "{");
     emit(1,     "const __lcm_hash_ptr *fp;");
     emit(1,     "for (fp = p; fp != NULL; fp = fp->parent)");
@@ -373,7 +373,7 @@ static void emit_c_struct_get_hash(lcmgen_t *lcm, FILE *f, lcm_struct_t *ls)
     emit(1, "cp.v = (void*)__%s_get_hash;", tn_);
     emit(1, "(void) cp;");
     emit(0, "");
-    emit(1, "int64_t hash = (int64_t)0x%016"PRIx64"LL", ls->hash);
+    emit(1, "uint64_t hash = (uint64_t)0x%016"PRIx64"LL", ls->hash);
 
     for (unsigned int m = 0; m < g_ptr_array_size(ls->members); m++) {
         lcm_member_t *lm = (lcm_member_t *) g_ptr_array_index(ls->members, m);
@@ -389,7 +389,7 @@ static void emit_c_struct_get_hash(lcmgen_t *lcm, FILE *f, lcm_struct_t *ls)
     emit(0, "int64_t __%s_get_hash(void)", tn_);
     emit(0, "{");
     emit(1, "if (!__%s_hash_computed) {", tn_);
-    emit(2,      "__%s_hash = __%s_hash_recursive(NULL);", tn_, tn_);
+    emit(2,      "__%s_hash = (int64_t)__%s_hash_recursive(NULL);", tn_, tn_);
     emit(2,      "__%s_hash_computed = 1;", tn_);
     emit(1,      "}");
     emit(0, "");
@@ -499,7 +499,11 @@ static void emit_c_encode_array(lcmgen_t *lcm, FILE *f, lcm_struct_t *ls)
 
     emit(0,"int __%s_encode_array(void *buf, int offset, int maxlen, const %s *p, int elements)", tn_, tn_);
     emit(0,"{");
-    emit(1,    "int pos = 0, thislen, element;");
+    emit(1,    "int pos = 0, element;");
+    if (g_ptr_array_size(ls->members) > 0) {
+        emit(1, "int thislen;");
+    }
+
     emit(0,"");
     emit(1,    "for (element = 0; element < elements; element++) {");
     emit(0,"");

--- a/lcmgen/emit_cpp.c
+++ b/lcmgen/emit_cpp.c
@@ -368,7 +368,7 @@ static void emit_header_start(lcmgen_t *lcmgen, FILE *f, lcm_struct_t *ls)
     emit(2, "inline int _encodeNoHash(void *buf, int offset, int maxlen) const;");
     emit(2, "inline int _getEncodedSizeNoHash() const;");
     emit(2, "inline int _decodeNoHash(const void *buf, int offset, int maxlen);");
-    emit(2, "inline static int64_t _computeHash(const __lcm_hash_ptr *p);");
+    emit(2, "inline static uint64_t _computeHash(const __lcm_hash_ptr *p);");
     emit(0, "};");
     emit(0, "");
 
@@ -381,7 +381,7 @@ static void emit_encode(lcmgen_t *lcm, FILE *f, lcm_struct_t *ls)
     emit(0, "int %s::encode(void *buf, int offset, int maxlen) const", sn);
     emit(0, "{");
     emit(1,     "int pos = 0, tlen;");
-    emit(1,     "int64_t hash = getHash();");
+    emit(1,     "int64_t hash = (int64_t)getHash();");
     emit(0, "");
     emit(1,     "tlen = __int64_t_encode_array(buf, offset + pos, maxlen - pos, &hash, 1);");
     emit(1,     "if(tlen < 0) return tlen; else pos += tlen;");
@@ -446,7 +446,7 @@ static void emit_compute_hash(lcmgen_t *lcm, FILE *f, lcm_struct_t *ls)
     }
 
     if(last_complex_member >= 0) {
-        emit(0, "int64_t %s::_computeHash(const __lcm_hash_ptr *p)", sn);
+        emit(0, "uint64_t %s::_computeHash(const __lcm_hash_ptr *p)", sn);
         emit(0, "{");
         emit(1,     "const __lcm_hash_ptr *fp;");
         emit(1,     "for(fp = p; fp != NULL; fp = fp->parent)");
@@ -456,7 +456,7 @@ static void emit_compute_hash(lcmgen_t *lcm, FILE *f, lcm_struct_t *ls)
             emit(1, "const __lcm_hash_ptr cp = { p, (void*)%s::getHash };", sn);
         }
         emit(0, "");
-        emit(1,     "int64_t hash = 0x%016"PRIx64"LL +", ls->hash);
+        emit(1,     "uint64_t hash = 0x%016"PRIx64"LL +", ls->hash);
 
         for (unsigned int m = 0; m <= last_complex_member; m++) {
             lcm_member_t *lm = (lcm_member_t *) g_ptr_array_index(ls->members, m);
@@ -470,9 +470,9 @@ static void emit_compute_hash(lcmgen_t *lcm, FILE *f, lcm_struct_t *ls)
         }
         emit(0, "");
     } else {
-        emit(0, "int64_t %s::_computeHash(const __lcm_hash_ptr *)", sn);
+        emit(0, "uint64_t %s::_computeHash(const __lcm_hash_ptr *)", sn);
         emit(0, "{");
-        emit(1,     "int64_t hash = 0x%016"PRIx64"LL;", ls->hash);
+        emit(1,     "uint64_t hash = 0x%016"PRIx64"LL;", ls->hash);
     }
 
     emit(1, "return (hash<<1) + ((hash>>63)&1);");


### PR DESCRIPTION
This change fixes issues that were caused by the unspecified behavior when shifting a negative signed integer. This was being done in both the marshalling code, and message hash computation.

Most of the time, the compiler would treat them as unsigned, but in some rare circumstances (always with optimizations turned on) it would not give the expected result.

See Section 5.8 paragraph 3 of the standard
http://open-std.org/JTC1/SC22/WG21/docs/papers/2015/n4527.pdf

In the C/C++ lcm-gen, switch to using use uint64_t for computing the lcmtype hashes (the getHash() method still returns an int64_t since that is what goes across the wire).

In The marshalling code, cast to uint64_t before bit-shifting

There are a couple other minor changes that we had stored up in this branch as well.