### PR TITLE
Add java option to prefer IPv4 in lcm-spy

### DIFF
--- a/lcm-java/Makefile.am
+++ b/lcm-java/Makefile.am
@@ -22,7 +22,7 @@ lcm-logplayer-gui: Makefile
 
 lcm-spy: Makefile
 	@echo > $@ "#!/bin/sh"
-	@echo >> $@ "exec java -server -Xincgc -Xmx128m -Xms64m -ea -cp ${jardir}/lcm.jar lcm.spy.Spy \$$*"
+	@echo >> $@ "exec java -server -Djava.net.preferIPv4Stack=true -Xincgc -Xmx128m -Xms64m -ea -cp ${jardir}/lcm.jar lcm.spy.Spy \$$*"
 	chmod 755 $@
 
 javaroot_cleanfiles = $(shell find $(JAVAROOT) -type f)


### PR DESCRIPTION
This avoids the error:
```
java.net.SocketException: Can't assign requested address
```
on OSX connected via WiFi (see [StackOverflow]).

I believe it shouldn't have any adverse effects for others, since I always see `lcm-spy` saying:
```
LCM: Disabling IPV6 support
```
anyway.

But if it causes problems for any users, just let me know and I'll look for a more general solution.

[StackOverflow]: http://stackoverflow.com/questions/18747134/