### PR TITLE
Fix Python install location, export entry point

### DIFF
--- a/lcm-cmake/lcmUtilities.cmake
+++ b/lcm-cmake/lcmUtilities.cmake
@@ -440,8 +440,12 @@ function(lcm_install_python)
         " and no Python interpreter found (required to guess DESTINATION)")
       return()
     endif()
-    set(_pyshort python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
-    set(_DESTINATION lib${LIB_SUFFIX}/${_pyshort}/site-packages)
+    execute_process(
+      COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
+        from distutils import sysconfig as sc
+        print(sc.get_python_lib(prefix='', plat_specific=True))"
+      OUTPUT_VARIABLE _DESTINATION
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
   endif()
   if(NOT DEFINED _RELATIVE_PATH)
     set(_RELATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}")

--- a/lcm-python/CMakeLists.txt
+++ b/lcm-python/CMakeLists.txt
@@ -1,5 +1,9 @@
-set(PYTHON_SHORT python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
-set(PYTHON_SITE lib${LIB_SUFFIX}/${PYTHON_SHORT}/site-packages)
+execute_process(
+  COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
+    from distutils import sysconfig as sc
+    print(sc.get_python_lib(prefix='', plat_specific=True))"
+  OUTPUT_VARIABLE PYTHON_SITE
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 set(lcm_python_sources
   module.c

--- a/lcm-python/module.c
+++ b/lcm-python/module.c
@@ -31,6 +31,9 @@ PyDoc_STRVAR (lcmmod_doc, "LCM python extension modules");
         ob = Py_InitModule3(name, methods, doc);
 #endif
 
+#if __GNUC__ >= 4 || defined(__clang__)
+__attribute__((visibility ("default")))
+#endif
 PyMODINIT_FUNC
 #if PY_MAJOR_VERSION >=3
 PyInit__lcm (void)


### PR DESCRIPTION
Use `distutils` to query the location where Python modules should be installed. This fixes installation on Debian and derivatives which use the non-standard `dist-packages` instead of `site-packages`. (It's also more robust, since obviously asking Python is always going to be better than trying to replicate its logic.) Also, add missing ELF export decoration for the Python module entry.

Fixes #127.