### PR TITLE
lcmgen: Emit Python more PEP8 compliant

### DIFF
--- a/lcmgen/emit_lua.c
+++ b/lcmgen/emit_lua.c
@@ -16,6 +16,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <linux/limits.h> /* PATH_MAX */
 #endif
 
 #include <glib.h>


### PR DESCRIPTION
Greetings,

I'm starting up a project and plan to use LCM as the backend pipeline, and found the Python output by lcm-gen doesn't output very cleanly to pass some basic lint tests. Here's a list of things that could use improvement:

- In ```emit_encode_one```, line 377, PEP8 E226 denotes a single white space should be placed on each
side of an arthimetic operator.  This would also apply to the shift-left and logical AND on line 629.

- In ```emit_member_initializer```, line 578 and 580, PEP8 E201 denotes there shouldn't be a space
after or before a square bracket.

- As no value is actually used for ```dim%d``` on line 580, a placeholder variable of ```_``` can be
used in it's place.

- Finally, the usage of ```staticmethod()``` can be simplified to adding a decorator before the ```def```
of the method. An example of the current output:
```
    def decode(data):
        ...
        return message.__decide_one(buf)
    decode = staticmethod(decode)
```

  While functional, since Python v2.4 PEP318 has defined the usage of decorators, which allows for
defining ```staticmethod``` as follows and removes hanging class values:
```
    @staticmethod
    def decode(data):
        ...
```
Therefore, I've put a PR together to make these corrections and are submitting them for merge.  I tested a compile on my branch, while I could get things to compile with only warnings about pointer casts in ```getopt``` and ``lcmgen``` *insert general gripe about unfamiliarity with C/C++ and cmake here* I wasn't able to get a working binary to test.  So some review there would be helpful.