### PR TITLE
Correct pointer-to-function type in lcm-gen C/C++

### DIFF
--- a/lcm/lcm_coretypes.h
+++ b/lcm/lcm_coretypes.h
@@ -26,7 +26,7 @@ typedef struct ___lcm_hash_ptr __lcm_hash_ptr;
 struct ___lcm_hash_ptr
 {
     const __lcm_hash_ptr *parent;
-    void *v;
+    int64_t (*v)(void);
 };
 
 /**

--- a/lcmgen/emit_c.c
+++ b/lcmgen/emit_c.c
@@ -391,7 +391,7 @@ static void emit_c_struct_get_hash(lcmgen_t *lcm, FILE *f, lcm_struct_t *ls)
     emit(0, "");
     emit(1, "__lcm_hash_ptr cp;");
     emit(1, "cp.parent =  p;");
-    emit(1, "cp.v = (void*)__%s_get_hash;", tn_);
+    emit(1, "cp.v = __%s_get_hash;", tn_);
     emit(1, "(void) cp;");
     emit(0, "");
     emit(1, "uint64_t hash = (uint64_t)0x%016"PRIx64"LL", ls->hash);

--- a/lcmgen/emit_cpp.c
+++ b/lcmgen/emit_cpp.c
@@ -455,7 +455,7 @@ static void emit_compute_hash(lcmgen_t *lcm, FILE *f, lcm_struct_t *ls)
         emit(2,         "if(fp->v == %s::getHash)", sn);
         emit(3,              "return 0;");
         if(g_ptr_array_size(ls->members)) {
-            emit(1, "const __lcm_hash_ptr cp = { p, (void*)%s::getHash };", sn);
+            emit(1, "const __lcm_hash_ptr cp = { p, %s::getHash };", sn);
         }
         emit(0, "");
         emit(1,     "uint64_t hash = 0x%016"PRIx64"LL +", ls->hash);


### PR DESCRIPTION
ISO C++ forbids casting between pointer-to-function and pointer-to-object. Storing a pointer-to-function (pointer to getHash()) in a `void *` is not allowed, and will result in a compiler error when using pedantic compiler flags.

This patch resolves the issue by storing the pointer-to-function in a field of the correct pointer-to-function type.