### PR TITLE
Fix typo: lcm_exports => lcm_export

### DIFF
--- a/lcm/CMakeLists.txt
+++ b/lcm/CMakeLists.txt
@@ -22,6 +22,7 @@ set(lcm_install_headers
   eventlog.h
   lcm.h
   lcm_coretypes.h
+  lcm_version.h
   lcm-cpp.hpp
   lcm-cpp-impl.hpp
   ${CMAKE_CURRENT_BINARY_DIR}/lcm_export.h

--- a/lcm/CMakeLists.txt
+++ b/lcm/CMakeLists.txt
@@ -24,7 +24,7 @@ set(lcm_install_headers
   lcm_coretypes.h
   lcm-cpp.hpp
   lcm-cpp-impl.hpp
-  ${CMAKE_CURRENT_BINARY_DIR}/lcm_exports.h
+  ${CMAKE_CURRENT_BINARY_DIR}/lcm_export.h
 )
 
 if(WIN32)


### PR DESCRIPTION
Fixes typo introduced in #110 preventing ``sudo make install`` from succeeding:

```
CMake Error at lcm/cmake_install.cmake:40 (file):
  file INSTALL cannot find "/home/wxm/software/lcm/build/lcm/lcm_exports.h".
Call Stack (most recent call first):
  cmake_install.cmake:68 (include)
```

@mwoehlke-kitware could you please review and merge? The current tip of master is broken. Thanks