### PR TITLE
cmake: export cmake build to CMake's user registry

### DIFF
--- a/lcm-cmake/install.cmake
+++ b/lcm-cmake/install.cmake
@@ -61,3 +61,6 @@ lcm_copy_file_target(lcm_use_file
   ${CMAKE_CURRENT_LIST_DIR}/${PROJECT_NAME}Utilities.cmake
   ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Utilities.cmake
 )
+
+# add to CMake package register
+export(PACKAGE ${PROJECT_NAME})

--- a/lcm-cmake/install.cmake
+++ b/lcm-cmake/install.cmake
@@ -62,5 +62,5 @@ lcm_copy_file_target(lcm_use_file
   ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Utilities.cmake
 )
 
-# add to CMake package register
+# Add to CMake package registry
 export(PACKAGE ${PROJECT_NAME})


### PR DESCRIPTION
so other projects can use this one without requiring
to install the package. See cmake [documentation](https://cmake.org/cmake/help/v3.7/command/export.html?highlight=export) section "export(PACKAGE <name>)" for further info in this.