### PR TITLE
Make lcmgen no-sanitize optional

### DIFF
--- a/lcmgen/CMakeLists.txt
+++ b/lcmgen/CMakeLists.txt
@@ -14,15 +14,32 @@ set(lcm-gen_sources
   tokenize.h
 )
 
-# Errors from sanitizers cause lcm-gen to fail when executed, which in turn
-# causes users' builds to fail. To work around this, strip sanitize flags when
-# building lcm-gen. Developers working on lcm-gen may wish to disable this
-# logic.
-macro(strip_flag FLAG VAR)
-  string(REGEX REPLACE "${FLAG}" "" ${VAR} "${${VAR}}")
-endmacro()
-strip_flag("-fsanitize[=-][^ ;]*" CMAKE_C_FLAGS)
-strip_flag("-fsanitize[=-][^ ;]*" CMAKE_EXE_LINKER_FLAGS)
+include(CMakeDependentOption)
+set(_uses_sanitizers OFF)
+if("${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS}" MATCHES "-fsanitize[=-][^ ;]*")
+  set(_uses_sanitizers ON)
+endif()
+
+cmake_dependent_option(LCM_SANITIZE_LCMGEN
+  "Enable sanitizers when building lcmgen (may cause lcmgen failures)"
+  OFF "_uses_sanitizers" OFF)
+mark_as_advanced(LCM_SANITIZE_LCMGEN)
+
+if(_uses_sanitizers AND NOT LCM_SANITIZE_LCMGEN)
+  message(WARNING
+    "It looks like you are building LCM with -fsanitize. This may cause lcmgen"
+    " to exit with a non-zero result triggered by the sanitizers detecting"
+    " known (harmless) memory leaks, which in turn may cause build systems to"
+    " spuriously believe that lcmgen has failed. Since you probably don't want"
+    " that, we are disabling sanitizers for lcmgen.\n"
+    "To override this behavior, set LCM_SANITIZE_LCMGEN to ON."
+  )
+  macro(strip_flag FLAG VAR)
+    string(REGEX REPLACE "${FLAG}" "" ${VAR} "${${VAR}}")
+  endmacro()
+  strip_flag("-fsanitize[=-][^ ;]*" CMAKE_C_FLAGS)
+  strip_flag("-fsanitize[=-][^ ;]*" CMAKE_EXE_LINKER_FLAGS)
+endif()
 
 add_executable(lcm-gen ${lcm-gen_sources})
 target_link_libraries(lcm-gen PRIVATE GLib2::glib)


### PR DESCRIPTION
Add a warning when sanitizers are being disabled for `lcmgen`, and an option (hidden unless applicable, and advanced when applicable) to override this behavior.