### PR TITLE
Fix dependency in documentation generation

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -28,6 +28,6 @@ add_custom_target(doc-doxygen
 add_custom_target(doc-dotnet
   COMMAND ${DOXYGEN_EXECUTABLE} ${lcm_BINARY_DIR}/lcm-dotnet/Doxyfile
   WORKING_DIRECTORY ${lcm_SOURCE_DIR}/lcm-dotnet
-  DEPENDS doc-clean)
+  DEPENDS doc-clean doc-doxygen)
 
 add_dependencies(doc doc-doxygen doc-dotnet)


### PR DESCRIPTION
Make .NET documentation depend on "main" documentation. Since both depend on erasing the old documentation directory first, and the .NET documentation lives in a subdirectory, this both ensures that the .NET documentation isn't the only documentation generated, and fixes an issue where the .NET documentation generation could fail if built first because the parent output directory doesn't exist.

@ashuang, since this is a trivial fix, I'll just go ahead and merge it if I haven't heard otherwise in a few days.