### PR TITLE
Target Java 1.6 by default

### DIFF
--- a/lcm-java/CMakeLists.txt
+++ b/lcm-java/CMakeLists.txt
@@ -1,5 +1,15 @@
 include(UseJava)
 
+set(LCM_JAVA_TARGET_VERSION "1.6" CACHE STRING
+  "Java version to target when building Java components (leave empty to use default)"
+)
+if(NOT LCM_JAVA_TARGET_VERSION STREQUAL "")
+  set(CMAKE_JAVA_COMPILE_FLAGS
+    -source ${LCM_JAVA_TARGET_VERSION}
+    -target ${LCM_JAVA_TARGET_VERSION}
+  )
+endif()
+
 add_subdirectory(jchart2d-code)
 
 set(lcm_java_sources


### PR DESCRIPTION
Add an option to specify the Java version for which to build the Java components. By default, this is set to 1.6. This should help e.g. MATLAB users that need to use LCM from within an older JVM than the system's default JVM. (Note that autotools did something similar.)

This is a minor improvement (adding the option) over #137. @wxmerkt, if you can confirm this approach works for you, I'll go ahead and merge it, seeing as @ashuang already approved the idea (unless I hear objections, of course).