### PR TITLE
Remove references to deprecated g_thread_init

### DIFF
--- a/lcm-logger/lcm_logger.c
+++ b/lcm-logger/lcm_logger.c
@@ -542,9 +542,6 @@ int main(int argc, char *argv[])
         fprintf(stderr, "ERROR.  --force_overwrite and --append can't both be used\n");
     }
 
-    // initialize GLib threading
-    g_thread_init(NULL);
-
     logger.time0 = timestamp_now();
     logger.max_write_queue_size = (int64_t)(max_write_queue_size_mb * (1 << 20));
 

--- a/lcm/lcm.c
+++ b/lcm/lcm.c
@@ -58,8 +58,6 @@ extern void lcm_memq_provider_init(GPtrArray * providers);
 lcm_t * 
 lcm_create (const char *url)
 {
-    if (!g_thread_supported ()) g_thread_init (NULL);
-
 #ifdef WIN32
     WSADATA    wsd;
     int status = WSAStartup ( MAKEWORD ( 2, 0 ), &wsd );


### PR DESCRIPTION
Fixes the Autotools build! (Oops.)