### PR TITLE
Fix build error under cygwin gcc.

### DIFF
--- a/lcm/Makefile.am
+++ b/lcm/Makefile.am
@@ -4,7 +4,7 @@ AM_CPPFLAGS = $(GLIB_CFLAGS)
 
 lib_LTLIBRARIES = liblcm.la
 
-liblcm_la_LDFLAGS = -version-info @LIBLCM_VERSION_INFO@
+liblcm_la_LDFLAGS = -version-info @LIBLCM_VERSION_INFO@ -no-undefined
 liblcm_la_SOURCES = \
 	dbg.h \
 	lcm.c \


### PR DESCRIPTION
I know the official build process on windows is VS2013, but I've been building in cygwin from the stable release successfully. On git HEAD it fails linking liblcm.la, saying 
```
CCLD     liblcm.la
libtool:   error: can't build x86_64-pc-msys shared library unless -no-undefined is specified
Makefile:502: recipe for target 'liblcm.la' failed
```
The C bindings build correctly after adding `-no-undefined` to the libtool flags as done here.

There's still another issue with the java bindings I haven't worked out, where it fails with

```
/bin/sh: line 6: /c/Program: No such file or directory
```

This is because java (by default) is installed to "Program Files" which has a space in it. Going into the lcm-java/Makefile and adding quotes around the paths with for `JAR=` and `JAVAC=` solves it-- however I'm not savvy enough with autotools to know what template to edit to fix that (looks like it gets set on https://github.com/lcm-proj/lcm/blob/master/configure.ac#L10 but not sure what to do quote it)

