### PR TITLE
tests/cpp fix for CMake < 3.3

### DIFF
--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -1,17 +1,19 @@
 set(test_cpp_libs lcm-test-types-cpp lcm gtest gtest_main)
-if(CMAKE_VERSION VERSION_LESS 3.3) # TODO remove when we require >=3.3
-  # NOTE: with CMake 3.3 or later, this is added as a dependency of the
-  # lcm-test-types-cpp INTERFACE target, so is not needed; CMake prior to
-  # 3.3 does not support dependencies on INTERFACE targets, and we need to
-  # enforce the build order for obvious reasons
-  list(APPEND test_cpp_libs lcm-test-types-generate-cpp)
-endif()
 
 add_executable(test-cpp-client client.cpp common.cpp)
 target_link_libraries(test-cpp-client ${test_cpp_libs})
 
 add_executable(test-cpp-memq_test memq_test.cpp common.cpp)
 target_link_libraries(test-cpp-memq_test ${test_cpp_libs})
+
+if(CMAKE_VERSION VERSION_LESS 3.3) # TODO remove when we require >=3.3
+  # NOTE: with CMake 3.3 or later, this is added as a dependency of the
+  # lcm-test-types-cpp INTERFACE target, so is not needed; CMake prior to
+  # 3.3 does not support dependencies on INTERFACE targets, and we need to
+  # enforce the build order for obvious reasons
+  add_dependencies(test-cpp-client lcm-test-types-generate-cpp)
+  add_dependencies(test-cpp-memq_test lcm-test-types-generate-cpp)
+endif()
 
 add_test(NAME CPP::memq_test COMMAND test-cpp-memq_test)
 


### PR DESCRIPTION
- On CMake 3.1, 3.2 use add_dependencies instead of
  target_link_libraries for lcm-test-types-generate-cpp.

@mwoehlke-kitware 