### PR TITLE
Fixes issue where UDP packets arrive out of order and the entire LCM message is lost.

### DIFF
--- a/lcm/lcm_mpudpm.c
+++ b/lcm/lcm_mpudpm.c
@@ -403,10 +403,6 @@ recv_message_fragment (lcm_mpudpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz)
 {
     lcm2_header_long_t *hdr = (lcm2_header_long_t*) lcmb->buf;
 
-    // any existing fragment buffer for this message source?
-    lcm_frag_buf_t *fbuf = lcm_frag_buf_store_lookup(lcm->frag_bufs,
-            &lcmb->from);
-
     uint32_t msg_seqno = ntohl (hdr->msg_seqno);
     uint32_t data_size = ntohl (hdr->msg_size);
     uint32_t fragment_offset = ntohl (hdr->fragment_offset);
@@ -415,9 +411,14 @@ recv_message_fragment (lcm_mpudpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz)
     uint32_t frag_size = sz - sizeof (lcm2_header_long_t);
     char *data_start = (char*) (hdr + 1);
 
+    // any existing fragment buffer for this message source?
+    lcm_frag_key_t key;
+    key.from = &(lcmb->from);
+    key.msg_seqno = msg_seqno;
+    lcm_frag_buf_t *fbuf = lcm_frag_buf_store_lookup(lcm->frag_bufs, &key);
+
     // discard any stale fragments from previous messages
-    if (fbuf && ((fbuf->msg_seqno != msg_seqno) ||
-            (fbuf->data_size != data_size))) {
+    if (fbuf && (fbuf->data_size != data_size)) {
         lcm_frag_buf_store_remove (lcm->frag_bufs, fbuf);
         dbg(DBG_LCM, "Dropping message (missing %d fragments)\n",
             fbuf->fragments_remaining);
@@ -429,41 +430,35 @@ recv_message_fragment (lcm_mpudpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz)
         return 0;
     }
 
-    // create a new fragment buffer if necessary
-    //TODO(abachrac): this discards a msg if the first fragment is out of order
-    if (!fbuf && hdr->fragment_no == 0) {
-        char *channel = (char*) (hdr + 1);
+    //if this is the first packet, set some values
+    char *channel = NULL;
+    if (hdr->fragment_no == 0) {
+        channel = (char*) (hdr + 1);
         int channel_sz = strlen (channel);
         if (channel_sz > LCM_MAX_CHANNEL_NAME_LENGTH) {
             dbg (DBG_LCM, "bad channel name length\n");
             lcm->udp_discarded_bad++;
             return 0;
         }
-
-        // if the packet has no subscribers, drop the message now.
-        if (!lcm_has_handlers(lcm->lcm, channel)
-                && !is_reserved_channel(channel))
-            return 0;
-
-        fbuf = lcm_frag_buf_new (*((struct sockaddr_in*) &lcmb->from),
-                channel, msg_seqno, data_size, fragments_in_msg,
-                lcmb->recv_utime);
-        lcm_frag_buf_store_add (lcm->frag_bufs, fbuf);
         data_start += channel_sz + 1;
         frag_size -= (channel_sz + 1);
     }
 
-    if (!fbuf){
-        // received fragment for message we dropped (hopefully intentionally)
-        //TODO(abachrac): is there a way to distinguish between intentionally
-        // dropped, and packets being dropped due to out of order packet 0?
-        return 0;
+    // create a new fragment buffer if necessary
+    if (!fbuf) {
+        fbuf = lcm_frag_buf_new (*((struct sockaddr_in*) &lcmb->from),
+                msg_seqno, data_size, fragments_in_msg,
+                lcmb->recv_utime);
+        lcm_frag_buf_store_add (lcm->frag_bufs, fbuf);
+    }
+    if (channel!=NULL) {
+        strncpy (fbuf->channel, channel, sizeof (fbuf->channel));
     }
 
 #ifdef __linux__
     if(lcm->kernel_rbuf_sz < 262145 && 
-            data_size > lcm->kernel_rbuf_sz &&
-            ! lcm->warned_about_small_kernel_buf) {
+           data_size > lcm->kernel_rbuf_sz &&
+           ! lcm->warned_about_small_kernel_buf) {
         fprintf(stderr, 
 "==== LCM Warning ===\n"
 "LCM detected that large packets are being received, but the kernel UDP\n"

--- a/lcm/udpm_util.c
+++ b/lcm/udpm_util.c
@@ -42,7 +42,9 @@ static guint
 _lcm_frag_key_hash (const void * key)
 {
     lcm_frag_key_t *frag_key = (lcm_frag_key_t *) key;
-    int v = frag_key->from->sin_port * frag_key->from->sin_addr.s_addr * frag_key->msg_seqno;
+    //try to combine 3 ints to create a unique into using bit shifting 
+    //ints are not completely unique, but old mult method also had collisions
+    int v = (((int) frag_key->from->sin_addr.s_addr ^  frag_key->from->sin_port) << 16) | (0x0000FFFF & frag_key->msg_seqno);
     return g_int_hash (&v);
 }
 

--- a/lcm/udpm_util.c
+++ b/lcm/udpm_util.c
@@ -11,18 +11,19 @@
 
 /******************** fragment buffer **********************/
 lcm_frag_buf_t *
-lcm_frag_buf_new (struct sockaddr_in from, const char *channel, 
+lcm_frag_buf_new (struct sockaddr_in from, 
         uint32_t msg_seqno, uint32_t data_size, uint16_t nfragments,
         int64_t first_packet_utime)
 {
     lcm_frag_buf_t *fbuf = (lcm_frag_buf_t*) malloc (sizeof (lcm_frag_buf_t));
-    strncpy (fbuf->channel, channel, sizeof (fbuf->channel));
     fbuf->from = from;
     fbuf->msg_seqno = msg_seqno;
     fbuf->data = (char*)malloc (data_size);
     fbuf->data_size = data_size;
     fbuf->fragments_remaining = nfragments;
     fbuf->last_packet_utime = first_packet_utime;
+    fbuf->key.from = &(fbuf->from);
+    fbuf->key.msg_seqno = msg_seqno;
     return fbuf;
 }
 
@@ -38,22 +39,23 @@ lcm_frag_buf_destroy (lcm_frag_buf_t *fbuf)
 /******************** fragment buffer store **********************/
 
 static guint
-_sockaddr_in_hash (const void * key)
+_lcm_frag_key_hash (const void * key)
 {
-    struct sockaddr_in *addr = (struct sockaddr_in*) key;
-    int v = addr->sin_port * addr->sin_addr.s_addr;
+    lcm_frag_key_t *frag_key = (lcm_frag_key_t *) key;
+    int v = frag_key->from->sin_port * frag_key->from->sin_addr.s_addr * frag_key->msg_seqno;
     return g_int_hash (&v);
 }
 
 static gboolean
-_sockaddr_in_equal (const void * a, const void *b)
+_lcm_frag_key_equal (const void * a, const void *b)
 {
-    struct sockaddr_in *a_addr = (struct sockaddr_in*) a;
-    struct sockaddr_in *b_addr = (struct sockaddr_in*) b;
+    lcm_frag_key_t *a_key = (lcm_frag_key_t*) a;
+    lcm_frag_key_t *b_key = (lcm_frag_key_t*) b;
 
-    return a_addr->sin_addr.s_addr == b_addr->sin_addr.s_addr &&
-           a_addr->sin_port        == b_addr->sin_port &&
-           a_addr->sin_family      == b_addr->sin_family;
+    return a_key->from->sin_addr.s_addr == b_key->from->sin_addr.s_addr &&
+           a_key->from->sin_port        == b_key->from->sin_port &&
+           a_key->from->sin_family      == b_key->from->sin_family &&
+           a_key->msg_seqno            == b_key->msg_seqno;
 }
 
 static void
@@ -75,8 +77,8 @@ lcm_frag_buf_store * lcm_frag_buf_store_new(uint32_t max_total_size,
     store->max_total_size = max_total_size;
     store->max_n_frag_bufs = max_n_frag_bufs;
 
-    store->frag_bufs = g_hash_table_new_full(_sockaddr_in_hash,
-                                       _sockaddr_in_equal, NULL,
+    store->frag_bufs = g_hash_table_new_full(_lcm_frag_key_hash,
+                                       _lcm_frag_key_equal, NULL,
                                        (GDestroyNotify) lcm_frag_buf_destroy);
     return store;
 }
@@ -87,7 +89,7 @@ void lcm_frag_buf_store_destroy(lcm_frag_buf_store * store){
 }
 
 lcm_frag_buf_t * lcm_frag_buf_store_lookup(lcm_frag_buf_store * store,
-        struct sockaddr* key) {
+        lcm_frag_key_t* key) {
     return (lcm_frag_buf_t *) g_hash_table_lookup(store->frag_bufs, key);
 }
 
@@ -103,7 +105,7 @@ lcm_frag_buf_store_add (lcm_frag_buf_store *store, lcm_frag_buf_t *fbuf)
             lcm_frag_buf_store_remove (store, lru_fbuf);
         }
     }
-    g_hash_table_insert (store->frag_bufs, &fbuf->from, fbuf);
+    g_hash_table_insert (store->frag_bufs, &fbuf->key, fbuf);
     store->total_size += fbuf->data_size;
 }
 
@@ -111,7 +113,7 @@ void
 lcm_frag_buf_store_remove (lcm_frag_buf_store *store, lcm_frag_buf_t *fbuf)
 {
     store->total_size -= fbuf->data_size;
-    g_hash_table_remove (store->frag_bufs, &fbuf->from);
+    g_hash_table_remove (store->frag_bufs, &fbuf->key);
 }
 
 

--- a/lcm/udpm_util.h
+++ b/lcm/udpm_util.h
@@ -183,17 +183,23 @@ lcm_buf_allocate_data(lcm_buf_queue_t * inbufs_empty, lcm_ringbuf_t **ringbuf);
 void lcm_buf_free_data(lcm_buf_t *lcmb, lcm_ringbuf_t *ringbuf);
 
 /******************** fragment buffer **********************/
+typedef struct _lcm_frag_key {
+    uint32_t msg_seqno;
+    struct   sockaddr_in *from;
+} lcm_frag_key_t;
+
 typedef struct _lcm_frag_buf {
-    char      channel[LCM_MAX_CHANNEL_NAME_LENGTH+1];
-    struct    sockaddr_in from;
-    char      *data;
-    uint32_t  data_size;
-    uint16_t  fragments_remaining;
-    uint32_t  msg_seqno;
-    int64_t   last_packet_utime;
+    char            channel[LCM_MAX_CHANNEL_NAME_LENGTH+1];
+    struct          sockaddr_in from;
+    char            *data;
+    uint32_t        data_size;
+    uint16_t        fragments_remaining;
+    uint32_t        msg_seqno;
+    int64_t         last_packet_utime;
+    lcm_frag_key_t  key;
 } lcm_frag_buf_t;
 
-lcm_frag_buf_t * lcm_frag_buf_new(struct sockaddr_in from, const char *channel,
+lcm_frag_buf_t * lcm_frag_buf_new(struct sockaddr_in from,
         uint32_t msg_seqno, uint32_t data_size, uint16_t nfragments,
         int64_t first_packet_utime);
 void lcm_frag_buf_destroy(lcm_frag_buf_t *fbuf);
@@ -211,7 +217,7 @@ lcm_frag_buf_store * lcm_frag_buf_store_new(uint32_t max_total_size,
         uint32_t max_n_frag_bufs);
 void lcm_frag_buf_store_destroy(lcm_frag_buf_store * store);
 lcm_frag_buf_t * lcm_frag_buf_store_lookup(lcm_frag_buf_store * store,
-        struct sockaddr* key);
+        lcm_frag_key_t* key);
 
 void lcm_frag_buf_store_remove(lcm_frag_buf_store *store, lcm_frag_buf_t *fbuf);
 void lcm_frag_buf_store_add(lcm_frag_buf_store *store, lcm_frag_buf_t *fbuf);


### PR DESCRIPTION
Fixes issue where UDP packets arrive out of order and the entire LCM message is lost.

This happens most commonly when a message size is barely larger than one UDP datagram (i.e.: the first packet is as large as it can be and the second packet is just one ethernet frame). Because UDP makes no guarantees about packet reception order, and because the UDP receive buffers are multi threaded, sometimes the second fragment arrives before the first.

In some cases (because of packet sizes and network architecture), the second packet will almost always arrive before the first. This causes long periods where LCM cannot receive any of the messages on that channel.

In the original fragment receive implementation, this would cause the whole packet to be lost. Now it can be received.

This also means that two messages from the same sender can have packets interleaved and still received successfully.

#Changes:
lcm_frag_buff type has an extra pointer and an extra uin32_t conatined within a new struct
Two conditions removed from two if statements
Two if statements removed
One if statement added
More packets could potentially wind up in the fragment hash table
Hashing function has an additional multiplication
Hash pointer equality check has an additional condition