### PR TITLE
Remove unused imports in lcm/logging/Log.java

### DIFF
--- a/lcm-java/lcm/logging/Log.java
+++ b/lcm-java/lcm/logging/Log.java
@@ -1,9 +1,6 @@
 package lcm.logging;
 
-import java.awt.*;
-import java.awt.event.*;
 import java.io.*;
-import java.util.*;
 
 import lcm.util.*;
 import lcm.lcm.*;


### PR DESCRIPTION
Remove unused imports `java.awt.*`, `java.awt.event.*` and `java.util.*` from `lcm-java/lcm/logging/Log.java`. It is worth noting that importing `java.awt.*` doesn't work on Android; removing these unused imports makes it possible to use LCM in Android apps.