### PR TITLE
Teach lcmgen to export decorate bindings

### DIFF
--- a/docs/content/tutorial-cmake.md
+++ b/docs/content/tutorial-cmake.md
@@ -43,6 +43,7 @@ the Python bindings unconditionally.)
 Now, you'll want to generate the bindings.
 
     lcm_wrap_types(
+      C_EXPORT my_lcmtypes
       C_SOURCES sources
       C_HEADERS c_install_headers
       CPP_HEADERS cpp_install_headers
@@ -87,6 +88,20 @@ should not be included in the installed version of the library. This prevents
 details of your build from leaking into the install. We'll handle the include
 directory for the installed library differently.
 
+There is one last step for creating the C library. Remember how we passed
+`C_EXPORT` to `lcm_wrap_types`? This tells `lcmgen` to export decorate the C
+bindings, so that we can use ELF hidden symbol visibility and create shared
+libraries on Windows. For this to work, someone needs to define the export
+decoration symbol:
+
+    generate_export_header(my_lcmtypes)
+
+This will create `my_lcmtypes_export.h` defining `MY_LCMTYPES_EXPORT`. You can
+use the `BASE_NAME` argument to `generate_export_header` to choose a different
+name; if you do, be sure to pass the same name to `C_EXPORT` when calling
+`lcm_wrap_types`. (See `test/types/CMakeLists.txt` in the LCM source for an
+example.)
+
 Let's not forget about our C++ users. Since the C++ bindings are header only,
 we'll use an `INTERFACE` library rather than a "real" library. An `INTERFACE`
 library is used to propagate dependencies and interface usage requirements, but
@@ -117,6 +132,7 @@ likewise preserves subdirectory components and also chooses the correct
 destination directory by default.
 
     lcm_install_headers(DESTINATION include
+      ${CMAKE_CURRENT_BINARY_DIR}/my_lcmtypes_export.h
       ${c_install_headers}
       ${cpp_install_headers}
     )

--- a/lcm-cmake/config.cmake
+++ b/lcm-cmake/config.cmake
@@ -1,5 +1,6 @@
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
+include(GenerateExportHeader)
 
 #------------------------------------------------------------------------------
 function(lcm_add_c_flags)

--- a/lcm-cmake/lcmUtilities.cmake
+++ b/lcm-cmake/lcmUtilities.cmake
@@ -1,6 +1,7 @@
 # Usage:
 #   lcm_wrap_types([C_HEADERS <VARIABLE_NAME> C_SOURCES <VARIABLE_NAME>
-#                   [C_INCLUDE <PATH>] [C_NOPUBSUB] [C_TYPEINFO]]
+#                   [C_INCLUDE <PATH>] [C_EXPORT <NAME>]
+#                   [C_NOPUBSUB] [C_TYPEINFO]]
 #                  [CPP_HEADERS <VARIABLE_NAME>
 #                   [CPP_INCLUDE <PATH>] [CPP11]]
 #                  [JAVA_SOURCES <VARIABLE_NAME>]
@@ -150,7 +151,7 @@ function(lcm_wrap_types)
     CREATE_CPP_AGGREGATE_HEADER
   )
   set(_sv_opts
-    C_HEADERS C_SOURCES C_INCLUDE
+    C_HEADERS C_SOURCES C_INCLUDE C_EXPORT
     CPP_HEADERS CPP_INCLUDE
     JAVA_SOURCES
     PYTHON_SOURCES
@@ -193,6 +194,11 @@ function(lcm_wrap_types)
   set(_args "")
   if(DEFINED _C_HEADERS)
     list(APPEND _args --c --c-cpath ${_DESTINATION} --c-hpath ${_DESTINATION})
+    if(DEFINED _C_EXPORT)
+      string(TOUPPER "${_C_EXPORT}_EXPORT" _C_EXPORT_SYMBOL)
+      list(APPEND _args --c-export-symbol ${_C_EXPORT_SYMBOL})
+      list(APPEND _args --c-export-include "${_C_EXPORT}_export.h")
+    endif()
     if(DEFINED _C_INCLUDE)
       list(APPEND _args --cinclude ${_C_INCLUDE})
     endif()

--- a/lcm/CMakeLists.txt
+++ b/lcm/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(GenerateExportHeader)
-
 if(UNIX)
   find_package(Threads)
 endif()

--- a/test/types/CMakeLists.txt
+++ b/test/types/CMakeLists.txt
@@ -11,6 +11,7 @@ if(LCM_ENABLE_LUA)
 endif()
 
 lcm_wrap_types(
+  C_EXPORT lcmtest
   C_SOURCES sources
   C_HEADERS c_headers
   CPP_HEADERS cpp_headers
@@ -35,6 +36,8 @@ set_target_properties(lcm-test-types-c PROPERTIES OUTPUT_NAME lcm-test-types)
 target_link_libraries(lcm-test-types-c PRIVATE lcm PUBLIC lcm-coretypes)
 target_include_directories(lcm-test-types-c INTERFACE
   ${CMAKE_CURRENT_BINARY_DIR})
+
+generate_export_header(lcm-test-types-c BASE_NAME lcmtest)
 
 add_custom_target(lcm-test-types-generate-cpp DEPENDS ${cpp_headers})
 


### PR DESCRIPTION
Teach `lcmgen` to add export decorations to the generated C bindings, and to include a header defining the export symbol. Modify CMake `lcm_wrap_types` helper to leverage this. Update test types to use it (bringing us closer to being able to build shared on Windows; #112 still needs to be addressed). Update CMake tutorial to cover this.

Fixes #111.