### PR TITLE
Fix comparison of void* and function pointer

### DIFF
--- a/lcmgen/emit_cpp.c
+++ b/lcmgen/emit_cpp.c
@@ -452,7 +452,7 @@ static void emit_compute_hash(lcmgen_t *lcm, FILE *f, lcm_struct_t *ls)
         emit(0, "{");
         emit(1,     "const __lcm_hash_ptr *fp;");
         emit(1,     "for(fp = p; fp != NULL; fp = fp->parent)");
-        emit(2,         "if(fp->v == %s::getHash)", sn);
+        emit(2,         "if(fp->v == reinterpret_cast<void*>(%s::getHash))", sn);
         emit(3,              "return 0;");
         if(g_ptr_array_size(ls->members)) {
             emit(1, "const __lcm_hash_ptr cp = { p, (void*)%s::getHash };", sn);


### PR DESCRIPTION
There is a part of the `_computeHash` method in generated C++ code that sometimes contains a comparison between `void*` and a function pointer, which is not allowed by the standard. This small fix resolves that issue by casting the function pointer to `void*` first and then just doing a normal `void*`-`void*` comparison.