### PR TITLE
Update documentation for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,3 +85,11 @@ option(LCM_INSTALL_PKGCONFIG "Install pkg-config files" ON)
 if(LCM_INSTALL_PKGCONFIG)
   add_subdirectory(lcm-pkgconfig)
 endif()
+
+# Distribution rules
+add_custom_target(dist
+  COMMAND ${CMAKE_COMMAND}
+    -DSOURCE_DIR=${lcm_SOURCE_DIR}
+    -DOUTPUT_DIR=${lcm_BINARY_DIR}
+    -DVERSION=${LCM_VERSION}
+    -P ${lcm_SOURCE_DIR}/lcm-cmake/mkdist.cmake)

--- a/WinSpecific/README.txt
+++ b/WinSpecific/README.txt
@@ -35,14 +35,6 @@ We specifically recommend the following:
 - http://ftp.gnome.org/pub/gnome/binaries/win32/glib/2.28/glib-dev_2.28.8-1_win32.zip
 - http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies/gettext-runtime_0.18.1.1-2_win32.zip
 
-The Visual Studio build requires an environment variable GLIB_PATH, which
-expects to find headers in $(GLIB_PATH)\include\glib-2.0 and libraries in
-$(GLIB_PATH)\lib.
-
-The overall lcm.sln Solution file has the project dependencies set, so it knows
-it needs to build the lcm.dll before building other projects, etc. All projects
-can be built from the top level.
-
 The bulk of the changes are in lcm_udp.c and lcm_file.c. We relied on glib to
 provide the regex functionality.  The pipe() functionality has been
 re-implemented using sockets, which should now provide almost identical
@@ -52,73 +44,13 @@ When writing programs that use LCM (but are not internal to LCM) with Visual
 Studio 2008 and earlier, add "WinSpecific/include" to your include path to get
 <stdint.h> and <inttypes.h>.
 
-To build on windows with Visual Studio 2013 or later:
------------------------------------------------------
-
-1. Open WinSpecific\vs12\LCM.sln
-2. Set configuration to either "Debug" or "Release" depending on if debug 
-   symbols should be generated.
-3. Build the solution.
-4. The built files are put in WinSpecific\vs12\<Configuration>
-
-To build with msbuild:
-----------------------
-
-1. Open a Visual Studio command prompt and cd to WinSpecific\vs12
-2. Run: 
-      msbuild /p:Configuration=Release LCM.sln
-   or
-      msbuild /p:Configuration=Debug LCM.sln
-
-3. The built files are put in WinSpecific\vs12\<Configuration>
-
-4. In order to clean run msbuild /t:Clean /p:Configuration=<Config> LCM.sln
-
 To run the test:
 ----------------
 
-The solution file LCM.sln will build all the tests as well.
 To execute the tests cd to lcm\test and run:
    python run_unit_tests.py
 and
    python run_client_server_tests.py
 
 NOTE: The c-client test might intermittently fail the first time it is run.
-If the test is rerun directly after is should pass.
-
-What to the deploy?
--------------------
-- From the Release-folder copy:
-    - lcm.dll, lcm.exp and lcm.lib
-    - All .exe-files
-- From the Debug-folder copy:
-    - lcmd.dll, lcmd.exp, lcmd.lib and lcmd.pdb
-
-Notes on Visual Studion 2013 build system
------------------------------------------
-
-This section contains some notes on how the VS2013 build system is setup that
-could be useful for maintenance.
-
-The project files have been made to contain minimal local settings in order
-to avoid duplication of parameters. Instead extensive use of property sheets
-is done.
-
-The following property sheets exist and are always imported in the same order:
-
-    1. Common.props: This is contain common parameters for all projects in all
-        configurations
-    2. (Debug.props | Release.props): These are added for every project to
-        their respective configurations.
-    3. UseGlib.props: This sheet adds glib-headers to the include path and
-        glib and gthread to the linked libraries.
-    4. RunLcmGen.props: This adds lcm-gen as a custom build tool to projects
-        that need to generate lcm descriptions during the build.
-    5. IncludeTypes.props: This adds the generated headers from packages
-        lcmtest and lcmtest2 to the include path. Used by tests.
-    6. Test.props: This is added to all tests that use gtest.
-
-Apart from these property sheets there are only a few settings that are stored
-in the project files. These can easily be seen by opening the project-file in
-a text editor.
-
+If the test is rerun directly after it should pass.

