### PR TITLE
Minor fixes to static library and install rules

### DIFF
--- a/lcm-cmake/install.cmake
+++ b/lcm-cmake/install.cmake
@@ -38,10 +38,7 @@ write_basic_package_version_file(
 )
 
 # Exported targets for build directory
-export(TARGETS
-  lcm-coretypes
-  lcm
-  lcm-gen
+export(EXPORT ${PROJECT_NAME}Targets
   FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake
 )
 

--- a/lcm/CMakeLists.txt
+++ b/lcm/CMakeLists.txt
@@ -69,6 +69,9 @@ endforeach()
 generate_export_header(lcm STATIC_DEFINE LCM_STATIC)
 
 target_compile_definitions(lcm-static PUBLIC LCM_STATIC)
+if(NOT WIN32)
+  set_target_properties(lcm-static PROPERTIES OUTPUT_NAME lcm)
+endif()
 
 target_include_directories(lcm-coretypes INTERFACE
   $<BUILD_INTERFACE:${lcm_SOURCE_DIR}>


### PR DESCRIPTION
Rename static library from `lcm-static.a` to `lcm.a` (except on Windows, where this would collide with the import `.lib` for the shared library). Use `export(EXPORT` instead of `export(TARGETS` to create the build-directory target exports file, which avoids having to maintain a One True List of exported targets (which was missing `lcm-static`).

Besides seeming like more logical naming, this should allow pkg-config users to choose between static and shared libraries by wrapping LCM's link arguments with `-Bstatic`/`-Bdynamic`.