### PR TITLE
Use -undefined dynamic_lookup for OSX

### DIFF
--- a/lcm-python/CMakeLists.txt
+++ b/lcm-python/CMakeLists.txt
@@ -30,8 +30,15 @@ target_include_directories(lcm-python PRIVATE
 
 target_link_libraries(lcm-python PRIVATE
   lcm-static
-  ${PYTHON_LIBRARY}
 )
+
+if(APPLE)
+  set_target_properties(lcm-python PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+else()
+  target_link_libraries(lcm-python PRIVATE
+    ${PYTHON_LIBRARY}
+  )
+endif()
 
 install(TARGETS lcm-python
   RUNTIME DESTINATION ${PYTHON_SITE}/lcm


### PR DESCRIPTION
Patch taken from [here](https://s3.amazonaws.com/drake-homebrew/patches/lcm-1.3.95-python-undefined-dynamic-lookup.patch).
http://blog.tim-smith.us/2015/09/python-extension-modules-os-x/

To test:
`diff <(otool -L $INSTALL1/lib/python2.7/site-packages/lcm/_lcm.so) <(otool -L $INSTALL2/lib/python2.7/site-packages/lcm/_lcm.so)`
