### PR TITLE
Avoid use of BASH_SOURCE in wrapper scripts

### DIFF
--- a/lcm-java/lcm-logplayer-gui.sh
+++ b/lcm-java/lcm-logplayer-gui.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-if [ -n "$(type -p perl)" ]
+if (perl -e '' 2>/dev/null)
   then mydir="$(dirname "$(perl -MCwd -le 'print Cwd::abs_path(shift)' "$0")")"
   else mydir="$(dirname "$0")"
 fi

--- a/lcm-java/lcm-logplayer-gui.sh
+++ b/lcm-java/lcm-logplayer-gui.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 if [ -n "$(type -p perl)" ]
-  then mydir="$(dirname "$(perl -MCwd -le 'print Cwd::abs_path(shift)' "${BASH_SOURCE[0]}")")"
-  else mydir="$(dirname "${BASH_SOURCE[0]}")"
+  then mydir="$(dirname "$(perl -MCwd -le 'print Cwd::abs_path(shift)' "$0")")"
+  else mydir="$(dirname "$0")"
 fi
 if [ -e "$mydir/lcm.jar" ]
   then jardir="$mydir"

--- a/lcm-java/lcm-spy.sh
+++ b/lcm-java/lcm-spy.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-if [ -n "$(type -p perl)" ]
+if (perl -e '' 2>/dev/null)
   then mydir="$(dirname "$(perl -MCwd -le 'print Cwd::abs_path(shift)' "$0")")"
   else mydir="$(dirname "$0")"
 fi

--- a/lcm-java/lcm-spy.sh
+++ b/lcm-java/lcm-spy.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 if [ -n "$(type -p perl)" ]
-  then mydir="$(dirname "$(perl -MCwd -le 'print Cwd::abs_path(shift)' "${BASH_SOURCE[0]}")")"
-  else mydir="$(dirname "${BASH_SOURCE[0]}")"
+  then mydir="$(dirname "$(perl -MCwd -le 'print Cwd::abs_path(shift)' "$0")")"
+  else mydir="$(dirname "$0")"
 fi
 if [ -e "$mydir/lcm.jar" ]
   then jardir="$mydir"


### PR DESCRIPTION
The wrapper scripts use `!#/bin/sh`, not `#!/bin/bash`, and we'd prefer to avoid the latter in case of systems that don't have it, if possible. Accordingly, replace use of `${BASH_SOURCE[0]}` with plain old `$0`. These should be the same except if the script is sourced via another script, and it seems safe enough to assume that doesn't happen for these.