### PR TITLE
Make lcm-logger flush queue before exiting

### DIFF
--- a/lcm-logger/lcm_logger.c
+++ b/lcm-logger/lcm_logger.c
@@ -229,7 +229,7 @@ write_thread(void *user_data)
 
         // Should the write thread exit?
         g_mutex_lock(logger->mutex);
-        if(logger->write_thread_exit_flag) {
+        if(msg == &logger->write_thread_exit_flag) {
             g_mutex_unlock(logger->mutex);
             return NULL;
         }


### PR DESCRIPTION
Make the write thread of `lcm-logger` write out all messages remaining in the queue before exiting. This means that messages received by `lcm-logger` before the `lcm-logger` was asked to terminate end up in the log.

This fixes lcm-proj/lcm#173.