### PR TITLE
Remove linking to gthread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if(CMAKE_VERSION VERSION_LESS 3.7)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/3.7")
 endif()
 
-find_package(GLib2 REQUIRED COMPONENTS gthread)
+find_package(GLib2 REQUIRED)
 
 # Configuration and utility functions
 include(lcm-cmake/config.cmake)

--- a/lcm-logger/CMakeLists.txt
+++ b/lcm-logger/CMakeLists.txt
@@ -3,7 +3,6 @@ target_link_libraries(lcm-logger
   lcm
   ${lcm-winport}
   GLib2::glib
-  GLib2::gthread
 )
 
 add_executable(lcm-logplayer lcm_logplayer.c)

--- a/lcm-pkgconfig/lcm.pc.in
+++ b/lcm-pkgconfig/lcm.pc.in
@@ -5,7 +5,7 @@ includedir=${prefix}/include
 
 Name: lcm
 Description: lcm
-Requires:  glib-2.0 gthread-2.0
+Requires:  glib-2.0
 Version: @LCM_VERSION@
 Libs: -L${libdir} -llcm
 Cflags: -I${includedir}

--- a/lcm/CMakeLists.txt
+++ b/lcm/CMakeLists.txt
@@ -58,7 +58,6 @@ target_include_directories(lcm INTERFACE
 
 target_link_libraries(lcm PRIVATE
   GLib2::glib
-  GLib2::gthread
   ${CMAKE_THREAD_LIBS_INIT}
 )
 


### PR DESCRIPTION
Since df709cb616d7, we no longer need to link to gthread. Accordingly, remove it from our GLib required components and remove linking to it.

See also #94. @tprk77, assigning to you to verify that this is no longer needed, since it was your change that made this possible. I did also test it on Fedora and Windows.