### PR TITLE
Bump version to 1.4.0 pre-release (1.3.95)

### DIFF
--- a/lcm/lcm_version.h
+++ b/lcm/lcm_version.h
@@ -5,7 +5,7 @@
 #define LCM_VERSION_MINOR 3
 
 /// LCM release patch version - the Z in version X.Y.Z
-#define LCM_VERSION_PATCH 1
+#define LCM_VERSION_PATCH 95
 
 /// LCM ABI version
 #define LCM_ABI_VERSION 1


### PR DESCRIPTION
Bump the version number, so that users can tell the difference between v1.3.x (LTS) and what will eventually be 1.4.x. Since we can't readily add trailer tags, and since they make version comparisons a pain, this uses the convention of using a very large number for the patch version.