### PR TITLE
Tweaks to .gitignore

### DIFF
--- a/lcm-python/.gitignore
+++ b/lcm-python/.gitignore
@@ -1,1 +1,1 @@
-build
+/build/

--- a/test/python/.gitignore
+++ b/test/python/.gitignore
@@ -1,0 +1,1 @@
+client.pyc


### PR DESCRIPTION
Modify `.gitignore` in lcm-python to enforce that the ignored `build` directory a) is actually a directory, and b) is exactly where we expect it. This will continue to ignore what we intend to ignore, but won't ignore some things that would match the old rule but aren't what we intend to ignore. Add an ignore for the `.pyc` generated from the test `client.py` when running the unit tests.