### PR TITLE
Explicitely add jchart to classpath on lcmspy launch

### DIFF
--- a/lcm-java/lcm-spy.sh
+++ b/lcm-java/lcm-spy.sh
@@ -12,4 +12,4 @@ else
   exit 1
 fi
 
-exec java -server -Djava.net.preferIPv4Stack=true -Xincgc -Xmx128m -Xms64m -ea -cp $jardir/lcm.jar lcm.spy.Spy "$@"
+exec java -server -Djava.net.preferIPv4Stack=true -Xincgc -Xmx128m -Xms64m -ea -cp $jardir/lcm.jar:$jardir/jchart2d-3.2.2.jar lcm.spy.Spy "$@"


### PR DESCRIPTION
I've encountered an issue with lcm-spy where lcm-spy spews many errors on startup, and refuses to open the structure viewer on any messages being seen (it spews similar errors when I try to open the structure viewer).

Errors look like this, though with varying classes within the jchart library:
```
ClassDiscoverer: java.lang.NoClassDefFoundError: info/monitorenter/gui/chart/IAxis
                 jar: /home/gizatt/lcm/build/lcm-java/lcm.jar
                 class: lcm/spy/ZoomableChartScrollWheel$5.class
``

Seems pretty clear that the cause is that the jchart library isn't being seen, even though it's in ```/usr/local/share/java``` right next to ```lcm.jar```. My naive, I-don't-know-any-java solution is attached. Is there a better way / some kind of system configuration I'm missing?