### PR TITLE
Add option to include with quotes instead of angular brackets

### DIFF
--- a/lcmgen/emit_c.c
+++ b/lcmgen/emit_c.c
@@ -104,13 +104,21 @@ static void emit_header_top(lcmgen_t *lcm, FILE *f, char *name)
 
     fprintf(f, "#include <stdint.h>\n");
     fprintf(f, "#include <stdlib.h>\n");
-    fprintf(f, "#include <lcm/lcm_coretypes.h>\n");
+    if(getopt_get_bool(lcm->gopt, "use-quotes-for-includes"))
+        fprintf(f, "#include \"lcm/lcm_coretypes.h\"\n");
+    else
+        fprintf(f, "#include <lcm/lcm_coretypes.h>\n");
+
 //    fprintf(f, "#include \"%s%slcm_lib.h\"\n",
 //            getopt_get_string(lcm->gopt, "cinclude"),
 //            strlen(getopt_get_string(lcm->gopt, "cinclude"))>0 ? "/" : "");
 
     if(!getopt_get_bool(lcm->gopt, "c-no-pubsub")) {
-        fprintf(f, "#include <lcm/lcm.h>\n");
+        if(getopt_get_bool(lcm->gopt, "use-quotes-for-includes"))
+            fprintf(f, "#include \"lcm/lcm.h\"\n");
+        else
+            fprintf(f, "#include <lcm/lcm.h>\n");
+
     }
     if(strlen(getopt_get_string(lcm->gopt, "c-export-include"))) {
         fprintf(f, "#include \"%s%s%s\"\n",

--- a/lcmgen/emit_cpp.c
+++ b/lcmgen/emit_cpp.c
@@ -202,7 +202,10 @@ static void emit_header_start(lcmgen_t *lcmgen, FILE *f, lcm_struct_t *ls)
     fprintf(f, "#ifndef __%s_hpp__\n", tn_);
     fprintf(f, "#define __%s_hpp__\n", tn_);
     fprintf(f, "\n");
-    fprintf(f, "#include <lcm/lcm_coretypes.h>\n");
+    if(getopt_get_bool(lcmgen->gopt, "use-quotes-for-includes"))
+        fprintf(f, "#include \"lcm/lcm_coretypes.h\"\n");
+    else
+        fprintf(f, "#include <lcm/lcm_coretypes.h>\n");
     fprintf(f, "\n");
 
     // do we need to #include <vector> and/or <string>?

--- a/lcmgen/main.c
+++ b/lcmgen/main.c
@@ -47,6 +47,7 @@ int main(int argc, char *argv[])
     getopt_add_bool  (gopt, 't',  "tokenize", 0,    "Show tokenization");
     getopt_add_bool  (gopt, 'd',  "debug",    0,    "Show parsed file");
     getopt_add_bool  (gopt, 0,    "lazy",     0,    "Generate output file only if .lcm is newer");
+    getopt_add_bool  (gopt, 0,    "use-quotes-for-includes",     0,    "Use quotes instead of angular brackets for including header files");
     getopt_add_string(gopt, 0,    "package-prefix",     "",
                       "Add this package name as a prefix to the declared package");
     getopt_add_bool  (gopt, 0,  "version",    0,    "Show version information and exit");


### PR DESCRIPTION
Add an option to use double quotes instead of angular brackets when including headers in the header files generated by `lcm-gen`.

The convention seems to be to use angular brackets for system includes.

The main difference is that the current directory is searched first and then include directory list when using double quotes, whereas the current directory is not searched when using angular brackets.
