### PR TITLE
Fix Clang -Wsign-conversion warning in lcm-gen C++

### DIFF
--- a/lcmgen/emit_cpp.c
+++ b/lcmgen/emit_cpp.c
@@ -431,7 +431,7 @@ static void emit_get_hash(lcmgen_t *lcm, FILE *f, lcm_struct_t *ls)
     const char *sn  = ls->structname->shortname;
     emit(0, "int64_t %s::getHash()", sn);
     emit(0, "{");
-    emit(1,     "static int64_t hash = _computeHash(NULL);");
+    emit(1,     "static int64_t hash = static_cast<int64_t>(_computeHash(NULL));");
     emit(1,     "return hash;");
     emit(0, "}");
     emit(0, "");


### PR DESCRIPTION
When building C++ code generated by `lcm-gen` using Clang, a warning about implicit conversion that changes signedness is triggered (`-Wsign-conversion`). This patch fixes the warning by making the conversion explicit, using `static_cast<int64_t>()`.