--- a/docs/content/build-instructions.md
+++ b/docs/content/build-instructions.md
@@ -3,19 +3,33 @@ Build Instructions {#build_instructions}
 
 [TOC]
 
-The process for building LCM may depend on whether you're building from a
-released version or from source control.
+Source releases may be obtained from https://github.com/lcm-proj/lcm/releases.
 
-# Building a released version {#build_released}
+You may also build the latest development version by cloning the git repository,
+https://github.com/lcm-proj/lcm.git.
 
-These instructions assume you've already downloaded a released version of LCM,
-available at:
+The following instructions assume that you have obtained a copy of the source,
+either by unpacking a release archive or cloning the git repository, and that
+your initial working directory contains the source code. (For release archives,
+this includes descending into the top level `lcm-X.Y.Z` subdirectory.)
 
-[https://github.com/lcm-proj/lcm/releases](https://github.com/lcm-proj/lcm/releases)
+Regardless of platform, CMake 3.1 or later is required. Binaries may be
+obtained from https://cmake.org/download/. Sufficiently recent Linux
+distributions may provide a new enough CMake via their package managers.
 
-Replace X.Y.Z below with the specific version number you're building.
+# CMake Overview {#build_cmake}
 
-## Ubuntu / Debian {#build_ubuntu_debian}
+These instructions assume that you will build in a directory named `build` as
+a direct subdirectory of the source directory, and that you will use the
+default generator. CMake permits the build directory to be almost anywhere
+(although in-source builds are strongly discouraged), and supports multiple
+generators. To users familiar with CMake, we recommend using
+[Ninja](https://ninja-build.org/).
+
+A detailed description of how to use CMake is not specific to LCM and is beyond
+the scope of these instructions.
+
+# Ubuntu / Debian {#build_ubuntu_debian}
 
 Required packages:
   - build-essential
@@ -27,34 +41,34 @@ Strongly recommended packages:
 
 From a terminal, run the following commands.
 
-    $ unzip lcm-X.Y.Z.zip
-    $ cd lcm-X.Y.Z
-    $ ./configure
+    $ mkdir build
+    $ cd build
+    $ cmake ..
     $ make
     $ sudo make install
-    $ sudo ldconfig
 
-## OS X {#build_osx}
+# OS X {#build_osx}
 
-There are several ways to build LCM on OS X, none of which are necessarily better than the others.
+There are several ways to build LCM on OS X, none of which are necessarily
+better than the others.
 
-### Homebrew
+## Homebrew
 
 Install Homebrew packages
 
     $ brew install glib pkg-config
 
-Install Java.  Type `javac` in a terminal, then follow the instructions
+Install Java.  Type `javac` in a terminal, then follow the instructions.
 
-Download and build LCM
+Download and build LCM.
 
-    $ unzip lcm-X.Y.Z.zip
-    $ cd lcm-X.Y.Z
-    $ ./configure
+    $ mkdir build
+    $ cd build
+    $ cmake ..
     $ make
     $ make install
 
-## Windows {#build_windows}
+# Windows {#build_windows}
 
 Requirements:
  - GLib for Windows (http://www.gtk.org).  You'll need the following packages
@@ -63,89 +77,52 @@ Requirements:
 
 Building:
   1. Follow the instructions in WinSpecific/README.txt to setup GLib.
-  2. Open WinSpecific/LCM.sln in MS Visual Studio and build the solution.
+  2. Use the CMake GUI to configure LCM.
+  3. Open the VS Solution created by CMake and build it.
 
-## Other / General {#build_other}
+# Other / General {#build_other}
 
 On other POSIX.1-2001 systems (e.g., other GNU/Linux distributions, FreeBSD,
 Solaris, etc.) the only major requirement is to install the GLib 2.x
 development files.  If possible, a Java development kit and Python should also
-be installed.  Then follow the 
-
-# Building from Git {#build_git}
-
-## Ubuntu / Debian {#build_git_ubuntu_debian}
-
-Required packages:
- - build-essential
- - autoconf
- - automake
- - autopoint
- - libglib2.0-dev
- - libtool
-
-Strongly recommended packages:
- - openjdk-6-jdk
- - python-dev
-
-From a terminal, run the following commands.
-
-    $ git clone https://github.com/lcm-proj/lcm lcm
-    $ cd lcm
-    $ ./bootstrap.sh
-    $ ./configure
-    $ make
-    $ sudo make install
-
-## OS X {#build_git_osx}
-
-### Homebrew
-
-Install Homebrew packages
-
-    $ brew install glib pkg-config automake libtool
-
-Install Java.  Type `javac` in a terminal, then follow the instructions
-
-Download and build LCM
-
-    $ git clone https://github.com/lcm-proj/lcm lcm
-    $ cd lcm
-    $ ./bootstrap.sh
-    $ ./configure
-    $ make
-    $ make install
-
-## Windows {#build_git_windows}
-
-Same as building from a released version, as above.
-
-## Other / General {#build_git_other}
-
-To build from Git in other GNU/Linux distributions, FreeBSD, Solaris, etc.,
-you'll need to install autotools.  Then follow the terminal commands shown
-above for Ubuntu.
+be installed.  Then follow the same instructions as for
+[Ubuntu / Debian](#build_ubuntu_debian).
 
 # Post Install {#build_post}
 
 ## Linux {#build_post_linux}
 
-Some Linux distributions, such as Arch, do not contain the default install location (`/usr/local/lib</`) in the `ld.so.conf` search path. In this case, create a `ld.so.conf` file for lcm:
+In the following, replace `$LCM_INSTALL_PREFIX` with the prefix to which
+LCM was installed (by default, `/usr/local`), and replace `$LCM_LIBRARY_DIR`
+with the location of the LCM library, `lcm.so` (e.g. `/usr/local/lib`).
 
-    $ export LCM_INSTALL_DIR=/usr/local/lib
-    $ echo $LCM_INSTALL_DIR > /etc/ld.so.conf.d/lcm.conf
+Some Linux distributions, such as Arch, do not contain the default install
+location (`/usr/local/lib/`) in the `ld.so.conf` search path. In this case,
+or if you installed LCM to a different, non-standard prefix, you may wish to
+create a `ld.so.conf` file for lcm:
 
-In addition, `pkgconfig` can be configured to find lcm.pc.
+    $ echo $LCM_LIBRARY_DIR > /etc/ld.so.conf.d/lcm.conf
 
-    $ export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$LCM_INSTALL_DIR/pkgconfig
+Python users may need to add the lcm install location to Python's site packages
+search path using a .pth file:
 
-Python users may need to add the lcm install location to Python's site packages search path using a .pth file.
+    $ PYTHON_VERSION=$(python -c "import sys; print(\"%s.%s\" % sys.version_info[:2])")
+    $ PYTHON_USER_SITE=$(python -m site --user-site)
+    $ echo "$LCM_LIBRARY_DIR/python$PYTHON_VERSION/site-packages" > $PYTHON_USER_SITE/lcm.pth
 
-    $ export PYTHON_VERSION=$(python -c "import sys; print(\"%s.%s\" % sys.version_info[:2])")
-    $ export PYTHON_USER_SITE=$(python -m site --user-site)
-    $ echo "$LCM_INSTALL_DIR/python$PYTHON_VERSION/site-packages" > $PYTHON_USER_SITE/lcm.pth
+Lua users may need to add to `LUA_CPATH`:
 
-Lua users may need to add to `LUA_CPATH`
+    $ LUA_VERSION=$(lua -e "print(string.sub(_VERSION, 5))")
+    $ export LUA_CPATH=$LUA_CPATH:$LCM_LIBRARY_DIR/lua/$LUA_VERSION/?.so
 
-    $ export LUA_VERSION=$(lua -e "print(string.sub(_VERSION, 5))")
-    $ export LUA_CPATH=$LUA_CPATH:$LCM_INSTALL_DIR/lua/$LUA_VERSION/?.so
+If you install LCM to a non-standard location (i.e. other than the default
+`/usr/local`, other CMake projects using LCM may need help finding it. Although
+you can always point to the directory where `lcmConfig.cmake` is installed by
+manually setting `lcm_DIR`, it may be convenient to add the location to the
+default search paths:
+
+    $ export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$LCM_INSTALL_PREFIX
+
+In addition, `pkgconfig` can be configured to find lcm.pc:
+
+    $ export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$LCM_LIBRARY_DIR/pkgconfig

--- a/docs/release_checklist
+++ b/docs/release_checklist
@@ -1,25 +1,22 @@
 # Build release archive
 
-1.  Reset your working copy to a clean state
-  $ git clean -x -d -f
-2.  Update NEWS (use Markdown syntax)
-3.  Verify that all manpages are up to date.
-4.  Bump the version number in:
-  a. configure.ac at the line AM_INIT_AUTOMAKE(lcm, X.Y.Z)
-  b. lcm-python/setup.py
-  c. lcm/lcm.h
-5.  Update the AGE, REVISION, and CURRENT variables.  See configure.ac
-  comments for details.
-6. Build the release tarball
-  $ autoreconf -i
-  $ ./configure
-  $ make
-  $ make distcheck
-7. Take the resulting tarball, extract it, build it, install it, make sure
-  the basic executables run.
+1. Update NEWS (use Markdown syntax)
+2. Verify that all manpages are up to date
+3. Bump the version number in:
+  a. lcm-cmake/version.cmake
+  b. lcm/lcm.h
+4. Commit the above changes and create the vX.Y.Z git tag.
+  $ git commit -a -m "Release X.Y.Z"
+  $ git tag vX.Y.Z
+5. Create the release tarball
+  $ make dist
+6. Take the resulting tarball, extract it, build it, install it, make sure
+  the basic executables run
   $ tar xzvf lcm-X.Y.Z.tar.gz
   $ cd lcm-X.Y.Z
-  $ ./configure
+  $ mkdir build
+  $ cd build
+  $ cmake ..
   $ make
   $ make install
 
@@ -40,31 +37,23 @@
 
 # Upload release archive
 
-1. Commit the changes, tag the release, and push to GitHub.
-  $ git commit -a -m "Release X.Y.Z"
-  $ git tag vX.Y.Z
+1. Push the changes and release tag to GitHub.
   $ git push origin master
   $ git push origin vX.Y.Z
-2. Convert tarball to ZIP file
-  $ tar xzvf lcm-X.Y.Z.tar.gz
-  $ zip -r lcm-X.Y.Z.zip lcm-X.Y.Z
-3. Draft a new release on GitHub
+2. Draft a new release on GitHub
   a. Associate the release with tag vX.Y.Z
   b. Name the release title "vX.Y.Z"
   c. Add release notes from the NEWS file
-  d. Attach lcm-X.Y.Z.zip
 
 # Update documentation
 
 1. Build docs
-  $ cd docs
-  $ ./build-docs.sh
+  $ make doc
 2. Clone the documentation repository
-  $ cd ../..
   $ git clone https://github.com/lcm-proj/lcm-proj.github.io
   $ cd lcm-proj.github.io
 3. Copy the built docs to the lcm.www repository
-  $ cp -r ../lcm/docs/html/* .
+  $ cp -r ../docs/html/* .
 4. Commit the changes, tag the release, and push to origin
   $ git commit -a -m "Release X.Y.Z"
   $ git tag vX.Y.Z

--- a/lcm-cmake/mkdist.cmake
+++ b/lcm-cmake/mkdist.cmake
@@ -1,0 +1,15 @@
+find_package(Git REQUIRED)
+
+execute_process(
+  COMMAND ${GIT_EXECUTABLE} archive
+    --output=${OUTPUT_DIR}/lcm-${VERSION}.tar.gz
+    --prefix=lcm-${VERSION}/
+    v${VERSION}
+  WORKING_DIRECTORY ${SOURCE_DIR})
+
+execute_process(
+  COMMAND ${GIT_EXECUTABLE} archive
+    --output=${OUTPUT_DIR}/lcm-${VERSION}.zip
+    --prefix=lcm-${VERSION}/
+    v${VERSION}
+  WORKING_DIRECTORY ${SOURCE_DIR})


### PR DESCRIPTION
Update build instructions to discuss the new CMake build system rather than autotools. Update release checklist. Create targets to automate creation of distribution tarballs (although, since with CMake we no longer need to package non-source-controlled files, these are just the tarballs created by `git archive`, and - since github also provides these - are mainly useful as a testing aid).

Caveat: I *think* the release instructions are correct, but haven't actually verified.

Also, @ashuang, if you've already done most of this sort of thing yourself, feel free to ignore this; if it's outdated/wrong/etc. I won't be offended :smile:.