### PR TITLE
Added lcm_struct->pkg for multi file lcmgen

### DIFF
--- a/lcmgen/lcmgen.c
+++ b/lcmgen/lcmgen.c
@@ -192,6 +192,7 @@ lcm_struct_t *lcm_struct_create(lcmgen_t *lcmgen, const char *lcmfile, const cha
 {
     lcm_struct_t *lr = (lcm_struct_t*) calloc(1, sizeof(lcm_struct_t));
     lr->lcmfile    = strdup(lcmfile);
+    lr->package    = strdup(lcmgen->package);
     lr->structname = lcm_typename_create(lcmgen, structname);
     lr->members    = g_ptr_array_new();
     lr->constants  = g_ptr_array_new();

--- a/lcmgen/lcmgen.h
+++ b/lcmgen/lcmgen.h
@@ -78,6 +78,7 @@ struct lcm_struct
   GPtrArray *constants; // lcm_constant_t
 
   char *lcmfile;       // file/path of function that declared it
+  char *package;       // package in which this struct is defined
   int64_t hash;
 
   // Comments in the LCM type defition immediately before a struct is declared


### PR DESCRIPTION
The lcmgen->package only saved the last package, which is problematic
when lcmgen is started with multiple .lcm files. If each is within a
different package it should be possible to access the correct package
in which the struct was defined. Each struct now has its own package
member which contains this info.