### PR TITLE
Make lcm-gen C/C++ include guard span includes

### DIFF
--- a/lcmgen/emit_c.c
+++ b/lcmgen/emit_c.c
@@ -98,6 +98,10 @@ static void emit_header_top(lcmgen_t *lcm, FILE *f, char *name)
 {
     emit_auto_generated_warning(f);
 
+    fprintf(f, "#ifndef _%s_h\n", name);
+    fprintf(f, "#define _%s_h\n", name);
+    fprintf(f, "\n");
+
     fprintf(f, "#include <stdint.h>\n");
     fprintf(f, "#include <stdlib.h>\n");
     fprintf(f, "#include <lcm/lcm_coretypes.h>\n");
@@ -114,10 +118,6 @@ static void emit_header_top(lcmgen_t *lcm, FILE *f, char *name)
                 strlen(getopt_get_string(lcm->gopt, "cinclude"))>0 ? "/" : "",
                 getopt_get_string(lcm->gopt, "c-export-include"));
     }
-    fprintf(f, "\n");
-
-    fprintf(f, "#ifndef _%s_h\n", name);
-    fprintf(f, "#define _%s_h\n", name);
     fprintf(f, "\n");
 
     fprintf(f, "#ifdef __cplusplus\n");

--- a/lcmgen/emit_cpp.c
+++ b/lcmgen/emit_cpp.c
@@ -199,10 +199,10 @@ static void emit_header_start(lcmgen_t *lcmgen, FILE *f, lcm_struct_t *ls)
 
     emit_auto_generated_warning(f);
 
-    fprintf(f, "#include <lcm/lcm_coretypes.h>\n");
-    fprintf(f, "\n");
     fprintf(f, "#ifndef __%s_hpp__\n", tn_);
     fprintf(f, "#define __%s_hpp__\n", tn_);
+    fprintf(f, "\n");
+    fprintf(f, "#include <lcm/lcm_coretypes.h>\n");
     fprintf(f, "\n");
 
     // do we need to #include <vector> and/or <string>?


### PR DESCRIPTION
Make the include guards in the C and C++ headers generated by `lcm-gen` span all of the file, including the `#include` list, by moving up the appropriate `#ifndef`/`#define` statements generated.

Having all of the header inside the include guards makes it manifest that the header can be `#include`-ed twice in client code without any side effects. This helps both the reader of the file, and static analysis tools that may warn about including a generated header twice unless we make it obvious that there is an include guard protecting the entire header file.