### PR TITLE
Propagate exit code from generation errors to main

### DIFF
--- a/lcmgen/main.c
+++ b/lcmgen/main.c
@@ -110,6 +110,7 @@ int main(int argc, char *argv[])
     }
 
     int did_something = 0;
+    int res = 0;
     if (getopt_get_bool(gopt, "debug")) {
         did_something = 1;
         lcmgen_dump(lcm);
@@ -119,6 +120,7 @@ int main(int argc, char *argv[])
         did_something = 1;
         if (emit_c(lcm)) {
             printf("An error occurred while emitting C code.\n");
+            res = -1;
         }
     }
 
@@ -126,6 +128,7 @@ int main(int argc, char *argv[])
         did_something = 1;
         if (emit_cpp(lcm)) {
             printf("An error occurred while emitting C++ code.\n");
+            res = -1;
         }
     }
 
@@ -133,6 +136,7 @@ int main(int argc, char *argv[])
         did_something = 1;
         if (emit_java(lcm)) {
             perror("An error occurred while emitting Java code.\n");
+            res = -1;
         }
     }
 
@@ -140,26 +144,30 @@ int main(int argc, char *argv[])
         did_something = 1;
         if (emit_python(lcm)) {
             printf("An error occurred while emitting Python code.\n");
+            res = -1;
         }
     }
 
     if (getopt_get_bool(gopt, "lua")) {
-    	did_something = 1;
-    	if (emit_lua(lcm)) {
-    		printf("An error occurred while emitting Lua code.\n");
-    	}
+       did_something = 1;
+       if (emit_lua(lcm)) {
+            printf("An error occurred while emitting Lua code.\n");
+            res = -1;
+        }
     }
 
     if (getopt_get_bool(gopt, "csharp")) {
         did_something = 1;
         if (emit_csharp(lcm)) {
             printf("An error occurred while emitting C#.NET code.\n");
+            res = -1;
         }
     }
 
     if (did_something == 0) {
         printf("No actions specified. Try --help.\n");
+        res = -1;
     }
 
-    return 0;
+    return res;
 }


### PR DESCRIPTION
This change adds result code propagation to exit code whenever a
code generation error happens. If any code generator fails main
exits with -1.