### PR TITLE
Create header-only link target lcm-coretypes

### DIFF
--- a/lcm-cmake/install.cmake
+++ b/lcm-cmake/install.cmake
@@ -39,6 +39,7 @@ write_basic_package_version_file(
 
 # Exported targets for build directory
 export(TARGETS
+  lcm-coretypes
   lcm
   lcm-gen
   FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake

--- a/lcm/CMakeLists.txt
+++ b/lcm/CMakeLists.txt
@@ -34,6 +34,7 @@ if(WIN32)
   )
 endif()
 
+add_library(lcm-coretypes INTERFACE)
 add_library(lcm ${lcm_sources})
 
 target_compile_definitions(lcm PRIVATE
@@ -48,6 +49,9 @@ set_target_properties(lcm PROPERTIES
   PUBLIC_HEADER "${lcm_install_headers}"
 )
 
+target_include_directories(lcm-coretypes INTERFACE
+  $<BUILD_INTERFACE:${lcm_SOURCE_DIR}>
+)
 target_include_directories(lcm INTERFACE
   $<BUILD_INTERFACE:${lcm_SOURCE_DIR}>
 )
@@ -58,7 +62,7 @@ target_link_libraries(lcm PRIVATE
   ${CMAKE_THREAD_LIBS_INIT}
 )
 
-install(TARGETS lcm
+install(TARGETS lcm-coretypes lcm
   EXPORT lcmTargets
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib${LIB_SUFFIX}


### PR DESCRIPTION
Introduce a new exported `INTERFACE` library, `lcm-coretypes`, which provides users a way to depend on the LCM headers without needing to link to the actual LCM library. LCM types libraries will likely want to "link" to this.

(In particular, C++ LCM types "libraries" are header-only with an include dependency on LCM but no link dependency. Consumers of these "libraries" need the LCM include directories, but may not need to link to the actual LCM library. The interface library gives consumers a way to make this work, conveniently.)