### PR TITLE
Remove old gthread-2.0 dependency

### DIFF
--- a/WinSpecific/vs12/UseGlib.props
+++ b/WinSpecific/vs12/UseGlib.props
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
@@ -7,7 +7,7 @@
       <AdditionalIncludeDirectories>$(GLIB_PATH)\include\glib-2.0;$(GLIB_PATH)\lib\glib-2.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>glib-2.0.lib;gthread-2.0.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>glib-2.0.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(GLIB_PATH)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AM_INIT_AUTOMAKE([foreign tar-ustar])
 AC_CONFIG_MACRO_DIR([m4])
 
 AC_PROG_CC
-PKG_CHECK_MODULES(GLIB,[glib-2.0 >= 2.0.0 gthread-2.0 >= 2.0.0],,[AC_MSG_ERROR([LCM requires GLib >= 2.0])])
+PKG_CHECK_MODULES(GLIB,[glib-2.0 >= 2.32.0],,[AC_MSG_ERROR([LCM requires GLib >= 2.32])])
 AC_PATH_PROGS(JAR, [jar])
 AC_PATH_PROGS(JAVAC, [javac])
 

--- a/lcm-logger/lcm-logger.vcproj
+++ b/lcm-logger/lcm-logger.vcproj
@@ -62,7 +62,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="Ws2_32.lib winmm.lib lcmd.lib getopt.lib glib-2.0.lib gthread-2.0.lib"
+				AdditionalDependencies="Ws2_32.lib winmm.lib lcmd.lib getopt.lib glib-2.0.lib"
 				LinkIncremental="2"
 				AdditionalLibraryDirectories="..\WinSpecific\debug; $(GLIB_PATH)\lib"
 				GenerateDebugInformation="true"
@@ -138,7 +138,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="Ws2_32.lib winmm.lib lcm.lib getopt.lib glib-2.0.lib gthread-2.0.lib"
+				AdditionalDependencies="Ws2_32.lib winmm.lib lcm.lib getopt.lib glib-2.0.lib"
 				LinkIncremental="1"
 				AdditionalLibraryDirectories="..\WinSpecific\release; $(GLIB_PATH)\lib"
 				GenerateDebugInformation="true"

--- a/lcm-lua/rock/LUAROCKS_INSTALL.md
+++ b/lcm-lua/rock/LUAROCKS_INSTALL.md
@@ -10,8 +10,8 @@ Avoid using the both the Autotools build and LuaRocks. Using both will cause the
 module to be installed twice, in two different location. You should really only
 use one or the other, to avoid confusion later when updating, uninstalling, etc.
 
-The rock depends on `glib-2.0` and `gthread-2.0`, like the LCM library itself.
-The rock does not depend on the LCM library; the LCM sources are compiled in.
+The rock depends on `glib-2.0`, like the LCM library itself. The rock does not
+depend on the LCM library; the LCM sources are compiled in.
 
 LuaRocks will look for:
 

--- a/lcm-lua/rock/lcm-1.3.0-0.rockspec
+++ b/lcm-lua/rock/lcm-1.3.0-0.rockspec
@@ -62,8 +62,7 @@ build = {
       },
       defines = {},
       libraries = {
-        "glib-2.0",
-        "gthread-2.0"
+        "glib-2.0"
       },
       incdirs = {
         "../..",
@@ -102,8 +101,7 @@ build = {
           defines = {'WIN32="lean_and_mean"'},
           libraries = {
             "Ws2_32",
-            "glib-2.0",
-            "gthread-2.0"
+            "glib-2.0"
           }
         }
       }

--- a/lcm-python/README
+++ b/lcm-python/README
@@ -15,7 +15,7 @@ BUILD REQUIREMENTS:
   - you should be able to build the LCM C library from Visual Studio.
   - you must set the GLIB_PATH environment variable.
   - The following files need to be discoverable by the dynamic linker:
-    intl.dll, libglib-2.0-0.dll, libgthread-2.0-0.dll
+    intl.dll, libglib-2.0-0.dll
 
 INSTALLATION:
   from a command shell:

--- a/lcm-python/setup.py
+++ b/lcm-python/setup.py
@@ -46,7 +46,7 @@ if os.name == 'nt':
     # define additional macro WIN32, used to discriminate win specific code
     define_macros = [('WIN32', 1)]
 
-    libraries = [ 'Ws2_32', 'glib-2.0', 'gthread-2.0' ]
+    libraries = [ 'Ws2_32', 'glib-2.0' ]
 
     # compiler arguments
     # /TP enforces compilation of code as c++
@@ -62,7 +62,7 @@ if os.name == 'nt':
     sources.append(os.path.join("..", "lcm", "windows", "WinPorting.cpp"))
 
 else:
-    pkg_deps = "glib-2.0 gthread-2.0"
+    pkg_deps = "glib-2.0"
 
     # include path
     pkgconfig_include_flags = subprocess.check_output( ["pkg-config", "--cflags-only-I", pkg_deps] ).decode(sys.stdout.encoding)

--- a/lcm/lcm.pc.in
+++ b/lcm/lcm.pc.in
@@ -5,7 +5,7 @@ includedir=@includedir@
 
 Name: lcm
 Description: Lightweight Communications and Marshalling (LCM)
-Requires: glib-2.0 gthread-2.0
+Requires: glib-2.0 >= 2.32.0
 Version: @VERSION@
 Libs: -L${libdir} -llcm
 Cflags: -I${includedir}

--- a/lcm/lcm.vcproj
+++ b/lcm/lcm.vcproj
@@ -63,7 +63,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=" /SECTION:.winlcm,RWS"
-				AdditionalDependencies="Ws2_32.lib winmm.lib glib-2.0.lib gthread-2.0.lib"
+				AdditionalDependencies="Ws2_32.lib winmm.lib glib-2.0.lib"
 				OutputFile="$(OutDir)\$(ProjectName)d.dll"
 				AdditionalLibraryDirectories="$(GLIB_PATH)\lib"
 				GenerateDebugInformation="true"
@@ -137,7 +137,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=" /SECTION:.winlcm,RWS"
-				AdditionalDependencies="Ws2_32.lib winmm.lib glib-2.0.lib gthread-2.0.lib"
+				AdditionalDependencies="Ws2_32.lib winmm.lib glib-2.0.lib"
 				AdditionalLibraryDirectories="$(GLIB_PATH)\lib"
 				RandomizedBaseAddress="1"
 				DataExecutionPrevention="0"


### PR DESCRIPTION
Fixes #76. Updated dependency of glib-2.0 to require version 2.32 or
higher, where possible. I'm not sure if it's possible to express this
for the Windows build.