### PR TITLE
Fix finding Python when multiple versions present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 lcm_option(
   LCM_ENABLE_PYTHON
   "Build Python bindings and utilities"
-  PYTHONLIBS_FOUND PythonLibs)
+  PYTHON_FOUND Python)
 if(LCM_ENABLE_PYTHON)
   add_subdirectory(lcm-python)
 endif()

--- a/cmake/FindPython.cmake
+++ b/cmake/FindPython.cmake
@@ -1,0 +1,14 @@
+include(FindPackageHandleStandardArgs)
+
+find_package(PythonInterp)
+if(PYTHON_EXECUTABLE)
+  execute_process(
+    COMMAND ${PYTHON_EXECUTABLE} -c "import sys; print sys.exec_prefix;"
+    OUTPUT_VARIABLE PYTHON_PREFIX
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  list(APPEND CMAKE_PREFIX_PATH ${PYTHON_PREFIX})
+  find_package(PythonLibs)
+endif()
+
+find_package_handle_standard_args(Python
+  REQUIRED_VARS PYTHON_EXECUTABLE PYTHON_INCLUDE_DIR PYTHON_LIBRARY)

--- a/lcm-python/CMakeLists.txt
+++ b/lcm-python/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(PythonInterp REQUIRED)
-
 set(PYTHON_SHORT python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
 set(PYTHON_SITE lib${LIB_SUFFIX}/${PYTHON_SHORT}/site-packages)
 


### PR DESCRIPTION
Create a simple `FindPython.cmake` module to find both the Python interpreter and libraries, using the install prefix of the former as a hint for the latter. This should reduce the chances of finding a mismatched interpreter and libraries, as can happen on some machines if an interpreter from a non-standard prefix is in the user's `PATH`. It also lets us simplify the logic to find "Python" by having one module that provides both components.

This specifically was causing problems on some OS X machines using Python from Homebrew.