### PR TITLE
Fixing a ThreadSanitizer Issue

### DIFF
--- a/lcm/lcm_file.c
+++ b/lcm/lcm_file.c
@@ -355,13 +355,26 @@ lcm_logprov_publish (lcm_logprov_t *lcm, const char *channel, const void *data,
     return 0;
 }
 
+#ifdef WIN32
 static lcm_provider_vtable_t logprov_vtable;
-static lcm_provider_info_t logprov_info;
+#else
+static lcm_provider_vtable_t logprov_vtable = {
+    .create      = lcm_logprov_create,
+    .destroy     = lcm_logprov_destroy,
+    .subscribe   = NULL,
+    .unsubscribe = NULL,
+    .publish     = lcm_logprov_publish,
+    .handle      = lcm_logprov_handle,
+    .get_fileno  = lcm_logprov_get_fileno
+};
+#endif
 
+static lcm_provider_info_t logprov_info;
 
 void
 lcm_logprov_provider_init (GPtrArray * providers)
 {
+#ifdef WIN32
 // Microsoft VS compiler issues. Can't do this statically
     logprov_vtable.create      = lcm_logprov_create;
     logprov_vtable.destroy     = lcm_logprov_destroy;
@@ -370,6 +383,7 @@ lcm_logprov_provider_init (GPtrArray * providers)
     logprov_vtable.publish     = lcm_logprov_publish;
     logprov_vtable.handle      = lcm_logprov_handle;
     logprov_vtable.get_fileno  = lcm_logprov_get_fileno;
+#endif
 
     logprov_info.name = "file";
     logprov_info.vtable = &logprov_vtable;

--- a/lcm/lcm_memq.c
+++ b/lcm/lcm_memq.c
@@ -153,12 +153,25 @@ lcm_memq_publish (lcm_memq_t *self, const char *channel, const void *data,
     return 0;
 }
 
+#ifdef WIN32
 static lcm_provider_vtable_t memq_vtable;
+#else
+static lcm_provider_vtable_t memq_vtable = {
+    .create      = lcm_memq_create,
+    .destroy     = lcm_memq_destroy,
+    .subscribe   = NULL,
+    .unsubscribe = NULL,
+    .publish     = lcm_memq_publish,
+    .handle      = lcm_memq_handle,
+    .get_fileno  = lcm_memq_get_fileno
+};
+#endif
 static lcm_provider_info_t memq_info;
 
 void
 lcm_memq_provider_init (GPtrArray * providers)
 {
+#ifdef WIN32
     memq_vtable.create      = lcm_memq_create;
     memq_vtable.destroy     = lcm_memq_destroy;
     memq_vtable.subscribe   = NULL;
@@ -166,7 +179,7 @@ lcm_memq_provider_init (GPtrArray * providers)
     memq_vtable.publish     = lcm_memq_publish;
     memq_vtable.handle      = lcm_memq_handle;
     memq_vtable.get_fileno  = lcm_memq_get_fileno;
-
+#endif
     memq_info.name = "memq";
     memq_info.vtable = &memq_vtable;
 

--- a/lcm/lcm_mpudpm.c
+++ b/lcm/lcm_mpudpm.c
@@ -1879,12 +1879,25 @@ lcm_mpudpm_create (lcm_t * parent, const char *network, const GHashTable *args)
     return lcm;
 }
 
+#ifdef WIN32
 static lcm_provider_vtable_t mpudpm_vtable;
+#else
+static lcm_provider_vtable_t mpudpm_vtable = {
+    .create      = lcm_mpudpm_create,
+    .destroy     = lcm_mpudpm_destroy,
+    .subscribe   = lcm_mpudpm_subscribe,
+    .unsubscribe = lcm_mpudpm_unsubscribe,
+    .publish     = lcm_mpudpm_publish,
+    .handle      = lcm_mpudpm_handle,
+    .get_fileno  = lcm_mpudpm_get_fileno
+};
+#endif
 static lcm_provider_info_t mpudpm_info;
 
 void
 lcm_mpudpm_provider_init (GPtrArray * providers)
 {
+#ifdef WIN32
     // Because of Microsoft Visual Studio compiler
     // difficulties, do this now, not statically
     mpudpm_vtable.create      = lcm_mpudpm_create;
@@ -1894,7 +1907,7 @@ lcm_mpudpm_provider_init (GPtrArray * providers)
     mpudpm_vtable.publish     = lcm_mpudpm_publish;
     mpudpm_vtable.handle      = lcm_mpudpm_handle;
     mpudpm_vtable.get_fileno  = lcm_mpudpm_get_fileno;
-
+#endif
     mpudpm_info.name = "mpudpm";
     mpudpm_info.vtable = &mpudpm_vtable;
 

--- a/lcm/lcm_tcpq.c
+++ b/lcm/lcm_tcpq.c
@@ -417,12 +417,25 @@ lcm_tcpq_publish(lcm_tcpq_t *self, const char *channel, const void *data,
     return 0;
 }
 
+#ifdef WIN32
 static lcm_provider_vtable_t tcpq_vtable;
+#else
+static lcm_provider_vtable_t tcpq_vtable = {
+    .create      = lcm_tcpq_create,
+    .destroy     = lcm_tcpq_destroy,
+    .subscribe   = lcm_tcpq_subscribe,
+    .unsubscribe = lcm_tcpq_unsubscribe,
+    .publish     = lcm_tcpq_publish,
+    .handle      = lcm_tcpq_handle,
+    .get_fileno  = lcm_tcpq_get_fileno
+};
+#endif
 static lcm_provider_info_t tcpq_info;
 
 void
 lcm_tcpq_provider_init (GPtrArray * providers)
 {
+#ifdef WIN32
     tcpq_vtable.create      = lcm_tcpq_create;
     tcpq_vtable.destroy     = lcm_tcpq_destroy;
     tcpq_vtable.subscribe   = lcm_tcpq_subscribe;
@@ -430,7 +443,7 @@ lcm_tcpq_provider_init (GPtrArray * providers)
     tcpq_vtable.publish     = lcm_tcpq_publish;
     tcpq_vtable.handle      = lcm_tcpq_handle;
     tcpq_vtable.get_fileno  = lcm_tcpq_get_fileno;
-
+#endif
     tcpq_info.name = "tcpq";
     tcpq_info.vtable = &tcpq_vtable;
 

--- a/lcm/lcm_udpm.c
+++ b/lcm/lcm_udpm.c
@@ -1214,12 +1214,26 @@ lcm_udpm_create (lcm_t * parent, const char *network, const GHashTable *args)
     return lcm;
 }
 
+#ifdef WIN32
 static lcm_provider_vtable_t udpm_vtable;
+#else
+static lcm_provider_vtable_t udpm_vtable = {
+    .create      = lcm_udpm_create,
+    .destroy     = lcm_udpm_destroy,
+    .subscribe   = lcm_udpm_subscribe,
+    .unsubscribe = NULL,
+    .publish     = lcm_udpm_publish,
+    .handle      = lcm_udpm_handle,
+    .get_fileno  = lcm_udpm_get_fileno,
+};
+#endif
+
 static lcm_provider_info_t udpm_info;
 
 void
 lcm_udpm_provider_init (GPtrArray * providers)
 {
+#ifdef WIN32
 // Because of Microsoft Visual Studio compiler
 // difficulties, do this now, not statically
     udpm_vtable.create      = lcm_udpm_create;
@@ -1229,7 +1243,7 @@ lcm_udpm_provider_init (GPtrArray * providers)
     udpm_vtable.publish     = lcm_udpm_publish;
     udpm_vtable.handle      = lcm_udpm_handle;
     udpm_vtable.get_fileno  = lcm_udpm_get_fileno;
-
+#endif
     udpm_info.name = "udpm";
     udpm_info.vtable = &udpm_vtable;
 


### PR DESCRIPTION
There seem to be at least two data races on lcm.vtable in lcm.c and udpm.c.  To reproduce the bug, I just modified the listener.cpp in the example folder:

https://gist.github.com/m-chaturvedi/4bce669434d2d197170b1ead1be97438 

If tsan is used on the above in addition to LCM, we can see that there are data-races.

Seems like we don't need to free the mutexes on static objects:
https://developer.gnome.org/glib/stable/glib-Deprecated-Thread-APIs.html#g-static-rec-mutex-free