### PR TITLE
In generated C++ code, use static_cast instead of C cast

### DIFF
--- a/lcmgen/emit_cpp.c
+++ b/lcmgen/emit_cpp.c
@@ -383,7 +383,7 @@ static void emit_encode(lcmgen_t *lcm, FILE *f, lcm_struct_t *ls)
     emit(0, "int %s::encode(void *buf, int offset, int maxlen) const", sn);
     emit(0, "{");
     emit(1,     "int pos = 0, tlen;");
-    emit(1,     "int64_t hash = (int64_t)getHash();");
+    emit(1,     "int64_t hash = getHash();");
     emit(0, "");
     emit(1,     "tlen = __int64_t_encode_array(buf, offset + pos, maxlen - pos, &hash, 1);");
     emit(1,     "if(tlen < 0) return tlen; else pos += tlen;");

--- a/lcmgen/emit_cpp.c
+++ b/lcmgen/emit_cpp.c
@@ -674,7 +674,7 @@ static void _decode_recursive(lcmgen_t* lcm, FILE* f, lcm_member_t* lm, int dept
             emit_start(1 + depth, "this->%s", lm->membername);
             for(int i=0; i<depth; i++)
                 emit_continue("[a%d]", i);
-            emit_end(".assign(((const char*)buf) + offset + pos, __elem_len -  1);");
+            emit_end(".assign(static_cast<const char*>(buf) + offset + pos, __elem_len -  1);");
             emit(1 + depth, "pos += __elem_len;");
         } else {
             emit_start(1 + depth, "tlen = this->%s", lm->membername);
@@ -730,7 +730,7 @@ static void emit_decode_nohash(lcmgen_t *lcm, FILE *f, lcm_struct_t *ls)
                 emit(1, "tlen = __int32_t_decode_array(buf, offset + pos, maxlen - pos, &__%s_len__, 1);", lm->membername);
                 emit(1, "if(tlen < 0) return tlen; else pos += tlen;");
                 emit(1, "if(__%s_len__ > maxlen - pos) return -1;", lm->membername);
-                emit(1, "this->%s.assign(((const char*)buf) + offset + pos, __%s_len__ - 1);", lm->membername, lm->membername);
+                emit(1, "this->%s.assign(static_cast<const char*>(buf) + offset + pos, __%s_len__ - 1);", lm->membername, lm->membername);
                 emit(1, "pos += __%s_len__;", lm->membername);
             } else {
                 emit(1, "tlen = __%s_decode_array(buf, offset + pos, maxlen - pos, &this->%s, 1);", lm->type->lctypename, lm->membername);


### PR DESCRIPTION
Using a C-style cast in C++ code triggers `-Wold-style-cast` in both GCC and Clang, and because lcm-cpp is header-only it is sometimes difficult for downstream projects to suppress this warning in LCM-generated code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lcm-proj/lcm/199)
<!-- Reviewable:end -->
