### PR TITLE
Prevent unindenting in the middle of an array in lcm-spy

### DIFF
--- a/lcm-java/lcm/spy/ObjectPanel.java
+++ b/lcm-java/lcm/spy/ObjectPanel.java
@@ -379,13 +379,13 @@ public class ObjectPanel extends JPanel
         {
             Section cs = sections.get(section);
 
+            if (collapse_depth == 0) {
+                unindent();
+            }
+
             // if this section is collapsed, resume drawing.
             if (sections.get(section).collapsed) {
                 collapse_depth --;
-            }
-
-            if (collapse_depth == 0) {
-                unindent();
             }
 
             spacer();


### PR DESCRIPTION
In the `lcm-spy` structure viewer, if `unindent()` is called after `collapse_depth` is decremented, arrays of  LCM types do not render correctly when some of the array elements are collapsed.

Rendering with the current master branch:
![screenshot from 2018-04-10 17-24-53](https://user-images.githubusercontent.com/409143/38584514-8cb2812a-3ce4-11e8-9ba7-ec58a148b24b.png)

Rendering after this change:
![screenshot from 2018-04-10 17-22-25](https://user-images.githubusercontent.com/409143/38584522-93025730-3ce4-11e8-8d54-a3cde503ddab.png)