### PR TITLE
Disable sanitization in lcmgen

### DIFF
--- a/lcmgen/CMakeLists.txt
+++ b/lcmgen/CMakeLists.txt
@@ -14,6 +14,12 @@ set(lcm-gen_sources
   tokenize.h
 )
 
+macro(strip_flag FLAG VAR)
+  string(REGEX REPLACE "${FLAG}" "" ${VAR} "${${VAR}}")
+endmacro()
+strip_flag("-fsanitize=(address|memory)" CMAKE_C_FLAGS)
+strip_flag("-fsanitize=(address|memory)" CMAKE_EXE_LINKER_FLAGS)
+
 add_executable(lcm-gen ${lcm-gen_sources})
 target_link_libraries(lcm-gen PRIVATE GLib2::glib)
 


### PR DESCRIPTION
Remove clang address/memory sanitization options when building `lcmgen`, as it is known to be sloppy about memory management and (per the comment in the source) we don't really care, since non-systemic leaks in a short lived process like lcmgen aren't really a problem. However, building with sanitization results in a broken executable due to the errors.

Users might want to build with sanitization for the sake of the libraries, or because they are building LCM as part of a "superbuild" and have sanitization turned on for all subprojects. In particular, this is breaking drake: RobotLocomotion/drake#2708.