### PR TITLE
add linking to gthread-2.0.lib in lcm.vcproj and lcm-logger.vcproj

### DIFF
--- a/lcm-logger/lcm-logger.vcproj
+++ b/lcm-logger/lcm-logger.vcproj
@@ -62,7 +62,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="Ws2_32.lib winmm.lib lcmd.lib getopt.lib glib-2.0.lib"
+				AdditionalDependencies="Ws2_32.lib winmm.lib lcmd.lib getopt.lib glib-2.0.lib gthread-2.0.lib"
 				LinkIncremental="2"
 				AdditionalLibraryDirectories="..\WinSpecific\debug; $(GLIB_PATH)\lib"
 				GenerateDebugInformation="true"
@@ -138,7 +138,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="Ws2_32.lib winmm.lib lcm.lib getopt.lib glib-2.0.lib"
+				AdditionalDependencies="Ws2_32.lib winmm.lib lcm.lib getopt.lib glib-2.0.lib gthread-2.0.lib"
 				LinkIncremental="1"
 				AdditionalLibraryDirectories="..\WinSpecific\release; $(GLIB_PATH)\lib"
 				GenerateDebugInformation="true"

--- a/lcm/lcm.vcproj
+++ b/lcm/lcm.vcproj
@@ -63,7 +63,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=" /SECTION:.winlcm,RWS"
-				AdditionalDependencies="Ws2_32.lib winmm.lib glib-2.0.lib"
+				AdditionalDependencies="Ws2_32.lib winmm.lib glib-2.0.lib gthread-2.0.lib"
 				OutputFile="$(OutDir)\$(ProjectName)d.dll"
 				AdditionalLibraryDirectories="$(GLIB_PATH)\lib"
 				GenerateDebugInformation="true"
@@ -137,7 +137,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=" /SECTION:.winlcm,RWS"
-				AdditionalDependencies="Ws2_32.lib winmm.lib glib-2.0.lib"
+				AdditionalDependencies="Ws2_32.lib winmm.lib glib-2.0.lib gthread-2.0.lib"
 				AdditionalLibraryDirectories="$(GLIB_PATH)\lib"
 				RandomizedBaseAddress="1"
 				DataExecutionPrevention="0"


### PR DESCRIPTION
Without this change, the compile will fail. Tested with VS2010 under x86 settings.