### PR TITLE
Add ability to use system third-party JAR's

### DIFF
--- a/lcm-java/CMakeLists.txt
+++ b/lcm-java/CMakeLists.txt
@@ -55,10 +55,12 @@ add_jar(lcm-java
 
 install_jar(lcm-java DESTINATION share/java)
 
-lcm_copy_file_target(lcm-spy-alias
-  ${CMAKE_CURRENT_SOURCE_DIR}/lcm-spy.sh
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/lcm-spy.sh.in
   ${CMAKE_CURRENT_BINARY_DIR}/lcm-spy
+  @ONLY
 )
+
 lcm_copy_file_target(lcm-logplayer-gui-alias
   ${CMAKE_CURRENT_SOURCE_DIR}/lcm-logplayer-gui.sh
   ${CMAKE_CURRENT_BINARY_DIR}/lcm-logplayer-gui

--- a/lcm-java/jchart2d-code/CMakeLists.txt
+++ b/lcm-java/jchart2d-code/CMakeLists.txt
@@ -5,9 +5,37 @@ set(jchart2d_depends
   ext/build/junit-4.8.1.jar
   ext/build/proguard-4.5.1.jar
   ext/build/jipViewer.jar
-  ext/xmlgraphics-commons-1.3.1.jar
-  ext/jide-oss-2.9.7.jar
 )
+
+macro(find_ext_jar VAR NAME)
+  option(USE_SYSTEM_${VAR} "Use system-provided ${NAME}, if available" ON)
+  if(USE_SYSTEM_${VAR})
+    find_jar(${VAR}_JAR ${NAME})
+  endif()
+
+  if(USE_SYSTEM_${VAR} AND ${VAR}_JAR)
+    list(APPEND jchart2d_depends ${${VAR}_JAR})
+    set(LCM_EXT_${VAR}_JAR "${${VAR}_JAR}" PARENT_SCOPE)
+  else()
+    file(GLOB _ext_jar
+      RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/ext
+      ext/${NAME}-*.jar)
+    list(APPEND jchart2d_depends ext/${_ext_jar})
+    set(LCM_EXT_${VAR}_JAR "\$ext/${_ext_jar}" PARENT_SCOPE)
+
+    lcm_copy_file_target(lcm-ext-${NAME}-jar
+      ${CMAKE_CURRENT_SOURCE_DIR}/ext/${_ext_jar}
+      ${CMAKE_CURRENT_BINARY_DIR}/ext/${_ext_jar}
+    )
+
+    install(FILES ext/${_ext_jar} DESTINATION share/java)
+
+    unset(_ext_jar)
+  endif()
+endmacro()
+
+find_ext_jar(XMLGRAPHICS_COMMONS xmlgraphics-commons)
+find_ext_jar(JIDE_OSS jide-oss)
 
 set(jchart2d_sources
   src/info/monitorenter/reflection/ObjRecorder2Trace2DAdapter.java
@@ -248,19 +276,3 @@ add_jar(jchart2d
 )
 
 install_jar(jchart2d share/java)
-
-lcm_copy_file_target(lcm-ext-xmlgraphics-commons-jar
-  ${CMAKE_CURRENT_SOURCE_DIR}/ext/xmlgraphics-commons-1.3.1.jar
-  ${CMAKE_CURRENT_BINARY_DIR}/ext/xmlgraphics-commons-1.3.1.jar
-)
-
-lcm_copy_file_target(lcm-ext-jide-oss-jar
-  ${CMAKE_CURRENT_SOURCE_DIR}/ext/jide-oss-2.9.7.jar
-  ${CMAKE_CURRENT_BINARY_DIR}/ext/jide-oss-2.9.7.jar
-)
-
-install(FILES
-  ext/xmlgraphics-commons-1.3.1.jar
-  ext/jide-oss-2.9.7.jar
-  DESTINATION share/java
-)

--- a/lcm-java/lcm-logplayer-gui.sh
+++ b/lcm-java/lcm-logplayer-gui.sh
@@ -17,7 +17,7 @@ else
 fi
 
 # Add user's CLASSPATH, if set
-[ -n "$CLASSPATH" ] && jars+=":$CLASSPATH"
+[ -n "$CLASSPATH" ] && jars="$jars:$CLASSPATH"
 
 # Launch the applet
 exec java -server -Xincgc -Xmx64m -Xms32m -ea -cp "$jars" lcm.logging.LogPlayer "$@"

--- a/lcm-java/lcm-spy.sh.in
+++ b/lcm-java/lcm-spy.sh.in
@@ -10,17 +10,18 @@ fi
 if [ -e "$mydir/lcm.jar" ]; then
   jars="$mydir/lcm.jar"
   jars+=":$mydir/jchart2d-code/jchart2d-3.2.2.jar"
-  jars+=":$mydir/jchart2d-code/ext/xmlgraphics-commons-1.3.1.jar"
-  jars+=":$mydir/jchart2d-code/ext/jide-oss-2.9.7.jar"
+  ext="$mydir/jchart2d-code/ext"
 elif [ -e "$mydir/../share/java/lcm.jar" ]; then
   jars="$mydir/../share/java/lcm.jar"
   jars+=":$mydir/../share/java/jchart2d-3.2.2.jar"
-  jars+=":$mydir/../share/java/xmlgraphics-commons-1.3.1.jar"
-  jars+=":$mydir/../share/java/jide-oss-2.9.7.jar"
+  ext="$mydir/../share/java"
 else
   echo "Unable to find 'lcm.jar'; please check your installation" >&2
   exit 1
 fi
+
+jars+=":@LCM_EXT_XMLGRAPHICS_COMMONS_JAR@"
+jars+=":@LCM_EXT_JIDE_OSS_JAR@"
 
 # Add user's CLASSPATH, if set
 [ -n "$CLASSPATH" ] && jars+=":$CLASSPATH"

--- a/lcm-java/lcm-spy.sh.in
+++ b/lcm-java/lcm-spy.sh.in
@@ -9,22 +9,22 @@ fi
 # Find dependency JARs
 if [ -e "$mydir/lcm.jar" ]; then
   jars="$mydir/lcm.jar"
-  jars+=":$mydir/jchart2d-code/jchart2d-3.2.2.jar"
+  jars="$jars:$mydir/jchart2d-code/jchart2d-3.2.2.jar"
   ext="$mydir/jchart2d-code/ext"
 elif [ -e "$mydir/../share/java/lcm.jar" ]; then
   jars="$mydir/../share/java/lcm.jar"
-  jars+=":$mydir/../share/java/jchart2d-3.2.2.jar"
+  jars="$jars:$mydir/../share/java/jchart2d-3.2.2.jar"
   ext="$mydir/../share/java"
 else
   echo "Unable to find 'lcm.jar'; please check your installation" >&2
   exit 1
 fi
 
-jars+=":@LCM_EXT_XMLGRAPHICS_COMMONS_JAR@"
-jars+=":@LCM_EXT_JIDE_OSS_JAR@"
+jars="$jars:@LCM_EXT_XMLGRAPHICS_COMMONS_JAR@"
+jars="$jars:@LCM_EXT_JIDE_OSS_JAR@"
 
 # Add user's CLASSPATH, if set
-[ -n "$CLASSPATH" ] && jars+=":$CLASSPATH"
+[ -n "$CLASSPATH" ] && jars="$jars:$CLASSPATH"
 
 # Launch the applet
 exec java -server -Djava.net.preferIPv4Stack=true -Xincgc -Xmx128m -Xms64m -ea -cp "$jars" lcm.spy.Spy "$@"


### PR DESCRIPTION
Modify lcm-spy and jchart2d build to allow use of system versions of xmlgraphics-commons and jide-oss. This is important for packaging, since distros are likely to not appreciate us installing our own versions, when these are provided by the distro.