### PR TITLE
Fix VS2010 compiler warning

### DIFF
--- a/lcm/dbg.h
+++ b/lcm/dbg.h
@@ -198,7 +198,7 @@ static void dbg_init()
 
 #else
 
-#define dbg(mode, arg) 
+#define dbg(mode, ...) 
 #define dbg_active(mode) false
 #define cdbg(mode,color,dtag,arg) 
 


### PR DESCRIPTION
VS2010 raises compiler warning
C4002: too many actual parameters for macro 'dbg'
if compiled with NO_DBG