### PR TITLE
Fix export decoration of Lua module

### DIFF
--- a/lcm-lua/init.c
+++ b/lcm-lua/init.c
@@ -30,6 +30,11 @@ int luaopen_lcm__pack(lua_State* L) {
   return 1;
 }
 
+#if defined(_WIN32)
+__declspec(dllexport)
+#elif __GNUC__ >= 4 || defined(__clang__)
+__attribute__((visibility ("default")))
+#endif
 int luaopen_lcm(lua_State* L) {
   lua_newtable(L);
 


### PR DESCRIPTION
Add missing export decoration for Lua module entry point. This fixes the Lua module that stopped working when ELF hidden visibility was enabled. (I'm not sure about Windows, as I don't have Lua on Windows, but I suspect it never worked on Windows.)