### PR TITLE
Add support for Lua 5.3. There are functions which were deprecated in…

### DIFF
--- a/lcm-lua/lua_ver_helper.h
+++ b/lcm-lua/lua_ver_helper.h
@@ -12,7 +12,7 @@
 #define luaX_setfenv(L, INDEX) lua_setfenv(L, INDEX)
 #define luaX_getfenv(L, INDEX) lua_getfenv(L, INDEX)
 
-#elif LUA_VERSION_NUM == 502
+#elif LUA_VERSION_NUM >= 502
 
 #define luaX_registerglobal(L, NAME, FUNCS) \
   do {                                      \

--- a/lcm-lua/lualcm_lcm.h
+++ b/lcm-lua/lualcm_lcm.h
@@ -1,6 +1,9 @@
 #ifndef TPRK77_LCM_LCM_H
 #define TPRK77_LCM_LCM_H
 
+// Needed for luaL_checkint which is deprecated in Lua 5.3
+#define LUA_COMPAT_APIINTCASTS
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
… 5.3, but a define was added to suppress the warning. Code builds and all tests pass.