### PR TITLE
Fix issues related to CMAKE visibility options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 find_package(GLib2 REQUIRED)
 
 # Configuration and utility functions
-include(lcm-cmake/config.cmake)
+include(lcm-cmake/config.cmake NO_POLICY_SCOPE)
 include(lcm-cmake/functions.cmake)
 include(lcm-cmake/version.cmake)
 

--- a/lcm-cmake/config.cmake
+++ b/lcm-cmake/config.cmake
@@ -46,8 +46,13 @@ endfunction()
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 # Enable ELF hidden visibility
+set(CMAKE_C_VISIBILITY_PRESET "hidden")
 set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
 set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+
+if(POLICY CMP0063)
+  cmake_policy(SET CMP0063 NEW)
+endif()
 
 # Set extra compiler flags
 if(NOT MSVC)


### PR DESCRIPTION
Set [`CMP0063`](https://cmake.org/cmake/help/v3.3/policy/CMP0063.html) to `NEW`, silencing configure warnings about said policy. Also set visibility preset for C, so that LCM bindings and the core LCM library are actually affected. (Previously, only gtest was honoring visibility, since that is the only C++ library.) Note that this required the recently merged changes (#116) to add ABI decoration to bindings.