### PR TITLE
Add golang backend support and code generation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,5 @@
 * Tim Perkins
 * Randy Sybel
 * Matt Walter
+* Jonas Kahler
+* Gustaf Johansson

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,12 @@ endif()
 # .NET
 # TODO
 
+# Go
+lcm_option(
+  LCM_ENABLE_GO
+  "Build Go utilities, bindings is source distributed"
+  GO_FOUND Go)
+
 option(LCM_ENABLE_TESTS "Build unit tests" ON)
 if(LCM_ENABLE_TESTS)
   enable_testing()

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ variety of programming languages.
   * C
   * C++
   * C#
+  * Go
   * Java
   * Lua
   * MATLAB

--- a/cmake/FindGo.cmake
+++ b/cmake/FindGo.cmake
@@ -1,0 +1,35 @@
+include(FindPackageHandleStandardArgs)
+
+find_program(
+  GO_EXECUTABLE go PATHS ENV GOROOT GOPATH GOBIN PATH_SUFFIXES bin
+)
+
+if (NOT GO_EXECUTABLE)
+  set(GO_EXECUTABLE "go")
+endif()
+
+execute_process(
+  COMMAND ${GO_EXECUTABLE} version
+  OUTPUT_VARIABLE GO_VERSION_OUTPUT
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if(GO_VERSION_OUTPUT MATCHES "go([0-9]+[.0-9]*)[^ ]* ([^/]+)/(.*)")
+  set(GO_VERSION ${CMAKE_MATCH_1})
+  set(GO_PLATFORM ${CMAKE_MATCH_2})
+  set(GO_ARCH ${CMAKE_MATCH_3})
+elseif(GO_VERSION_OUTPUT MATCHES "go version devel .* ([^/]+)/(.*)")
+  set(GO_VERSION "99-devel")
+  set(GO_PLATFORM ${CMAKE_MATCH_1})
+  set(GO_ARCH ${CMAKE_MATCH_2})
+  message("WARNING: Development version of Go being used, can't determine compatibility.")
+else()
+  message("Unable to parse the Go version string: ${GO_VERSION_OUTPUT}")
+endif()
+
+mark_as_advanced(GO_EXECUTABLE)
+
+find_package_handle_standard_args(Go
+  REQUIRED_VARS GO_EXECUTABLE GO_VERSION GO_PLATFORM GO_ARCH
+  VERSION_VAR GO_VERSION
+)

--- a/docs/content/mainpage.md
+++ b/docs/content/mainpage.md
@@ -54,6 +54,7 @@ case people find them useful.
  - [C](\ref LcmC)
  - [C++](\ref LcmCpp)
  - [C# / .NET](lcm-dotnet/index.html)
+ - [Go](https://godoc.org/github.com/lcm-proj/lcm/lcm-go/lcm)
  - [Java](javadocs/index.html)
  - [Lua](\ref lua_api)
  - [Python](python/index.html)

--- a/docs/content/tutorial-go.md
+++ b/docs/content/tutorial-go.md
@@ -1,0 +1,208 @@
+Go Tutorial {#tut_go}
+====
+\brief Sending and receiving LCM messages using Go
+
+# Introduction {#tut_go_intro}
+
+This tutorial will walk you through the main tasks for exchanging LCM messages
+using the Go LCM library. Throughout this tutorial, we will look at how to:
+
+\li Initialize an LCM instance.
+\li Publish a message.
+\li Subscribe to a channel and receive a message over it.
+
+Like the other tutorials, this one uses the \p example_t message type defined in
+the \ref tut_lcmgen "type definition tutorial", and assumes that you have
+generated the Go bindings by executing for it:
+
+\code
+cd examples/go
+go generate
+\endcode
+
+This should produce a few go files in `exlcm`, we will use the file called
+`exlcm/example_t.go`.
+
+The file contains everything you need to encode and decode data of type
+example_t, which is necessary in order to use LCM.
+
+# Initializing LCM {#tut_go_initialize}
+
+That was not too difficult, right? Time to actually get our hands dirty with
+some actual Go code.
+
+The first thing that you will need to do, is to fetch the actual library. You
+can use `go get` or any other dependency manager of your choice:
+`go get github.com/lcm-proj/lcm/lcm-go/lcm`
+
+After you have successfully executed that, you are able to use and import the
+just fetched library. Make sure that the following code is inside a subdirectory
+of `$GOPATH/src`.
+
+\code
+package main
+
+import "github.com/lcm-proj/lcm/lcm-go/lcm"
+
+func main() {
+    lc, err := lcm.New()
+    if err != nil {
+        panic(err)
+    }
+    defer lc.Destroy()
+}
+\endcode
+
+This will result in a new lcm instance by the name `lc` that is ready for use.
+
+As we are dealing with Go bindings towards the C library, it is quite easy to
+use. Maybe even easier than the C library itself. `lc` contains all the methods
+that you will need to utilize LCM based communication.
+
+Compile and run the code to see, if it works: `go run path/to/subdirectory`
+
+As you can see, we are also using `defer` to destroy the LCM instance just right
+before main is done executing.
+
+# Publishing a message {#tut_go_publish}
+
+Now that you have successfully created an LCM instance in Go, it is time to
+actually send some data to a channel. This is done by sending data down a Golang
+channel that the `Publisher(string)` method of the instance that we just created
+returns.
+
+The passed string is the channel's name that you want to send the data to.
+Alongside the actual Go channel that you can send the data to, another channel
+is returned. This is an error channel that you have to check for any errors that
+could potentially occur.
+
+Finally, make sure that you are actually sending (LCM) encoded data down the
+channel. So where do you get that from? *From the Go bindings that you have
+generated earlier!*
+
+\code
+    // Skipping the code above...
+    // Create a pointer to a new ExampleT object.
+    example := &exlcm.ExampleT{}
+
+    publisher, errs := lc.Publisher("EXAMPLE")
+
+    go func() {
+        defer close(publisher)
+
+        // Let's send that a couple of times
+        for i := 0; i < 100; i++ {            
+            // Encode the data.
+            encEx, err := example.Encode()
+            if err != nil {
+                panic(err)
+            }
+
+            // Send down a channel.
+            publisher <- encEx
+        }
+    }()
+
+FOR_SELECT:
+    for {
+        select {
+            err, ok := <- errs:
+            if !ok {
+                break FOR_SELECT
+            }
+            panic(err)
+        }
+    }
+\endcode
+
+As you can see, it does not require much code to send something through LCM
+using Go. Obviously, in a real-world case, one would need to initialize
+`example` with appropriate values, instead of initializing everything to default
+values.
+
+An important note: as soon as you are done with sending to a channel, you should
+close the corresponding publisher channel, as we are doing in the `defer`
+statement. This is necessary, so that you do not end up in a potential deadlock.
+The errs channel is only closed *after* the publisher one is.
+
+# Receiving LCM Messages {#tut_go_receive}
+
+Receiving messages is just as simple as sending them out. It's just the other
+way around. Needless to say, it is important that the sender and receiver
+"know" about the channel that is used for communication. Therefore, we will
+also use the channel called **EXAMPLE** that we used earlier to send out
+information, as the receiving channel.
+
+In order to receive data, you will need to check for data that comes down a
+Go channel. Usually, deserialize the received data back into a suitable object
+is a reasonable way to do here.
+
+\code
+    // Skipping the code from the initialization part.
+    // Subscribe to the previously used EXAMPLE channel. The subscription Go
+    // channel has a buffer size 5, whenever more messages are pending than the
+    // buffer size they are dropped.
+    if subscription, err := lc.Subscribe("EXAMPLE", 5); if err != nil {
+        panic(err)
+    }
+    // Not explicitly necessary, as Destroy() also unsubscribes to all
+    // subscriptions.
+    defer lc.Unsubscribe(subscription)
+
+FOR:
+    for {
+        select {
+        // Usually you have a timeout to not deadlock.
+        case <-time.After(5 * time.Second):
+            break FOR
+
+        case data, ok := <- subscription.ReceiveChan:
+            if !ok {
+                // That means that the channel was closed.
+                break FOR
+            }
+            fmt.Println("Received information on", channel)
+
+            // Empty example_t
+            exType := &exlcm.ExampleT{}
+
+            // Decode the received data
+            if err := exType.Decode(data); err != nil {
+                panic(err)
+            }
+
+            // Simple print out of the whole object.
+            fmt.Println(exType)
+
+        }
+    }
+\endcode
+
+Done!
+
+As you can see, we are also unsubscribing right before we are done. This is only
+possible because we are timing out (and returning) after five seconds.
+ReceiveChan is only closed whenever one unsubscribes. Therefore:: **be aware of
+potential deadlocks that you could introduce to your application**.
+
+# Conclusion and Important Information {#tu_go_concl}
+
+Obviously, this tutorial outlines just a really simple use-case of LCM in Go.
+Some of the practices used here ought to be avoided in a proper production
+application (such as the use of panic for error handling).
+
+Throughout the tutorial you might have noticed that the original type name which
+was called `example_t` got transferred into something like `ExampleT`. This is
+was an actively chosen design decision. As it is Go best-practice to use
+Camel-Casing, every _ will be removed and the following character will be
+capitalized. Furthermore, the casing describes if a member or function gets
+exported or not in Go: capitalized member/function name = exported function;
+small-cased member/function name = unexported function. Therefore, every type
+gets automatically capitalized by the code generator.
+
+You can find more complete and compilable executables here:
+[listener/main.go](https://github.com/lcm-proj/lcm/blob/master/examples/go/listener/main.go) | [sender/main.go](https://github.com/lcm-proj/lcm/blob/master/examples/go/sender/main.go)
+
+If you need more information about the language itself, you should check out
+[the official Go web pages](https://golang.org/), which are usually of great
+help.

--- a/docs/content/tutorial-lcmgen.md
+++ b/docs/content/tutorial-lcmgen.md
@@ -8,7 +8,7 @@ fields, each with its own type and name.  Some of these fields may be
 structs themselves, or arrays.  LCM supports multiple languages and, types are
 defined in a language-neutral specification that looks very similar to C.
 
-Let's define an example type called <tt>example_t</tt>.  Create 
+Let's define an example type called <tt>example_t</tt>.  Create
 a file called <tt>example_t.lcm</tt> with the following contents.  
 
 \include types/example_t.lcm
@@ -56,6 +56,7 @@ table to generate bindings for the programming language of your choice.
 <tr><td>Python</td><td><tt>lcm-gen -p example_t.lcm</tt></tr>
 <tr><td>C#</td><td><tt>lcm-gen --csharp example_t.lcm</tt></tr>
 <tr><td>MATLAB</td><td>Generate Java code</tr>
+<tr><td>Go</td><td>lcm-gen -g example_t.lcm</td></tr>
 </table>
 
 You can pass additional arguments to <tt>lcm-gen</tt> to adjust its behavior

--- a/docs/content/tutorial.md
+++ b/docs/content/tutorial.md
@@ -14,13 +14,13 @@ Each message is sent on a <em>channel</em>, which is identified by a
 human-readable name. For example, messages containing information about the
 temperature in the hallway might be published on the "HALLWAY_TEMPERATURE"
 channel. By convention, all messages on a channel have the same type.
-  
+
 Any application can publish on any channel, although it is common for
 a single application serves as the sole source of data on a channel. Any
 application can receive data on any channel--- for example, both a thermostat
 application and data logger might subscribe to the "HALLWAY_TEMPERATURE"
 channel.
-  
+
 This tutorial will walk you through the main tasks for exchange messages
 between two applications:
 
@@ -44,6 +44,7 @@ languages, consult the following sections for language-specific tutorials.
  - \ref tut_matlab "Steps 2-4: MATLAB"
  - \ref tut_python "Steps 2-4: Python"
  - \ref tut_lua "Steps 2-4: Lua"
+ - \ref tut_go "Steps 2-4: Go"
 
 Note that C and C++ are considered to be separate programming languages.  It is
 possible to use the C bindings from C++, but there are also LCM bindings
@@ -75,3 +76,4 @@ Java     | [MySubscriber.java](https://github.com/lcm-proj/lcm/blob/master/examp
 Lua      | [listener.lua](https://github.com/lcm-proj/lcm/blob/master/examples/lua/listener.lua) | [send-message.lua](https://github.com/lcm-proj/lcm/blob/master/examples/lua/send-message.lua)
 MATLAB   | [listener.m](https://github.com/lcm-proj/lcm/blob/master/examples/matlab/listener.m) | [sendmessage.m](https://github.com/lcm-proj/lcm/blob/master/examples/matlab/sendmessage.m)
 Python   | [listener.py](https://github.com/lcm-proj/lcm/blob/master/examples/python/listener.py) | [send-message.py](https://github.com/lcm-proj/lcm/blob/master/examples/python/send-message.py)
+Go       | [listener/main.go](https://github.com/lcm-proj/lcm/blob/master/examples/go/listener/main.go) | [sender/main.go](https://github.com/lcm-proj/lcm/blob/master/examples/go/sender/main.go)

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -10,3 +10,4 @@
 /c/exlcm_example_t.h
 /c/listener-async
 /java/temperature_demo_java/lcmtypes/
+!/go/listener/

--- a/examples/go/gen.go
+++ b/examples/go/gen.go
@@ -1,0 +1,10 @@
+package exlcm
+
+// This file generates the example types using go generate which invokes lcm-gen
+// Run using <go generate>
+
+//go:generate lcm-gen -g ../types/exampleconst_t.lcm
+//go:generate lcm-gen -g ../types/example_list_t.lcm
+//go:generate lcm-gen -g ../types/example_t.lcm
+//go:generate lcm-gen -g ../types/multidim_array_t.lcm
+//go:generate lcm-gen -g ../types/node_t.lcm

--- a/examples/go/listener/main.go
+++ b/examples/go/listener/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"../exlcm"
+	golcm "github.com/lcm-proj/lcm/lcm-go/lcm"
+)
+
+func main() {
+	// Create a new LCM instance.
+	lcm, err := golcm.New()
+	if err != nil {
+		panic(err)
+	}
+
+	// Subscripe to the previously used EXAMPLE channel.
+	subscription, err := lcm.Subscribe("EXAMPLE", 5)
+	if err != nil {
+		panic(err)
+	}
+
+FOR_SELECT:
+	for {
+		select {
+		case <-time.After(15 * time.Second):
+			break FOR_SELECT
+
+		case data, ok := <-subscription.ReceiveChan:
+			if !ok {
+				break FOR_SELECT
+			}
+
+			fmt.Println("received information on")
+
+			// Empty example_t
+			exType := &exlcm.ExlcmExampleT{}
+
+			// Decode the received data
+			if err := exType.Decode(data); err != nil {
+				panic(err)
+			}
+
+			// Simple print out of the whole object.
+			fmt.Println(exType)
+		}
+	}
+}

--- a/examples/go/sender/main.go
+++ b/examples/go/sender/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+
+	"../exlcm"
+	golcm "github.com/lcm-proj/lcm/lcm-go/lcm"
+)
+
+func sendData(publisher chan<- []byte) {
+	defer close(publisher)
+
+	// Let's send 100 times some data.
+	for i := 0; i < 100; i++ {
+		example := &exlcm.ExlcmExampleT{
+			Name: fmt.Sprintf("Datapoint %d", i),
+		}
+
+		encData, err := example.Encode()
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Println("sending data no", i)
+		publisher <- encData
+	}
+}
+
+func main() {
+	// Create a new LCM instance.
+	lcm, err := golcm.New()
+	if err != nil {
+		panic(err)
+	}
+	defer lcm.Destroy()
+
+	publisher, errs := lcm.Publisher("EXAMPLE")
+	go sendData(publisher)
+
+FOR_SELECT:
+	for {
+		select {
+		case err, ok := <-errs:
+			if !ok {
+				break FOR_SELECT
+			}
+			panic(err)
+		}
+	}
+}

--- a/lcm-go/README.md
+++ b/lcm-go/README.md
@@ -1,0 +1,27 @@
+# Go-LCM
+
+[![GoDoc](https://godoc.org/github.com/lcm-proj/lcm/lcm-go/lcm?status.svg)](https://godoc.org/github.com/lcm-proj/lcm/lcm-go/lcm)
+[![Go Report Card](https://goreportcard.com/badge/github.com/lcm-proj/lcm/lcm-go/lcm)](https://goreportcard.com/report/github.com/lcm-proj/lcm/lcm-go/lcm)
+
+  Golang extension module allowing access to the Lightweight Communications and
+  Marshaller (LCM) library from Go.
+
+  https://github.com/lcm-proj/lcm
+
+## INSTALLATION
+  - go get github.com/lcm-proj/lcm/lcm-go/lcm
+
+## BUILD REQUIREMENTS:
+  - System with support for Go
+  - System with build support for LCM (see lcm docs)
+
+## AUTHORS:
+
+  - Jonas Kahler <jonas@derkahler.de>
+  - Gustaf Johansson <gustaf@pinon.se>
+
+  - And the [LCM AUTHORS](https://github.com/lcm-proj/lcm/blob/master/AUTHORS)
+
+## LICENSE:
+
+  Same as LCM, [COPYING](https://github.com/lcm-proj/lcm/blob/master/COPYING)

--- a/lcm-go/lcm/lcm.go
+++ b/lcm-go/lcm/lcm.go
@@ -1,0 +1,209 @@
+package lcm
+
+// #cgo LDFLAGS: -llcm
+//
+// #include <stdlib.h>
+// #include <string.h>
+// #include <lcm/lcm.h>
+//
+// extern void goLCMCallbackHandler(void *, int, char *);
+//
+// static void lcm_msg_handler(const lcm_recv_buf_t *buffer,
+//                                   const char *channel, void *userdata) {
+//      (void)userdata;
+//      goLCMCallbackHandler((void *)buffer->data, (int)buffer->data_size,
+//                           (char *)channel);
+// }
+//
+// static lcm_subscription_t * lcm_go_subscribe(lcm_t *lcm,
+//                                              const char *channel) {
+//     return lcm_subscribe(lcm, channel, &lcm_msg_handler, NULL);
+// }
+import "C"
+
+import (
+	"errors"
+	"unsafe"
+)
+
+// Subscription is a wrapper type for a subscription to an LCM channel.
+type Subscription struct {
+	ReceiveChan chan []byte // Channel on which messages to the subscribed channel are forwarded
+	Drops       int         // The number of dropped packages so far
+	channel     string
+	cPtr        *C.lcm_subscription_t
+}
+
+var subscriptions map[LCM]map[string]Subscription
+
+func init() {
+	subscriptions = make(map[LCM]map[string]Subscription)
+}
+
+// Channel returns the LCM channel name of the subscription.
+func (subscription Subscription) Channel() string {
+	return subscription.channel
+}
+
+// LCM is a wrapper type for all things LCM.
+type LCM struct {
+	Errors chan error // Errors when handling incoming LCM messages
+	closed bool
+	cPtr   *C.lcm_t
+}
+
+// New returns a new LCM instance. In case of a failure, an error is returned.
+func New() (LCM, error) {
+	cPtr := C.lcm_create(nil)
+	if cPtr == nil {
+		return LCM{}, errors.New("could not create c pointer to lcm_t")
+	}
+
+	lcm := LCM{
+		Errors: make(chan error),
+		cPtr:   cPtr,
+	}
+
+	go lcm.handle()
+
+	subscriptions[lcm] = make(map[string]Subscription)
+
+	return lcm, nil
+}
+
+// Subscribe subscribes to an LCM channel with the given buffer size.
+// Whenever an incoming message is handled by LCM the encoded data is sent in
+// the form of a []byte down the ReceiveChan member of the returned
+// Subscription.
+func (lcm LCM) Subscribe(channel string, size int) (Subscription, error) {
+	cChannel := C.CString(channel)
+	defer C.free(unsafe.Pointer(cChannel))
+
+	cPtr := C.lcm_go_subscribe(lcm.cPtr, cChannel)
+	if cPtr == nil {
+		return Subscription{}, errors.New("could not subscribe to channel " +
+			channel)
+	}
+
+	subscription := Subscription{
+		ReceiveChan: make(chan []byte, size),
+		channel:     channel,
+		cPtr:        cPtr,
+	}
+	subscriptions[lcm][channel] = subscription
+
+	return subscription, nil
+}
+
+// Unsubscribe removes an Subscription from an LCM object.
+func (lcm LCM) Unsubscribe(subscription Subscription) error {
+	status := C.lcm_unsubscribe(lcm.cPtr, subscription.cPtr)
+	if status != 0 {
+		return errors.New("could not unsubsribe from " + subscription.channel)
+	}
+
+	close(subscription.ReceiveChan)
+
+	if _, ok := subscriptions[lcm][subscription.channel]; ok {
+		delete(subscriptions[lcm], subscription.channel)
+	}
+
+	return nil
+}
+
+// UnsubscribeAll removes all Subscriptions from an LCM object.
+func (lcm LCM) UnsubscribeAll() error {
+	for _, sub := range subscriptions[lcm] {
+		if err := lcm.Unsubscribe(sub); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Publisher returns a channel that the caller can send data to, which is
+// sent out to the channel passed as the argument. Furthermoe, an error channel
+// is returned that allows the caller to listen for and handle any errors.
+func (lcm LCM) Publisher(channel string) (chan<- []byte, <-chan error) {
+	publisher := make(chan []byte)
+	errs := make(chan error)
+
+	go func() {
+		defer close(errs)
+	FOR_SELECT:
+		for {
+			select {
+			case data, ok := <-publisher:
+				if !ok {
+					break FOR_SELECT
+				}
+
+				dataSize := C.size_t(len(data))
+
+				buffer := C.malloc(dataSize)
+				if buffer == nil {
+					errs <- errors.New("could not malloc memory for lcm message")
+				}
+				defer C.free(buffer)
+				C.memcpy(buffer, unsafe.Pointer(&data[0]), dataSize)
+
+				cChannel := C.CString(channel)
+				defer C.free(unsafe.Pointer(cChannel))
+
+				status := C.lcm_publish(lcm.cPtr, cChannel, buffer,
+					C.uint(dataSize))
+				if status == -1 {
+					errs <- errors.New("could not publish lcm message")
+				}
+			}
+		}
+	}()
+
+	return publisher, errs
+}
+
+// Destroy destroys an LCM object, so that it can be picked up by the garbage
+// collector. This method also unsubscribes to all channels that lcm previously
+// subscribed to.
+func (lcm LCM) Destroy() error {
+	lcm.closed = true
+
+	C.lcm_destroy(lcm.cPtr)
+
+	if err := lcm.UnsubscribeAll(); err != nil {
+		return err
+	}
+
+	delete(subscriptions, lcm)
+
+	return nil
+}
+
+func (lcm LCM) handle() {
+	defer close(lcm.Errors)
+
+	for !lcm.closed {
+		if status := C.lcm_handle(lcm.cPtr); status != 0 {
+			lcm.Errors <- errors.New("could not call lcm_handle")
+		}
+	}
+}
+
+//export goLCMCallbackHandler
+func goLCMCallbackHandler(data unsafe.Pointer, size C.int, name *C.char) {
+	channel := C.GoString(name)
+	buffer := C.GoBytes(data, size)
+
+	for _, subs := range subscriptions {
+		if sub, ok := subs[channel]; ok {
+			select {
+			case sub.ReceiveChan <- buffer:
+				break
+			default:
+				sub.Drops++
+			}
+		} else {
+			panic("LCM gave us a msg on a non-existing channel")
+		}
+	}
+}

--- a/lcm-go/lcm/lcm_test.go
+++ b/lcm-go/lcm/lcm_test.go
@@ -1,0 +1,77 @@
+package lcm
+
+import (
+	"testing"
+	"time"
+)
+
+const (
+	// The amount of messages we want to exchange here.
+	messageGoal = 10000
+	// Max time we want to wait for executing to be done.
+	timeout = 1 * time.Second
+)
+
+var (
+	// Some sample data.
+	someBytes = []byte("abcdefghijklmnopqrstuvwxyz")
+)
+
+func TestLCM(t *testing.T) {
+	// The amount of messages that we received.
+	messages := 1
+
+	// New LCM
+	lcm, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lcm.Destroy()
+
+	// Subscribe to "TEST" LCM channel using Go
+	subscription, err := lcm.Subscribe("TEST", messageGoal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err = lcm.Unsubscribe(subscription); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// Send messageGoal messages
+	go func() {
+		t.Log("sending", "amount", messageGoal)
+		publishChan, _ := lcm.Publisher("TEST")
+		for i := 1; i < messageGoal; i++ {
+			publishChan <- someBytes
+		}
+		close(publishChan)
+	}()
+
+FOR_SELECT:
+	for {
+		select {
+		case <-time.After(timeout):
+			t.Log("timed out after", timeout)
+			break FOR_SELECT
+		case _, ok := <-subscription.ReceiveChan:
+			if !ok {
+				break FOR_SELECT
+			}
+			messages++
+		}
+
+		// Stop, if we are already there...
+		if messages == messageGoal {
+			break
+		}
+	}
+
+	// Did we receive messageGoal messages?
+	if messages != messageGoal {
+		t.Fatalf("Expected %d but received %d messages.", messageGoal, messages)
+	}
+
+	t.Log("received", "amount", messages)
+}

--- a/lcmgen/CMakeLists.txt
+++ b/lcmgen/CMakeLists.txt
@@ -2,6 +2,7 @@ set(lcm-gen_sources
   emit_c.c
   emit_csharp.c
   emit_cpp.c
+  emit_go.c
   emit_java.c
   emit_lua.c
   emit_python.c

--- a/lcmgen/emit_go.c
+++ b/lcmgen/emit_go.c
@@ -1,0 +1,1719 @@
+#include <assert.h>
+#include <ctype.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#ifdef WIN32
+#define __STDC_FORMAT_MACROS // Enable integer types
+#endif
+
+#include "lcmgen.h"
+
+#define TABS "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t"
+#define emit_start(n, ...) \
+    do { fprintf(f, "%.*s", n, TABS); fprintf(f, __VA_ARGS__); } while (0)
+#define emit_continue(...) \
+    do { fprintf(f, __VA_ARGS__); } while (0)
+#define emit_end(...) \
+    do { fprintf(f, __VA_ARGS__); fprintf(f, "\n"); } while (0)
+#define emit(n, ...) \
+    do { fprintf(f, "%.*s", n, TABS); fprintf(f, __VA_ARGS__); \
+        fprintf(f, "\n"); } while (0)
+#define emit_nl() \
+    do { fprintf(f, "\n"); } while (0)
+
+/*
+ * Simple function that takes a string like this.is.a.string and turns it into
+ * this_is_a_string.
+ *
+ * CAUTION: memory has to be freed manually.
+ */
+static char *dots_to_underscores(const char *const s)
+{
+    char *p = strdup(s);
+
+    for (char *t = p; *t != 0; t++)
+        if (*t == '.')
+            *t = '_';
+
+    return p;
+}
+
+/*
+ * Simple function that takes a string like this.is.a.string and turns it into
+ * this/is/a/string.
+ *
+ * CAUTION: memory has to be freed manually.
+ */
+static char *dots_to_path(const char *const s)
+{
+    char *p = strdup(s);
+
+    for (char *t = p; *t != 0; t++)
+        if (*t == '.')
+            *t = G_DIR_SEPARATOR;
+
+    return p;
+}
+
+/*
+ * Simple function that takes a string like this.is.a.string and turns it into
+ * string.
+ *
+ * CAUTION: memory has to be freed manually.
+ */
+static char *strip_dots(const char *const s)
+{
+    char *p = (char *)s;
+
+    for (char *t = p; *t != 0; t++)
+        if (*t == '.')
+            p = t + 1;
+
+    return strdup(p);
+}
+
+/*
+ * Simple function that takes a string like this_is_a_string and turns it into
+ * This_is_a_string.
+ *
+ * CAUTION: memory has to be freed manually.
+ */
+static char *first_to_upper(const char *const str)
+{
+    char *s = strdup(str);
+    s[0] = toupper(s[0]);
+    return s;
+}
+
+/*
+ * Simple function that takes a string like this_is.a_string and turns it into
+ * ThisIsAString. To follow Golang naming conventions.
+ *
+ * CAUTION: memory has to be freed manually.
+ */
+static char *go_name(const char *const str)
+{
+    char *ret = malloc(strlen(str)+1);
+
+    char *t = ret;
+    int upper = FALSE;
+    for (const char *p = str; *p != 0; p++) {
+        switch (*p) {
+            case '.':
+                upper = TRUE;
+                break;
+            case '_':
+                upper = TRUE;
+                break;
+            default:
+                if (upper) {
+                    *t = toupper(*p);
+                    upper = FALSE;
+                } else {
+                    *t = *p;
+                }
+                t++;
+                break;
+        }
+    }
+    *t = '\0';
+
+    return ret;
+}
+
+/*
+ * Returns the Golang corresponding type of an LCM type.
+ */
+static const char *const map_builtintype_name(const char *const type)
+{
+    if (strcmp(type, "boolean") == 0) return "bool";
+    if (strcmp(type, "byte") == 0) return "byte";
+    if (strcmp(type, "int8_t") == 0) return "int8";
+    if (strcmp(type, "int16_t") == 0) return "int16";
+    if (strcmp(type, "int32_t") == 0) return "int32";
+    if (strcmp(type, "int64_t") == 0) return "int64";
+    if (strcmp(type, "float") == 0) return "float32";
+    if (strcmp(type, "double") == 0) return "float64";
+    if (strcmp(type, "string") == 0) return "string";
+    assert(0);
+    return NULL;
+}
+
+/*
+ * Returns the size of a primitive type (string excluded) in bytes.
+ */
+static int primitive_type_size (const char *const type)
+{
+    if (strcmp(type, "byte") == 0) return 1;
+    if (strcmp(type, "boolean") == 0) return 1;
+    if (strcmp(type, "int8_t") == 0) return 1;
+    if (strcmp(type, "int16_t") == 0) return 2;
+    if (strcmp(type, "int32_t") == 0) return 4;
+    if (strcmp(type, "int64_t") == 0) return 8;
+    if (strcmp(type, "float") == 0) return 4;
+    if (strcmp(type, "double") == 0) return 8;
+    assert (0);
+    return 0;
+}
+
+/*
+ * Returns the index of first member in which name is used as a variable
+ * dimension or members->len if not found.
+ * Starts at given index.
+ */
+unsigned int lcm_find_member_with_named_dimension(lcm_struct_t *ls,
+    const char *const name, unsigned int start)
+{
+
+    for (unsigned int i = start; i < ls->members->len; i++) {
+        lcm_member_t *lm = (lcm_member_t *) g_ptr_array_index(ls->members, i);
+        for (unsigned int j = 0; j < lm->dimensions->len; j++) {
+            lcm_dimension_t *dim = (lcm_dimension_t *) g_ptr_array_index(
+                lm->dimensions, j);
+            if (dim->mode == LCM_VAR) {
+                if (strcmp(name, dim->size) == 0) {
+                    return i;
+                }
+            }
+        }
+    }
+    return ls->members->len;
+}
+
+/*
+ * Locate the lcm_struct_t of given lcm_member_t from lcmgen_t
+ */
+lcm_struct_t *lcm_find_struct(lcmgen_t *lcm, lcm_member_t *lm) {
+    int found = FALSE;
+    lcm_struct_t *ls = NULL;
+
+    for (unsigned int s = 0; s < lcm->structs->len; s++) {
+        ls = (lcm_struct_t *) g_ptr_array_index(lcm->structs, s);
+
+        if (strcmp(lm->type->lctypename, ls->structname->lctypename)
+            == 0) {
+            found = TRUE;
+            break;
+        }
+    }
+
+    if (!found) {
+        return NULL;
+    }
+
+    return ls;
+}
+
+/*
+ * Calculates the fingerprint during code generation.
+ *
+ * Algorithm as described in:
+ *     https://lcm-proj.github.io/type_specification.html
+ *
+ * Returns calculated fingerprint or 0 on error
+ */
+struct __fingerprints
+{
+    const struct __fingerprints *parent;
+    uint64_t fingerprint;
+};
+
+uint64_t __lcm_recursive_fingerprint(lcmgen_t *lcm, lcm_struct_t *ls,
+    const struct __fingerprints *fs)
+{
+    uint64_t fingerprint = ls->hash;
+
+    // Check if we are present in list of hashes, bail out if its the case
+    for (const struct __fingerprints *fs_ = fs; fs_ != NULL; fs_ = fs_->parent) {
+        if (fs_->fingerprint == fingerprint) {
+            return 0;
+        }
+    }
+    struct __fingerprints fp;
+    fp.parent = fs;
+    fp.fingerprint = fingerprint;
+
+    // Compute hash for all members
+    for (unsigned int m = 0; m < ls->members->len; m++) {
+        lcm_member_t *lm = (lcm_member_t *)g_ptr_array_index(ls->members, m);
+
+        if (!lcm_is_primitive_type(lm->type->lctypename)) {
+            lcm_struct_t *ls_ = lcm_find_struct(lcm, lm);
+
+            if (ls_ != NULL) {
+                fingerprint += __lcm_recursive_fingerprint(lcm, ls_, &fp);
+            } else {
+                fprintf(stderr, "Unable to locate fingerprint for member '%s' of '%s'\n",
+                    lm->membername, ls->structname->shortname);
+                return 0;
+            }
+        }
+    }
+
+    return (fingerprint << 1) + (fingerprint >> 63);
+}
+uint64_t lcm_get_fingerprint(lcmgen_t *lcm, lcm_struct_t *ls)
+{
+    return __lcm_recursive_fingerprint(lcm, ls, NULL);
+}
+
+/*
+ * Returns the index of the first dimension named name or dimensions->len if
+ * not found.
+ * Starts at given index.
+ */
+unsigned int lcm_find_named_dimension(FILE *f, lcm_struct_t *ls,
+    lcm_member_t *lm, const char *const name, unsigned int start)
+{
+
+    for (unsigned int i = start; i < lm->dimensions->len; i++) {
+        lcm_dimension_t *dim = (lcm_dimension_t *) g_ptr_array_index(
+            lm->dimensions, i);
+        if (dim->mode == LCM_VAR) {
+            if (strcmp(name, dim->size) == 0) {
+                return i;
+            }
+        }
+    }
+    return lm->dimensions->len;
+}
+
+/*
+ * Takes a typical LCM membername like rapid.test and turns it into something
+ * usable in go.
+ *
+ * CAUTION: memory has to be freed manually.
+ */
+static char *go_membername(lcm_struct_t *ls, const char *const str,
+    int method)
+{
+    char *membername = go_name(str);
+
+    if (lcm_find_member_with_named_dimension(ls, str, 0) >= ls->members->len) {
+        // If not a read-only attribute, uppercase it to export it.
+        membername[0] = toupper(membername[0]);
+    } else if (method) {
+        // If read-only should be method invocation.
+        size_t len = strlen(membername);
+        membername = realloc(membername, len + 3);
+        membername[0] = toupper(membername[0]);
+        membername[len++] = '(';
+        membername[len++] = ')';
+        membername[len++] = '\0';
+    }
+
+    return membername;
+}
+
+/*
+ * More sofisticated than map_builtintype_name(const char *). If it cannot find
+ * a corresponding builtin type, this function assumes that we are dealing with
+ * nested types. By doing so, it uses string manipulation to make the types
+ * work with Golang.
+ *
+ * Fingerprint suffix is added if fingerprint is != 0
+ *
+ * CAUTION: memory has to be freed manually.
+ */
+static char *go_typename(const char *const package,
+    const char *const typepackage, const char *const type,
+    const int64_t fingerprint)
+{
+    if (lcm_is_primitive_type(type)) {
+        return strdup(map_builtintype_name(type));
+    }
+
+    // In case none of the above
+    GString *name = g_string_new("");
+
+    char *gotype = go_name(type);
+
+    // Uppercase first character to make it public
+    gotype[0] = toupper(gotype[0]);
+
+    if (strcmp(package, typepackage) != 0) {
+        char *pkg = strip_dots(typepackage);
+        g_string_printf(name, "%s.%s", pkg, gotype);
+        free(pkg);
+    } else {
+        name = g_string_append(name, gotype);
+    }
+    free(gotype);
+
+    // Add fingerprint suffix
+    if (fingerprint != 0) {
+        g_string_append_printf(name, "_%lx", (uint64_t)fingerprint);
+    }
+
+    char *ret = name->str;
+    g_string_free(name, FALSE);
+    return ret;
+}
+
+/*
+ * Returns the go filename
+ *
+ * CAUTION: memory has to be freed manually.
+ */
+char *go_filename(lcmgen_t *lcm, const char *const dir, const char *const name,
+    uint64_t fingerprint, const char *const suffix)
+{
+    if (fingerprint != 0)
+        return g_strdup_printf("%s/%s_%lx%s.go",
+            dir,
+            name,
+            fingerprint,
+            suffix);
+    else
+        return g_strdup_printf("%s/%s%s.go",
+            dir,
+            name,
+            suffix);
+}
+
+/*
+ * Emits a LCM comment.
+ */
+static void emit_comment(FILE *f, int indent, const char *const comment)
+{
+    if (!comment)
+        return;
+
+    gchar **lines = g_strsplit(comment, "\n", 0);
+    for (int line = 0; lines[line]; line++) {
+        emit(indent, "// %s", lines[line]);
+    }
+
+    g_strfreev(lines);
+}
+
+static void emit_auto_generated_warning(FILE *f)
+{
+    fprintf(f,
+            "// THIS IS AN AUTOMATICALLY GENERATED FILE.  DO NOT MODIFY\n"
+            "// BY HAND!!\n"
+            "//\n"
+            "// Generated by lcm-gen\n\n");
+}
+
+/*
+ * Emits the decoding function for primitive types.
+ */
+static void emit_encode_function(FILE *f, const char *const type,
+    const char *const src, int indent)
+{
+    if (!strcmp(type, "boolean")) {
+        emit(indent, "if p.%s {", src);
+        emit(indent + 1, "data[offset] = 1");
+        emit(indent, "} else {");
+        emit(indent + 1, "data[offset] = 0");
+        emit(indent, "}");
+        emit(indent, "offset += 1");
+    } else if (!strcmp(type, "byte")) {
+        emit(indent, "data[offset] = p.%s", src);
+        emit(indent, "offset += 1");
+    } else if (!strcmp(type, "int8_t")) {
+        emit(indent, "data[offset] = byte(p.%s)", src);
+        emit(indent, "offset += 1");
+    } else if (!strcmp(type, "int16_t")) {
+        emit(indent, "binary.BigEndian.PutUint16(data[offset:],");
+        emit(indent + 1, "uint16(p.%s))", src);
+        emit(indent, "offset += 2");
+    } else if (!strcmp(type, "int32_t")) {
+        emit(indent, "binary.BigEndian.PutUint32(data[offset:],");
+        emit(indent + 1, "uint32(p.%s))", src);
+        emit(indent, "offset += 4");
+    } else if (!strcmp(type, "int64_t")) {
+        emit(indent, "binary.BigEndian.PutUint64(data[offset:],");
+        emit(indent + 1, "uint64(p.%s))", src);
+        emit(indent, "offset += 8");
+    } else if (!strcmp(type, "float")) {
+        emit(indent, "binary.BigEndian.PutUint32(data[offset:],");
+        emit(indent + 1, "math.Float32bits(p.%s))", src);
+        emit(indent, "offset += 4");
+    } else if (!strcmp(type, "double")) {
+        emit(indent, "binary.BigEndian.PutUint64(data[offset:],");
+        emit(indent + 1, "math.Float64bits(p.%s))", src);
+        emit(indent, "offset += 8");
+    } else if (!strcmp(type, "string")) {
+        emit(indent, "{");
+        emit(indent + 1, "bstr := []byte(p.%s)", src);
+        emit(indent + 1, "binary.BigEndian.PutUint32(data[offset:],");
+        emit(indent + 2, "uint32(len(bstr))+1)");
+        emit(indent + 1, "offset += 4");
+        emit(indent + 1, "offset += copy(data[offset:], bstr)");
+        emit(indent + 1, "data[offset] = 0");
+        emit(indent + 1, "offset += 1");
+        emit(indent, "}");
+    } else {
+        assert(0);
+    }
+}
+
+/*
+ * Emits the encoding function for primitive types.
+ */
+static void emit_decode_function(FILE *f, const char *const type,
+    const char *const dst, int indent)
+{
+    if (!strcmp(type, "boolean")) {
+        emit(indent, "if data[offset] != 0 {");
+        emit(indent + 1, "p.%s = true", dst);
+        emit(indent, "} else {");
+        emit(indent + 1, "p.%s = false", dst);
+        emit(indent, "}");
+        emit(indent, "offset += 1");
+    } else if (!strcmp(type, "byte")) {
+        emit(indent, "p.%s = data[offset]", dst);
+        emit(indent, "offset += 1");
+    } else if (!strcmp(type, "int8_t")) {
+        emit(indent, "p.%s = int8(data[offset])", dst);
+        emit(indent, "offset += 1");
+    } else if (!strcmp(type, "int16_t")) {
+        emit(indent, "p.%s = int16(binary.BigEndian.Uint16(data[offset:]))",
+            dst);
+        emit(indent, "offset += 2");
+    } else if (!strcmp(type, "int32_t")) {
+        emit(indent, "p.%s = int32(binary.BigEndian.Uint32(data[offset:]))",
+            dst);
+        emit(indent, "offset += 4");
+    } else if (!strcmp(type, "int64_t")) {
+        emit(indent, "p.%s = int64(binary.BigEndian.Uint64(data[offset:]))",
+            dst);
+        emit(indent, "offset += 8");
+    } else if (!strcmp(type, "float")) {
+        emit(indent, "p.%s = math.Float32frombits(binary.BigEndian.Uint32("
+            "data[offset:]))", dst);
+        emit(indent, "offset += 4");
+    } else if (!strcmp(type, "double")) {
+        emit(indent, "p.%s = math.Float64frombits(binary.BigEndian.Uint64("
+            "data[offset:]))", dst);
+        emit(indent, "offset += 8");
+    } else if (!strcmp(type, "string")) {
+        emit(indent, "{");
+        emit(indent + 1, "length := int(binary.BigEndian.Uint32("
+            "data[offset:]))");
+        emit(indent + 1, "offset += 4");
+        emit(indent + 1, "if length < 1 {");
+        emit(indent + 2, "return fmt.Errorf(\"Decoded string length is "
+            "negative\")");
+        emit(indent + 1, "}");
+        emit(indent + 1, "p.%s = string(data[offset : offset+length-1])", dst);
+        emit(indent + 1, "offset += length");
+        emit(indent, "}");
+    }
+}
+
+/*
+ * In order to fill slices, they have to be made first. This function emits
+ * the necessary Go code when called. As more than one slice has to be created
+ * when they are nested, this function takes start_dim as an argument.
+ */
+static void emit_go_slice_make(FILE *f, int indent, const char *const package,
+    lcm_member_t *lm, unsigned int start_dim, const char *const name,
+    const char *const size, const int64_t fingerprint)
+{
+
+    emit_start(indent, "p.%s = make(", name);
+
+    for (unsigned int i = start_dim; i < lm->dimensions->len; i++) {
+        lcm_dimension_t *dim =
+            (lcm_dimension_t*)g_ptr_array_index(lm->dimensions, i);
+
+        if (dim->mode == LCM_VAR) {
+            emit_continue("[]");
+        } else {
+            emit_continue("[%s]", dim->size);
+        }
+    }
+
+    char *type = go_typename(package, lm->type->package,
+        lm->type->lctypename, fingerprint);
+    emit_end("%s, p.%s)", type, size);
+    free(type);
+}
+
+/*
+ * Function to emit (nested) for loop(s), as this has to happen quite often in
+ * case of multi-dimensional arrays.
+ */
+static unsigned int emit_go_array_loops(FILE *f, lcmgen_t *lcm,
+    lcm_struct_t *ls, lcm_member_t *lm, GString *arraystr, int slice_emit,
+    unsigned int end, const uint64_t fingerprint)
+{
+    unsigned int n;
+    GString *slicestr = g_string_new(NULL);
+
+    for (n = 0; n < end; n++) {
+        lcm_dimension_t *dim =
+            (lcm_dimension_t*)g_ptr_array_index(lm->dimensions, n);
+
+        if (slice_emit)
+            g_string_assign(slicestr, arraystr->str);
+
+        g_string_append_printf(arraystr, "[i%d]", n);
+
+        if (dim->mode == LCM_VAR) {
+            char *size = go_membername(ls, dim->size, FALSE);
+            const char *type = map_builtintype_name(
+                lcm_find_member(ls, dim->size)->type->lctypename);
+
+            if (slice_emit)
+                emit_go_slice_make(f, n + 1, ls->structname->package, lm, n,
+                    slicestr->str, size, fingerprint);
+
+            emit(1 + n, "for i%d := %s(0); i%d < p.%s; i%d++ {",
+                n, type, n, size, n);
+
+            free(size);
+        } else {
+            emit(1 + n, "for i%d := 0; i%d < %s; i%d++ {", n, n, dim->size, n);
+        }
+    }
+
+    g_string_free(slicestr, TRUE);
+
+    return n;
+}
+
+/*
+ * Ends the loops created with emit_go_array_loops(...).
+ */
+static void emit_go_array_loops_end(FILE *f, unsigned int n)
+{
+    for (; n > 0; n--)
+        emit(n, "}");
+}
+
+/*
+ * Emits the header of the .go file.
+ */
+static void emit_go_header(FILE *f, const char *const gopackage)
+{
+    emit_auto_generated_warning(f);
+    emit(0, "package %s", gopackage);
+    emit_nl();
+}
+
+/*
+ * Emits the import of required packages.
+ */
+static void emit_go_lcm_imports(FILE *f, lcmgen_t *lcm, lcm_struct_t *ls)
+{
+    emit(0, "import (");
+    emit(1, "\"encoding/binary\"");
+    emit(1, "\"fmt\"");
+    emit(1, "\"math\"");
+    emit(1, "\"math/bits\"");
+    for (int i = 0; i < ls->members->len; i++) {
+        lcm_member_t *lm = (lcm_member_t *)g_ptr_array_index(ls->members, i);
+
+        if (lcm_is_primitive_type(lm->type->lctypename))
+                continue;
+
+        int imported = FALSE;
+        for (int j = i - 1; j > 0; j--) {
+            lcm_member_t *lm_ =
+                (lcm_member_t *)g_ptr_array_index(ls->members, j);
+
+            if (strcmp(lm->type->package, lm_->type->package) == 0)
+                imported = TRUE;
+        }
+
+        // Import if not already imported and not our own package
+        if (!imported &&
+                strcmp(ls->structname->package, lm->type->package) != 0) {
+            char *package = dots_to_path(lm->type->package);
+            char *prefix = getopt_get_string(lcm->gopt, "go-import-prefix");
+            emit(1, "\"%s%s\"", prefix, package);
+            free(package);
+        }
+    }
+    emit(0, ")");
+    emit_nl();
+
+    // Silence (possible) not used import warning by go compiler
+    emit(0, "const _ = math.Pi");
+    emit(0, "const _ = bits.UintSize");
+    emit_nl();
+}
+
+/*
+ * Emits the fingerprint of this particular struct as a constant.
+ */
+static void emit_go_lcm_fingerprint_const(FILE *f, uint64_t hash,
+    const char *const type)
+{
+    emit(0, "const %s_Fingerprint uint64 = 0x%016"PRIx64, type, hash);
+    emit_nl();
+}
+
+/*
+ * Emits the fingerprint function or constant if pre-calculated.
+ */
+static void emit_continue_go_fingerprint_string(FILE *f, lcmgen_t *lcm,
+    const char *const type)
+{
+    emit_continue("%s_Fingerprint", type);
+    if (!getopt_get_bool(lcm->gopt, "go-fingerprint")) {
+        emit_continue("()");
+    }
+}
+
+/*
+ * Emits the const defintions.
+ */
+static void emit_go_lcm_const_definitions(FILE *f, lcmgen_t *lcm,
+    lcm_struct_t *ls, const char *const gotype, const uint64_t fingerprint)
+{
+    if (!ls->constants->len) {
+        return;
+    }
+
+    unsigned int mlen = 0, tlen = 0;
+    for (unsigned int i = 0; i < ls->constants->len; i++) {
+        lcm_constant_t *lc =
+            (lcm_constant_t *)g_ptr_array_index(ls->constants, i);
+
+        char *constname = go_membername(ls, lc->membername, FALSE);
+        // Constants can only be in our own package, use "" to skip package
+        // prefix
+        char *consttype = go_typename("", "", lc->lctypename, fingerprint);
+
+        if (strlen(constname) > mlen)
+            mlen = strlen(constname);
+
+        if (strlen(consttype) > tlen)
+            tlen = strlen(consttype);
+
+        free(consttype);
+        free(constname);
+    }
+
+    emit(0, "// LCM constants");
+    emit(0, "const (");
+    for (unsigned int i = 0; i < ls->constants->len; i++) {
+        lcm_constant_t *lc =
+            (lcm_constant_t *)g_ptr_array_index(ls->constants, i);
+
+        emit_comment(f, 1, lc->comment);
+
+        char *constname = go_membername(ls, lc->membername, FALSE);
+        // Constants can only be in our own package, use "" to skip package
+        // prefix
+        char *consttype = go_typename("", "", lc->lctypename, fingerprint);
+        char *structtype = go_typename("", "", ls->structname->lctypename,
+            fingerprint);
+
+        int mspaces = mlen - strlen(constname) + 1;
+        int tspaces = tlen - strlen(consttype) + 1;
+        // Always prepend with typename otherwise we might have collisions
+        // with other types constants
+
+        emit(1, "%s_%s%*s%s%*s= %s", structtype, constname, mspaces, "",
+            consttype, tspaces, "", lc->val_str);
+
+        free(structtype);
+        free(consttype);
+        free(constname);
+    }
+    emit(0, ")");
+    emit_nl();
+}
+
+/*
+ * Emits the struct's defintion.
+ */
+static int emit_go_lcm_struct_definition(FILE *f, lcmgen_t *lcm,
+    lcm_struct_t *ls, const char *const gotype, const uint64_t fingerprint)
+{
+    unsigned int max_member_len = 0;
+    unsigned int max_type_len = 0;
+
+    for (unsigned int i = 0; i < ls->members->len; i++) {
+        lcm_member_t *lm = (lcm_member_t *)g_ptr_array_index(ls->members, i);
+
+        char *membername = go_membername(ls, lm->membername, FALSE);
+        if (strlen(membername) > max_member_len)
+            max_member_len = strlen(membername);
+        free(membername);
+
+        char *membertype;
+        if (lcm_is_primitive_type(lm->type->lctypename)) {
+            membertype = go_typename("", "", lm->type->lctypename, 0);
+        } else {
+            uint64_t lm_fingerprint = 0;
+            if (fingerprint != 0) {
+                lcm_struct_t *ls_lm = lcm_find_struct(lcm, lm);
+                if (ls_lm == NULL) {
+                    fprintf(stderr, "Unable to locate %s\n", lm->membername);
+                    return -1;
+                }
+                lm_fingerprint = lcm_get_fingerprint(lcm, ls_lm);
+            }
+
+            membertype = go_typename(ls->structname->package,
+                lm->type->package, lm->type->lctypename,
+                lm_fingerprint);
+        }
+
+        GString *arraystr = g_string_new(NULL);
+        for (unsigned int d = 0; d < lm->dimensions->len; d++) {
+            lcm_dimension_t *dim =
+                (lcm_dimension_t *)g_ptr_array_index(lm->dimensions, d);
+            if (dim->mode == LCM_CONST) {
+                g_string_append_printf(arraystr, "[%s]", dim->size);
+            } else {
+                g_string_append(arraystr, "[]");
+            }
+        }
+
+        int membertype_len = strlen(membertype) + arraystr->len;
+        if (membertype_len > max_type_len)
+            max_type_len = membertype_len;
+        free(membertype);
+        g_string_free(arraystr, TRUE);
+    }
+
+    emit_comment(f, 0, ls->comment);
+    emit(0, "type %s struct {", gotype);
+
+    for (unsigned int i = 0; i < ls->members->len; i++) {
+        lcm_member_t *lm = (lcm_member_t *)g_ptr_array_index(ls->members, i);
+
+        emit_comment(f, 1, lm->comment);
+
+        char *membername = go_membername(ls, lm->membername, FALSE);
+        char *membertype = NULL;
+
+        if (lcm_is_primitive_type(lm->type->lctypename)) {
+            membertype = go_typename("", "", lm->type->lctypename, 0);
+        } else {
+            uint64_t member_fp = 0;
+            if (fingerprint != 0) {
+                lcm_struct_t *ls_lm = lcm_find_struct(lcm, lm);
+                if (ls_lm == NULL) {
+                    fprintf(stderr, "Unable to locate %s\n", lm->membername);
+                    return -1;
+                }
+
+                member_fp = lcm_get_fingerprint(lcm, ls_lm);
+            }
+            membertype = go_typename(ls->structname->package,
+                lm->type->package, lm->type->lctypename,
+                member_fp);
+        }
+
+        GString *arraystr = g_string_new(NULL);
+        for (unsigned int d = 0; d < lm->dimensions->len; d++) {
+            lcm_dimension_t *dim =
+                (lcm_dimension_t *)g_ptr_array_index(lm->dimensions, d);
+            if (dim->mode == LCM_CONST) {
+                g_string_append_printf(arraystr, "[%s]", dim->size);
+            } else {
+                g_string_append(arraystr, "[]");
+            }
+        }
+
+        GString *gotag = g_string_new(lm->membername);
+        char *gotag_name = getopt_get_string(lcm->gopt, "go-tag-name");
+
+        if (strlen(gotag_name) > 0) {
+            g_string_printf(gotag, "%s:\"%s\"", gotag_name, lm->membername);
+        }
+
+        int type_spaces = max_member_len - strlen(membername) + 1;
+        int tag_spaces = max_type_len - strlen(membertype) - arraystr->len + 1;
+        emit(1, "%s%*s%s%s%*s`%s`", membername, type_spaces, "", arraystr->str,
+            membertype, tag_spaces, "", gotag->str);
+
+        free(membername);
+        free(membertype);
+        g_string_free(arraystr, TRUE);
+        g_string_free(gotag, TRUE);
+    }
+
+    emit(0, "}");
+    emit_nl();
+
+    return 0;
+}
+
+/*
+ * This function emits code that will create an exact copy of the struct.
+ */
+static void emit_go_lcm_deep_copy(FILE *f, lcmgen_t *lcm, lcm_struct_t *ls,
+    const char *const gotype, const uint64_t fingerprint)
+{
+    emit(0, "// Copy creates a deep copy");
+    emit(0, "// TODO: fix the fugly x and p names...");
+    emit(0, "func (x *%s) Copy() (p %s) {", gotype, gotype);
+
+    for (unsigned int m = 0; m < ls->members->len; m++) {
+        lcm_member_t *lm = (lcm_member_t *)g_ptr_array_index(ls->members, m);
+
+        char *membername = go_membername(ls, lm->membername, FALSE);
+
+        if (lcm_is_primitive_type(lm->type->lctypename)) {
+
+            if (!lm->dimensions->len) {
+                emit(1, "p.%s = x.%s", membername, membername);
+            } else {
+                GString *arraystr = g_string_new(membername);
+                unsigned int n = emit_go_array_loops(f, lcm, ls, lm, arraystr,
+                    TRUE, lm->dimensions->len, fingerprint);
+                emit(n + 1, "p.%s = x.%s", arraystr->str, arraystr->str);
+                emit_go_array_loops_end(f, n);
+                g_string_free(arraystr, TRUE);
+            }
+        } else {
+            if (!lm->dimensions->len) {
+                emit(1, "p.%s = x.%s.Copy()", membername, membername);
+            } else {
+                GString *arraystr = g_string_new(membername);
+                unsigned int n = emit_go_array_loops(f, lcm, ls, lm, arraystr,
+                    TRUE, lm->dimensions->len, fingerprint);
+                emit(n + 1, "p.%s = x.%s.Copy()", arraystr->str, arraystr->str);
+                emit_go_array_loops_end(f, n);
+                g_string_free(arraystr, TRUE);
+            }
+        }
+
+        emit_nl();
+        free(membername);
+    }
+
+    emit(1, "return");
+    emit(0, "}");
+    emit_nl();
+}
+
+/*
+ * Emits the main decode function.
+ */
+static void emit_go_lcm_encode(FILE *f, lcmgen_t *lcm, lcm_struct_t *ls,
+    const char *const gotype)
+{
+    emit(0, "// Encode encodes a message (fingerprint & data) into binary "
+        "form");
+    emit(0, "//");
+    emit(0, "// returns Encoded data or error");
+    emit(0, "func (p *%s) Encode() (data []byte, err error) {", gotype);
+    emit(1, "var size int");
+    emit(1, "if size, err = p.Size(); err != nil {");
+    emit(2, "return");
+    emit(1, "}");
+    emit_nl();
+    emit(1, "data = make([]byte, 8+size)");
+    emit_start(1, "binary.BigEndian.PutUint64(data, ");
+    emit_continue_go_fingerprint_string(f, lcm, gotype);
+    emit_end(")");
+    emit_nl();
+    emit(1, "var d []byte");
+    emit(1, "if d, err = p.MarshalBinary(); err != nil {");
+    emit(2, "return");
+    emit(1, "}");
+    emit_nl();
+    emit(1, "if copied := copy(data[8:], d); copied != size {");
+    emit(2, "return []byte{},");
+    emit(3, "fmt.Errorf(\"Encoding error, buffer not filled (%%v != %%v)\", "
+        "copied, size)");
+    emit(1, "}");
+    emit(1, "return");
+    emit(0, "}");
+    emit_nl();
+}
+
+/*
+ * Emits getters for read-only struct members. That is all who are used as the
+ * size definition for LCM dynamic arrays.
+ */
+static void emit_go_lcm_read_only_getters(FILE *f, lcmgen_t *lcm,
+    lcm_struct_t *ls, const char *const gotype, const uint64_t fingerprint)
+{
+
+    for (unsigned int k = 0; k < ls->members->len; k++) {
+        lcm_member_t *lm = (lcm_member_t *)g_ptr_array_index(ls->members, k);
+
+        unsigned int i = lcm_find_member_with_named_dimension(ls,
+            lm->membername, k);
+        if (i >= ls->members->len) {
+            continue;
+        }
+
+        char *methodname = go_membername(ls, lm->membername, TRUE);
+        char *structname = go_membername(ls, lm->membername, FALSE);
+        char *type = go_typename(ls->structname->package,
+            lm->type->package, lm->type->lctypename,
+            fingerprint);
+
+        emit(0, "// %s returns the value of dynamic array size attribute",
+            methodname);
+        emit(0, "// %s.%s.", gotype, lm->membername);
+        emit(0, "// And validates that the size is correct for all fields in "
+            "which it is used.");
+        emit(0, "func (p *%s) %s (%s, error) {", gotype, methodname, type);
+
+        unsigned int iteration = 0;
+
+        for (;
+            i < ls->members->len;
+            i = lcm_find_member_with_named_dimension(ls, lm->membername, i + 1)
+        ) {
+
+            lcm_member_t *lm_ = (lcm_member_t *) g_ptr_array_index(ls->members,
+                i);
+            char *membername = go_membername(ls, lm_->membername, TRUE);
+
+            unsigned int j = lcm_find_named_dimension(f, ls, lm_,
+                lm->membername, 0);
+
+            for (; j < lm_->dimensions->len;
+                j = lcm_find_named_dimension(f, ls, lm_, lm->membername, j + 1)
+            ) {
+
+                GString *arraystr = g_string_new(NULL);
+                unsigned int n = emit_go_array_loops(f, lcm, ls, lm_, arraystr,
+                    FALSE, j, fingerprint);
+
+
+                if (iteration == 0) {
+                    emit(j+1, "// Set value to first dynamic array using this "
+                        "size");
+                    emit(j+1, "// %s%s", membername, arraystr->str);
+                    if (n == 0) {
+                        emit(j+1, "p.%s = %s(len(p.%s%s))", structname,
+                            map_builtintype_name(lm->type->lctypename),
+                            membername, arraystr->str);
+                    } else {
+                        emit(j+2, "p.%s = %s(len(p.%s%s))", structname,
+                            map_builtintype_name(lm->type->lctypename),
+                            membername, arraystr->str);
+                    }
+                }
+                if (iteration == 1 || n != 0) {
+                    emit(j+1, "// Validate size matches all other dynamic "
+                        "arrays");
+                    emit_nl();
+                }
+                if (iteration != 0 || n != 0) {
+                    emit(j+1, "// %s%s", membername, arraystr->str);
+                    emit(j+1, "if int(p.%s) != len(p.%s%s) {", structname,
+                        membername, arraystr->str);
+                    emit(j+2, "return 0, fmt.Errorf(\"Defined dynamic array "
+                        "size not matching actual \"+");
+                    emit(j+3, "\"array size (got %%d expected %%d for %s%s)\",",
+                        membername, arraystr->str);
+                    emit(j+3, "len(p.%s%s), p.%s)", membername, arraystr->str,
+                        structname);
+                    emit(j+1, "}");
+                }
+
+                g_string_free(arraystr, TRUE);
+                emit_go_array_loops_end(f, n);
+                iteration++;
+            }
+
+            emit_nl();
+
+            free(membername);
+        }
+
+        emit(1, "// Return size");
+        emit(1, "return p.%s, nil", structname);
+        emit(0, "}");
+        emit_nl();
+
+        free(type);
+        free(structname);
+        free(methodname);
+    }
+}
+
+/*
+ * Emits validation code for a struct member that is used as the size
+ * definition for a LCM dynamic array, and populates the read-only member with
+ * correct value.
+ */
+static void emit_go_lcm_dynamic_array_check(FILE *f, lcm_struct_t *ls,
+    lcm_member_t *lm)
+{
+    if (lcm_find_member_with_named_dimension(ls, lm->membername, 0)
+        < ls->members->len) {
+        char *methodname = go_membername(ls, lm->membername, TRUE);
+        char *typename = go_membername(ls, lm->membername, FALSE);
+        emit(1, "// Validate and populate p.%s", typename);
+        emit(1, "if _, err = p.%s; err != nil {", methodname);
+        emit(2, "return");
+        emit(1, "}");
+        free(typename);
+        free(methodname);
+    }
+}
+
+/*
+ * Emits Golang code to marshal each of the structs members into a byte slice
+ * that can be send.
+ */
+static void emit_go_lcm_marshal_binary(FILE *f, lcmgen_t *lcm, lcm_struct_t *ls,
+    const char *const gotype, const uint64_t fingerprint)
+{
+    emit(0, "// MarshalBinary implements the BinaryMarshaller interface");
+    emit(0, "func (p *%s) MarshalBinary() (data []byte, err error) {", gotype);
+    if (ls->members->len) {
+        emit(1, "var size int");
+        emit(1, "if size, err = p.Size(); err != nil {");
+        emit(2, "return");
+        emit(1, "}");
+        emit_nl();
+        emit(1, "data = make([]byte, size)");
+        emit(1, "offset := 0");
+        emit_nl();
+    }
+
+    for (unsigned int i = 0; i < ls->members->len; i++) {
+        lcm_member_t *lm = (lcm_member_t *)g_ptr_array_index(ls->members, i);
+
+        emit(1, "// LCM struct name: %s", lm->membername);
+
+        char *membername = go_membername(ls, lm->membername, FALSE);
+
+        if (lcm_is_primitive_type(lm->type->lctypename)) {
+            if (!lm->dimensions->len) {
+                emit_encode_function(f, lm->type->lctypename,
+                    membername, 1);
+            } else {
+                GString *arraystr = g_string_new(membername);
+                unsigned int n = emit_go_array_loops(f, lcm, ls, lm, arraystr,
+                    FALSE, lm->dimensions->len, fingerprint);
+                emit_encode_function(f, lm->type->lctypename,
+                        arraystr->str, 1+n);
+                emit_go_array_loops_end(f, n);
+                g_string_free(arraystr, TRUE);
+            }
+        } else {
+            if (!lm->dimensions->len) {
+                emit(1, "{");
+                emit(2, "var tmp []byte");
+                emit(2, "if tmp, err = p.%s.MarshalBinary(); err != nil {",
+                    membername);
+                emit(3, "return");
+                emit(2, "}");
+                emit(2, "offset += copy(data[offset:], tmp)");
+                emit(1, "}");
+            } else {
+                GString *arraystr = g_string_new(NULL);
+                unsigned int n = emit_go_array_loops(f, lcm, ls, lm, arraystr,
+                    FALSE, lm->dimensions->len, fingerprint);
+                emit(2, "var tmp []byte");
+                emit(2, "if tmp, err = p.%s%s.MarshalBinary(); err != nil {",
+                        membername, arraystr->str);
+                emit(3, "return");
+                emit(2, "}");
+                emit(2, "offset += copy(data[offset:], tmp)");
+                emit_go_array_loops_end(f, n);
+                g_string_free(arraystr, TRUE);
+            }
+        }
+
+        emit_nl();
+        free(membername);
+    }
+
+    emit(1, "return");
+    emit(0, "}");
+    emit_nl();
+}
+
+/*
+ * Emits the main decode function.
+ */
+static void emit_go_lcm_decode(FILE *f, lcmgen_t *lcm, lcm_struct_t *ls,
+    const char *const gotype)
+{
+    emit(0, "// Decode decodes a message (fingerprint & data) from binary "
+        "form");
+    emit(0, "// and verifies that the fingerprint match the expected");
+    emit(0, "//");
+    emit(0, "// param data The buffer containing the encoded message");
+    emit(0, "// returns Error");
+    emit(0, "func (p *%s) Decode(data []byte) (err error) {", gotype);
+    emit(1, "length := len(data)");
+    emit(1, "if length < 8 {");
+    emit(2, "return fmt.Errorf(\"Missing fingerprint in buffer\")");
+    emit(1, "}");
+    emit_nl();
+    emit_start(1, "if fp := binary.BigEndian.Uint64(data[:8]); fp != ");
+    emit_continue_go_fingerprint_string(f, lcm, gotype);
+    emit_end(" {");
+    emit(2, "return fmt.Errorf(\"Fingerprints does not match (got %%x "
+        "expected %%x)\",");
+    emit_start(3, "fp, ");
+    emit_continue_go_fingerprint_string(f, lcm, gotype);
+    emit_end(")");
+    emit(1, "}");
+    emit_nl();
+    emit(1, "if err = p.UnmarshalBinary(data[8:]); err != nil {");
+    emit(2, "return");
+    emit(1, "}");
+    emit_nl();
+    emit(1, "length -= 8");
+    emit(1, "var size int");
+    emit(1, "if size, err = p.Size(); err != nil {");
+    emit(2, "return");
+    emit(1, "}");
+    emit(1, "if length != size {");
+    emit(2, "return fmt.Errorf(\"Missing data in buffer (size missmatch, "
+        "got %%v expected %%v)\",");
+    emit(3, "length, size)");
+    emit(1, "}");
+    emit_nl();
+    emit(1, "return");
+    emit(0, "}");
+    emit_nl();
+}
+
+/*
+ * Emits Golang code to unmarshal data from a byte slice back into the structs
+ * members.
+ */
+static void emit_go_lcm_unmarshal_binary(FILE *f, lcmgen_t *lcm,
+    lcm_struct_t *ls, const char *const gotype, const uint64_t fingerprint)
+{
+    int readVar = 0;
+    emit(0, "// UnmarshalBinary implements the BinaryUnmarshaler interface");
+    emit(0, "func (p *%s) UnmarshalBinary(data []byte) (err error) {", gotype);
+    if (ls->members->len) {
+        emit(1, "offset := 0");
+        emit_nl();
+    }
+
+    for (unsigned int m = 0; m < ls->members->len; m++) {
+        lcm_member_t *lm = (lcm_member_t *) g_ptr_array_index(ls->members, m);
+
+        char *membername = go_membername(ls, lm->membername, FALSE);
+
+        if (lcm_is_primitive_type(lm->type->lctypename)) {
+            if (!lm->dimensions->len) {
+                emit_decode_function(f, lm->type->lctypename, membername, 1);
+            } else {
+                GString *arraystr = g_string_new(membername);
+                unsigned int n = emit_go_array_loops(f, lcm, ls, lm, arraystr,
+                    TRUE, lm->dimensions->len, fingerprint);
+                emit_decode_function(f, lm->type->lctypename, arraystr->str,
+                    1+n);
+                emit_go_array_loops_end(f, n);
+                g_string_free(arraystr, TRUE);
+            }
+        } else {
+            if (!lm->dimensions->len) {
+                emit(1, "if err = p.%s.UnmarshalBinary(data[offset:]); "
+                    "err != nil {", membername);
+                emit(2, "return");
+                emit(1, "}");
+                emit(1, "{");
+                emit(2, "var size int");
+                emit(2, "if size, err = p.%s.Size(); err != nil {", membername);
+                emit(3, "return");
+                emit(2, "}");
+                emit(2, "offset += size");
+                emit(1, "}");
+            } else {
+                GString *arraystr = g_string_new(membername);
+                unsigned int n = emit_go_array_loops(f, lcm, ls, lm, arraystr,
+                    TRUE, lm->dimensions->len, fingerprint);
+                emit(n + 1, "if err = p.%s.UnmarshalBinary(data[offset:]); "
+                    "err != nil {", arraystr->str);
+                emit(n + 2, "return");
+                emit(n + 1, "}");
+                emit(n + 1, "var size int");
+                emit(n + 1, "if size, err = p.%s.Size(); err != nil {",
+                    arraystr->str);
+                emit(n + 2, "return");
+                emit(n + 1, "}");
+                emit(n + 1, "offset += size");
+                emit_go_array_loops_end(f, n);
+                g_string_free(arraystr, TRUE);
+            }
+        }
+
+        emit_nl();
+        free(membername);
+    }
+
+    emit(1, "return");
+    emit(0, "}");
+    emit_nl();
+}
+
+/*
+ * Emits code to calculate the fingerprint in runtime.
+ *
+ * Algorithm as described in:
+ *     https://lcm-proj.github.io/type_specification.html
+ */
+static void emit_go_lcm_fingerprint(FILE *f, lcmgen_t *lcm, lcm_struct_t *ls,
+    const char *const typename, const char *const gotype,
+    const uint64_t fingerprint)
+{
+    emit(0, "// Fingerprint generates the LCM fingerprint value for this "
+        "message");
+    emit(0, "func %s_Fingerprint(path ...uint64) uint64 {", gotype);
+    emit(1, "for _, v := range path {");
+    emit(2, "if v == %s_Fingerprint {", typename);
+    emit(3, "return 0");
+    emit(2, "}");
+    emit(1, "}");
+    emit_nl();
+
+    emit(1, "path = append(path, %s_Fingerprint)", typename);
+    emit_start(1, "return bits.RotateLeft64(%s_Fingerprint", typename);
+
+    for (unsigned int m = 0; m < ls->members->len; m++) {
+        lcm_member_t *lm = (lcm_member_t *)g_ptr_array_index(ls->members, m);
+
+        if (!lcm_is_primitive_type(lm->type->lctypename)) {
+            emit_end("+");
+            char *lm_gotype = go_typename(ls->structname->package,
+                lm->type->package, lm->type->lctypename,
+                fingerprint);
+            emit_start(2, "%s_Fingerprint(path...)", lm_gotype);
+            free(lm_gotype);
+        }
+    }
+
+    emit_end(", 1)");
+    emit(0, "}");
+    emit_nl();
+}
+
+/*
+ * Emits code to calculate the size a string in bytes. This takes into account
+ * that LCM will send 4 bytes prepending the string and one terminating it.
+ */
+static void emit_go_lcm_string_size(FILE *f, int indent,
+    const char *const str_prefix, const char *const str_name,
+    const char *const str_postfix, const char *const rec_val)
+{
+    emit(indent, "%s += 4 // LCM string length", rec_val);
+    emit(indent, "%s += len([]byte(%s%s%s))",rec_val, str_prefix, str_name,
+         str_postfix);
+    emit(indent, "%s += 1 // LCM zero termination", rec_val);
+}
+
+/*
+ * Emits codes to calculate the actual size in bytes when this message is
+ * marshalled.
+ */
+static void emit_go_lcm_size(FILE *f, lcmgen_t *lcm, lcm_struct_t *ls,
+    const char *const gotype, const uint64_t fingerprint)
+{
+    emit(0, "// Size returns the size of this message in bytes");
+    emit(0, "func (p *%s) Size() (size int, err error) {", gotype);
+    emit_nl();
+
+    if (!ls->members->len) {
+        goto ret_size;
+    }
+
+    for (unsigned int m = 0; m < ls->members->len; m++) {
+        lcm_member_t *lm = (lcm_member_t *)g_ptr_array_index(ls->members, m);
+
+        char *membername = go_membername(ls, lm->membername, FALSE);
+
+        if (lcm_is_primitive_type(lm->type->lctypename)) {
+            if (!lm->dimensions->len) {
+                if (strcmp(lm->type->lctypename, "string") == 0) {
+                    emit_go_lcm_string_size(f, 1, "p.", membername, "", "size");
+                } else {
+                    emit_go_lcm_dynamic_array_check(f, ls, lm);
+                    emit(1, "size += %d // p.%s",
+                         primitive_type_size(lm->type->lctypename), membername);
+                }
+            } else {
+                GString *arraystr = g_string_new(NULL);
+                unsigned int n = emit_go_array_loops(f, lcm, ls, lm, arraystr,
+                    FALSE, lm->dimensions->len, fingerprint);
+
+                if (strcmp(lm->type->lctypename, "string") == 0) {
+                    emit_go_lcm_string_size(f, n + 1, "p.", membername,
+                                        arraystr->str, "size");
+                } else {
+                    emit(n + 1, "size += %d // p.%s",
+                         primitive_type_size(lm->type->lctypename), membername);
+                }
+
+                emit_go_array_loops_end(f, n);
+                g_string_free(arraystr, TRUE);
+            }
+        } else {
+            if (!lm->dimensions->len) {
+                emit(1, "{");
+                emit(2, "var tmp int");
+                emit(2, "if tmp, err = p.%s.Size(); err != nil {", membername);
+                emit(3, "return");
+                emit(2, "}");
+                emit(2, "size += tmp");
+                emit(1, "}");
+            } else {
+                GString *arraystr = g_string_new(NULL);
+                unsigned int n = emit_go_array_loops(f, lcm, ls, lm, arraystr,
+                    FALSE, lm->dimensions->len, fingerprint);
+                emit(n + 1, "var tmp int");
+                emit(n + 1, "if tmp, err = p.%s%s.Size(); err != nil {",
+                    membername, arraystr->str);
+                emit(n + 2, "return");
+                emit(n + 1, "}");
+                emit(n + 1, "size += tmp");
+                emit_go_array_loops_end(f, n);
+                g_string_free(arraystr, TRUE);
+            }
+        }
+
+        free(membername);
+
+        emit_nl();
+    }
+
+ret_size:
+    emit(1, "return");
+    emit(0, "}");
+}
+
+int emit_go_lcm(lcmgen_t *lcm, lcm_struct_t *ls, const char *const dir,
+    int64_t fingerprint)
+{
+    int res = 0;
+    char *typename = strip_dots(ls->structname->lctypename);
+    char *gopackage = strip_dots(ls->structname->package);
+    char *gotype = go_typename("", "",
+        ls->structname->lctypename, fingerprint);
+    char *path = go_filename(lcm, dir, typename, fingerprint, "");
+
+    if (!lcm_needs_generation(lcm, ls->lcmfile, path))
+        return 0;
+
+    if (getopt_get_bool(lcm->gopt, "go-no-overwrite")) {
+        if (access(path, F_OK) == 0) {
+            printf("%s exists, skipped\n", path);
+            return 0;
+        } else {
+            if (errno != ENOENT) {
+                perror(path);
+                res = -1;
+                goto ret_free;
+            }
+        }
+    }
+
+    FILE *f = fopen(path, "w");
+    if (f == NULL) {
+        perror(path);
+        res = -1;
+        goto ret_free;
+    }
+
+
+    // Header
+    emit_go_header(f, gopackage);
+
+    // Imports
+    emit_go_lcm_imports(f, lcm, ls);
+
+    // Fingerprint const
+    if (fingerprint == 0) {
+        emit_go_lcm_fingerprint_const(f, ls->hash, typename);
+    } else {
+        emit_go_lcm_fingerprint_const(f, fingerprint, gotype);
+    }
+
+    // Const definitions
+    emit_go_lcm_const_definitions(f, lcm, ls, gotype, fingerprint);
+
+    // Struct definition
+    if (emit_go_lcm_struct_definition(f, lcm, ls, gotype, fingerprint) != 0) {
+        res = -1;
+        goto ret_file;
+    }
+
+    // Functions
+    // Deep copy
+    emit_go_lcm_deep_copy(f, lcm, ls, gotype, fingerprint);
+
+    // Encode
+    emit_go_lcm_encode(f, lcm, ls, gotype);
+
+    // MarshalBinary
+    emit_go_lcm_marshal_binary(f, lcm, ls, gotype, fingerprint);
+
+    // Decode
+    emit_go_lcm_decode(f, lcm, ls, gotype);
+
+    // UnmarshalBinary
+    emit_go_lcm_unmarshal_binary(f, lcm, ls, gotype, fingerprint);
+
+    // Getters for read only fields (all fields used as array sizes)
+    emit_go_lcm_read_only_getters(f, lcm, ls, gotype, fingerprint);
+
+    // Fingerprint
+    if (fingerprint == 0) {
+        emit_go_lcm_fingerprint(f, lcm, ls, typename, gotype, fingerprint);
+    }
+
+    // Size
+    emit_go_lcm_size(f, lcm, ls, gotype, fingerprint);
+
+ret_file:
+    fclose(f);
+
+ret_free:
+    free(typename);
+    free(gopackage);
+    free(gotype);
+    free(path);
+
+    return res;
+}
+
+int emit_go_gopacket(lcmgen_t *lcm, lcm_struct_t *ls, const char *const dir,
+    int64_t fingerprint)
+{
+    char *typename = strip_dots(ls->structname->lctypename);
+    char *gopackage = strip_dots(ls->structname->package);
+    char *gotype = go_typename("", "",
+        ls->structname->lctypename, fingerprint);
+    char *path = go_filename(lcm, dir, typename, fingerprint, "_gopacket");
+
+    if (!lcm_needs_generation(lcm, ls->lcmfile, path))
+        return 0;
+
+    FILE *f = fopen(path, "w");
+    if (f==NULL)
+        return -1;
+
+    // Header
+    emit_go_header(f, gopackage);
+
+    // Imports
+    emit(0, "import (");
+    emit(1, "\"github.com/google/gopacket\"");
+    emit(1, "\"github.com/google/gopacket/layers\"");
+    emit(0, ")");
+    emit_nl();
+
+    // The gopacket LayerClass assigned to us
+    emit(0, "var layerClass%s = gopacket.LayerTypeZero",
+        gotype);
+    emit_nl();
+
+    // Register our decoder
+    emit(0, "func init() {");
+    emit(1, "// Register ourselves as decoders for %s.%s", gopackage, typename);
+    emit(1, "layerClass%s = layers.RegisterLCMLayerType(", gotype);
+    emit(2, "0,");
+    emit(2, "\"%s\",", gotype);
+    emit_start(2, "layers.LCMFingerprint(");
+    emit_continue_go_fingerprint_string(f, lcm, gotype);
+    emit_end("),");
+    emit(2, "gopacket.DecodeFunc(decodeFunc%s))", gotype);
+    emit(0, "}");
+    emit_nl();
+
+    // Implement the gopacket Decoder go interface
+    emit(0,"// decodeFunc%s is the implementation of Decoder (type DecodeFunc)",
+        gotype);
+    emit(0, "func decodeFunc%s(data []byte, pb gopacket.PacketBuilder) error {",
+        gotype);
+    emit(1, "lcm := %s{}", gotype);
+    emit_nl();
+    emit(1, "if err := lcm.DecodeFromBytes(data, pb); err != nil {");
+    emit(2, "return err");
+    emit(1, "}");
+    emit_nl();
+    emit(1, "pb.AddLayer(&lcm)");
+    emit(1, "pb.SetApplicationLayer(&lcm)");
+    emit_nl();
+    emit(1, "return nil // No further call since we have no payload");
+    emit(0, "}");
+    emit_nl();
+
+    // Implement the gopacket DecodingLayer go interface
+    emit(0, "// DecodeFromBytes implements DecodingLayer");
+    emit(0, "func (lcm *%s) DecodeFromBytes(data []byte, "
+            "df gopacket.DecodeFeedback) error {", gotype);
+    emit(1, "return lcm.Decode(data)");
+    emit(0, "}");
+    emit_nl();
+
+    emit(0, "// CanDecode implements DecodingLayer");
+    emit(0, "func (%s) CanDecode() gopacket.LayerClass {", gotype);
+    emit(1, "return layerClass%s", gotype);
+    emit(0, "}");
+    emit_nl();
+
+    emit(0, "// NextLayerType implements DecodingLayer");
+    emit(0, "func (%s) NextLayerType() gopacket.LayerType {", gotype);
+    emit(1, "return gopacket.LayerTypePayload");
+    emit(0, "}");
+    emit_nl();
+
+    // Implement the gopacket Layer go interface
+    emit(0, "// LayerType implements Layer");
+    emit(0, "func (%s) LayerType() gopacket.LayerType {", gotype);
+    emit(1, "return layerClass%s", gotype);
+    emit(0, "}");
+    emit_nl();
+
+    emit(0, "// Payload implements Layer");
+    emit(0, "func (lcm *%s) LayerContents() []byte {", gotype);
+    emit(1, "data, err := lcm.Encode()");
+    emit(1, "if err != nil {");
+    emit(2, "panic(err) // What should we do here!?");
+    emit(1, "}");
+    emit(1, "return data");
+    emit(0, "}");
+    emit_nl();
+
+    emit(0, "// LayerPayload implements Layer");
+    emit(0, "func (%s) LayerPayload() []byte {", gotype);
+    emit(1, "return nil");
+    emit(0, "}");
+    emit_nl();
+
+    // Implement the gopacket ApplicationLayer go interface (embeds Layer)
+    emit(0, "// Payload implements ApplicationLayer");
+    emit(0, "func (%s) Payload() []byte {", gotype);
+    emit(1, "return nil");
+    emit(0, "}");
+    emit_nl();
+
+    free(gopackage);
+    free(gotype);
+    free(path);
+    free(typename);
+
+    fclose(f);
+
+    return 0;
+}
+
+void setup_go_options(getopt_t *gopt)
+{
+    getopt_add_string(gopt, 0, "go-path", ".", "Location for .go files");
+    getopt_add_bool(gopt, 0, "go-mkdir", TRUE,
+        "Create parent directories as needed");
+    getopt_add_string(gopt, 0, "go-tag-name", "",
+        "Give the struct member tag the a name (e.g. json for `json:\"tag\"`)");
+    getopt_add_bool(gopt, 0, "go-strip-dirs", FALSE,
+        "Do not generate directories for Go packages");
+    getopt_add_bool(gopt, 0, "go-fingerprint", FALSE,
+        "Add fingerprint as suffix to filenames and types, fingerprint is "
+        "pre-calculate to const");
+    getopt_add_bool(gopt, 0, "go-no-overwrite", FALSE,
+        "Do not overwrite an existing target file, skip and log");
+    getopt_add_bool(gopt, 0, "go-emit-gopacket", FALSE, "Emit gopacket API");
+    getopt_add_string(gopt, 0, "go-import-prefix", "",
+        "Add this package prefix to all LCM type import statements");
+    getopt_add_string(gopt, 0, "go-default-package", "lcmtypes",
+        "Default Go package if LCM type has no package");
+}
+
+int emit_go(lcmgen_t *lcm)
+{
+    int res = 0;
+
+    GString *gopath = g_string_new(getopt_get_string(lcm->gopt, "go-path"));
+    gopath = g_string_append_c(gopath, '/');
+
+    ////////////////////////////////////////////////////////////
+    // ENUMS
+    // Deprecated and thus not supported
+    if (lcm->enums->len) {
+        fprintf(stderr, "Go generator does not support enums.\n");
+        res = -1;
+        goto ret;
+    }
+
+    if (!strlen(lcm->package)) {
+        fprintf(stderr, "Not yet implemented: go-default-package\n");
+        res = -1;
+        goto ret;
+    }
+
+    if (strcmp(getopt_get_string(lcm->gopt, "package-prefix"), "") != 0) {
+        fprintf(stderr, "Go generator does not support --package-prefix\n");
+        res = -1;
+        goto ret;
+    }
+
+    ////////////////////////////////////////////////////////////
+    // STRUCTS
+    for (unsigned int i = 0; i < lcm->structs->len; i++) {
+
+        GString *dir = g_string_new(gopath->str);
+
+        lcm_struct_t *ls = (lcm_struct_t *) g_ptr_array_index(lcm->structs, i);
+
+        if (!getopt_get_bool(lcm->gopt, "go-strip-dirs")) {
+            char *pkg_path = dots_to_path(ls->structname->package);
+            dir = g_string_append(dir, pkg_path);
+            dir = g_string_append_c(dir, '/');
+            free(pkg_path);
+        }
+
+        // Create path if not existing and requested
+        if (getopt_get_bool(lcm->gopt, "go-mkdir")) {
+            char *dirname = g_path_get_dirname(dir->str);
+            g_mkdir_with_parents(dirname, 0755);
+            g_free(dirname);
+        }
+
+        if (ls->enums->len) {
+            fprintf(stderr, "Go generator does not support enums.\n");
+            return -1;
+        }
+
+        if (ls->structs->len) {
+            fprintf(stderr,
+                "Go generator does not (yet) support embedded structs.\n");
+            return -1;
+        }
+
+        int64_t fingerprint = 0;
+        if (getopt_get_bool(lcm->gopt, "go-fingerprint")) {
+            fingerprint = lcm_get_fingerprint(lcm, ls);
+            if (fingerprint == 0) {
+                fprintf(stderr, "Unable to calculate fingerprint as requested "
+                    "(--go-fingerprint) for '%s'.\n",
+                    ls->structname->shortname);
+                res = -1;
+                goto ret;
+            }
+        }
+
+        if (emit_go_lcm(lcm, ls, dir->str, fingerprint)) {
+            fprintf(stderr, "Emit Go LCM structs failed.\n");
+            res = -1;
+            goto ret;
+        }
+
+        if (getopt_get_bool(lcm->gopt, "go-emit-gopacket") &&
+            emit_go_gopacket(lcm, ls, dir->str, fingerprint)) {
+            fprintf(stderr, "Emit Go gopacket API failed.\n");
+            res = -1;
+            goto ret;
+        }
+
+        g_string_free(dir, TRUE);
+    }
+
+ret:
+    g_string_free(gopath, TRUE);
+
+    return res;
+}

--- a/lcmgen/lcmgen.c
+++ b/lcmgen/lcmgen.c
@@ -611,7 +611,7 @@ int parse_member(lcmgen_t *lcmgen, lcm_struct_t *lr, tokenize_t *t)
                         lcm_member_t *thislm = (lcm_member_t*) g_ptr_array_index(lr->members, i);
                         if (!strcmp(thislm->membername, t->token)) {
                             if (g_ptr_array_size(thislm->dimensions) != 0)
-                                semantic_error(t, "Array dimension '%s' must be not be an array type.", t->token);
+                                semantic_error(t, "Array dimension '%s' must not be an array type.", t->token);
                             if (!lcm_is_array_dimension_type(thislm->type->lctypename))
                                 semantic_error(t, "Array dimension '%s' must be an integer type.", t->token);
                             okay = 1;

--- a/lcmgen/lcmgen.h
+++ b/lcmgen/lcmgen.h
@@ -130,7 +130,7 @@ typedef struct lcm_enum lcm_enum_t;
 struct lcm_enum
 {
     lcm_typename_t *enumname; // name of the enum
-	
+
 	GPtrArray *values;   // legal values for the enum
 	char *lcmfile;      // file/path of function that declared it
 
@@ -163,6 +163,9 @@ struct lcmgen
 
 // Returns 1 if the argument is a built-in type (e.g., "int64_t", "float").
 int lcm_is_primitive_type(const char *t);
+
+// Returns 1 if the argument is an array dimension type (e.g., "int*_t").
+int lcm_is_array_dimension_type(const char *t);
 
 // Returns 1 if the argument is a legal constant type (e.g., "int64_t", "float").
 int lcm_is_legal_const_type(const char *t);

--- a/lcmgen/main.c
+++ b/lcmgen/main.c
@@ -36,6 +36,9 @@ int emit_lua(lcmgen_t *lcm);
 void setup_csharp_options(getopt_t *gopt);
 int emit_csharp(lcmgen_t *lcm);
 
+void setup_go_options(getopt_t *gopt);
+int emit_go(lcmgen_t *lcm);
+
 void setup_cpp_options(getopt_t *gopt);
 int emit_cpp(lcmgen_t *lcm);
 
@@ -78,6 +81,10 @@ int main(int argc, char *argv[])
     getopt_add_spacer(gopt, "**** C#.NET options ****");
     getopt_add_bool  (gopt, 0, "csharp",      0,     "Emit C#.NET code");
     setup_csharp_options(gopt);
+
+    getopt_add_spacer(gopt, "**** Go options ****");
+    getopt_add_bool  (gopt, 'g', "go",      0,     "Emit Go code");
+    setup_go_options(gopt);
 
     if (!getopt_parse(gopt, argc, argv, 1) || getopt_get_bool(gopt,"help")) {
         printf("Usage: %s [options] <input files>\n\n", argv[0]);
@@ -160,6 +167,14 @@ int main(int argc, char *argv[])
         did_something = 1;
         if (emit_csharp(lcm)) {
             printf("An error occurred while emitting C#.NET code.\n");
+            res = -1;
+        }
+    }
+
+    if (getopt_get_bool(gopt, "go")) {
+        did_something = 1;
+        if (emit_go(lcm)) {
+            printf("An error occurred while emitting Go code.\n");
             res = -1;
         }
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,3 +16,7 @@ endif()
 if(LCM_ENABLE_LUA)
   add_subdirectory(lua)
 endif()
+
+if(LCM_ENABLE_GO)
+  add_subdirectory(go)
+endif()

--- a/test/README
+++ b/test/README
@@ -14,7 +14,7 @@ of requests to the server, and checks the replies it receives.
 
 This tests basic message transmission, without any marshalling.
 
-Client publishes a random set of mmessages to the "TEST_ECHO" channel and
+Client publishes a random set of messages to the "TEST_ECHO" channel and
 listens for replies on "TEST_ECHO_REPLY".  The replies should be identical to
 the transmitted messages, and should be received within 1 s of transmission.
 
@@ -57,22 +57,22 @@ follows:
   .orientation[2] = n + 1
   .orientation[3] = n + 1
   .num_ranges     = n + 1
-  .ranges[i]      = i         (i = 0 ... n-1)
+  .ranges[i]      = i         (i = 0 ... n)
   .name           = <string representation of n+1>
   .enabled        = (n+1) % 2
 
 
-3. example_list_t
+3. primitives_list_t
 =================
 
 This tests nested datatypes.
 
-Client publishes 100 lcmtest.example_list_t messages to channel
-"test_lcmtest_example_list_t".  Message number n should be populated as
+Client publishes 100 lcmtest.primitives_list_t messages to channel
+"test_lcmtest_primitives_list_t".  Message number n should be populated as
 follows, for n from 0 to 99:
 
-  .n = n
-  .examples[i] = {            (i = 0 ... n-1)
+  .num_items = n
+  .items[i] = {               (i = 0 ... n-1)
     .i8             = -(i % 100)
     .i16            = -(i * 10)
     .i64            = -(i * 10000)
@@ -166,7 +166,7 @@ The server should reply to each message with an lcmtest.multidim_array_t
 message on channel "test_lcmtest_multidim_array_t_reply".  The reply should be
 similar to the client message, but with as if the client was on message (n+1).
 
-5. cross_package_t
+6. cross_package_t
 ===================
 
 This tests nested datatypes crossing package boundaries.
@@ -192,7 +192,7 @@ n from 0 to 999:
   .another.val               = n
 
 The server should reply to each message with an lcmtest2.cross_package_t message on
-channel "test_lcmtest2_cross_package_t".  The reply should be populated as
+channel "test_lcmtest2_cross_package_t_reply".  The reply should be populated as
 follows:
   .primitives.i8             = (n + 1) % 100
   .primitives.i16            = (n + 1) * 10
@@ -210,4 +210,3 @@ follows:
   .primitives.enabled        = (n+1) % 2
 
   .another.val               = n + 1
-

--- a/test/go/CMakeLists.txt
+++ b/test/go/CMakeLists.txt
@@ -1,0 +1,15 @@
+find_program(GO_EXECUTABLE go)
+
+if(PYTHON_EXECUTABLE AND GO_EXECUTABLE)
+  add_test(NAME Go::client_server COMMAND
+    ${CMAKE_COMMAND} -E env
+      "GOPATH=${lcm_BINARY_DIR}/test/types/go:${GOPATH}"
+      ${PYTHON_EXECUTABLE}
+      ${CMAKE_CURRENT_SOURCE_DIR}/../run_client_server_test.py
+      $<TARGET_FILE:test-c-server>
+      ${GO_EXECUTABLE} test ${CMAKE_CURRENT_SOURCE_DIR}/client_test.go)
+endif()
+
+add_test(NAME Go::unit_test COMMAND
+  ${GO_EXECUTABLE} test -v ./...
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../lcm-go/)

--- a/test/go/client_test.go
+++ b/test/go/client_test.go
@@ -1,0 +1,338 @@
+package client
+
+import (
+	"bytes"
+	"lcmtest"
+	"lcmtest2"
+	"math/rand"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	lcm "../../lcm-go/lcm"
+)
+
+// 1. Echo test
+type echo struct {
+	data []byte
+}
+
+func (e *echo) Encode() ([]byte, error) {
+	return e.data, nil
+}
+func (e *echo) Decode(d []byte) error {
+	e.data = d
+	return nil
+}
+func echoGenerate(n int) (tester, error) {
+	rand.Seed(int64(n))
+	datalen := rand.Intn(10000) + 10
+	data := make([]byte, datalen)
+	_, _ = rand.Read(data)
+
+	return &echo{data: data}, nil
+}
+
+// 2. primitives_t test
+func primitiveTGenerate(n int) (tester, error) {
+	ranges := make([]int16, n)
+	for i := 0; i < n; i++ {
+		ranges[i] = int16(i)
+	}
+	data := lcmtest.LcmtestPrimitivesT{
+		I8:          int8(n % 100),
+		I16:         int16(n) * 10,
+		I64:         int64(n) * 10000,
+		Position:    [3]float32{float32(n), float32(n), float32(n)},
+		Orientation: [4]float64{float64(n), float64(n), float64(n), float64(n)},
+		Ranges:      ranges,
+		Name:        strconv.Itoa(n),
+		Enabled:     (n % 2) != 0,
+	}
+	if _, err := data.NumRanges(); err != nil {
+		return nil, err
+	}
+	return &data, nil
+}
+
+// 3. primitives_list_t
+func primitivesListTGenerate(n int) (tester, error) {
+	primitivesT := make([]lcmtest.LcmtestPrimitivesT, n)
+	for i := 0; i < n; i++ {
+		ranges := make([]int16, i)
+		for j := 0; j < i; j++ {
+			ranges[j] = -int16(j)
+		}
+		primitivesT[i] = lcmtest.LcmtestPrimitivesT{
+			I8:          -int8(i % 100),
+			I16:         -(int16(i) * 10),
+			I64:         -(int64(i) * 10000),
+			Position:    [3]float32{float32(-i), float32(-i), float32(-i)},
+			Orientation: [4]float64{float64(-i), float64(-i), float64(-i), float64(-i)},
+			Ranges:      ranges,
+			Name:        strconv.Itoa(-i),
+			Enabled:     (i % 2) == 0,
+		}
+		if _, err := primitivesT[i].NumRanges(); err != nil {
+			return nil, err
+		}
+	}
+	data := lcmtest.LcmtestPrimitivesListT{
+		Items: primitivesT,
+	}
+	if _, err := data.NumItems(); err != nil {
+		return nil, err
+	}
+	return &data, nil
+}
+
+// 4. node_t
+func nodeTGenerate(n int) (tester, error) {
+	data := lcmtest.LcmtestNodeT{}
+	for i := 0; i < n; i++ {
+		children := make([]lcmtest.LcmtestNodeT, i+1)
+		for j := 0; j <= i; j++ {
+			children[j] = data.Copy()
+		}
+
+		data = lcmtest.LcmtestNodeT{
+			Children: children,
+		}
+
+		if _, err := data.NumChildren(); err != nil {
+			return nil, err
+		}
+	}
+	return &data, nil
+}
+
+// 5. multidim_array_t
+func multidimArrayTGenerate(n int) (tester, error) {
+	data := lcmtest.LcmtestMultidimArrayT{
+		Data: make([][][]int32, n),
+	}
+	for i := 0; i < n; i++ {
+		data.Data[i] = make([][]int32, n)
+		for j := 0; j < n; j++ {
+			data.Data[i][j] = make([]int32, n)
+			for k := 0; k < n; k++ {
+				data.Data[i][j][k] = int32(i*n*n + j*n + k)
+			}
+		}
+	}
+	for p := 0; p < 2; p++ {
+		data.Strarray[p] = make([]string, n)
+		for q := 0; q < n; q++ {
+			data.Strarray[p][q] = strconv.Itoa(p*n + q)
+		}
+	}
+
+	if _, err := data.SizeA(); err != nil {
+		return nil, err
+	}
+	if _, err := data.SizeB(); err != nil {
+		return nil, err
+	}
+	if _, err := data.SizeC(); err != nil {
+		return nil, err
+	}
+
+	return &data, nil
+}
+
+// 6. cross_package_t
+func crossPackageTGenerate(n int) (tester, error) {
+	another := lcmtest2.Lcmtest2AnotherTypeT{
+		Val: int32(n),
+	}
+
+	primitives, err := primitiveTGenerate(n)
+	if err != nil {
+		return nil, err
+	}
+
+	data := lcmtest2.Lcmtest2CrossPackageT{
+		Primitives: *primitives.(*lcmtest.LcmtestPrimitivesT),
+		Another:    another,
+	}
+
+	return &data, nil
+}
+
+type tester interface {
+	Encode() ([]byte, error)
+	Decode([]byte) error
+}
+
+// Generator function that generates the data for a specific iteration of a
+// TC and send that data on the specific publish channel for a TC
+type generatorFunc func(n int) (tester, error)
+
+// Test is the high level test implementation
+func test(lc lcm.LCM, iterations int, pub, sub string,
+	generate generatorFunc, typ tester, step int) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Log("Subscribing to", sub)
+		subs, err := lc.Subscribe(sub, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		publisher, errs := lc.Publisher(pub)
+		defer close(publisher)
+
+		for i := 0; i < iterations; i++ {
+			// Generate data
+			data, err := generate(i)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var encoded []byte
+			encoded, err = data.Encode()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Send and receive data
+			t.Log("Sent data on", pub)
+			publisher <- encoded
+
+			t.Log("Receiving data on", sub)
+			validate(t, subs, i+step, typ, generate)
+		}
+
+		// Check for any leftovers or errors
+		for {
+			select {
+			case data := <-subs.ReceiveChan:
+				t.Fatal("Leftover data found", data)
+			case err := <-errs:
+				t.Fatal("Error during publish", err)
+			case err := <-lc.Errors:
+				t.Fatal("LCM error", err)
+			default:
+				return
+			}
+		}
+	}
+}
+
+func validate(t *testing.T, subs lcm.Subscription, i int, data tester, generate generatorFunc) {
+	select {
+	case <-time.After(1 * time.Second):
+		t.Fatal("Timeout")
+	case received, ok := <-subs.ReceiveChan:
+		if !ok {
+			t.Fatal("Receive channel closed")
+		}
+
+		// Validate data
+		if err := data.Decode(received); err != nil {
+			t.Fatal(err)
+		}
+		// Expected data
+		expected, err := generate(i)
+		if err != nil {
+			t.Fatalf("Error: %v\nduring generation of expected data for:\n%v",
+				err, data)
+		}
+
+		var match bool
+		if d, ok := data.(*echo); ok {
+			// Echo comparison is slow when using reflect, since it only
+			// contains bytes, compare them instead
+			match = bytes.Equal(d.data, expected.(*echo).data)
+		} else {
+			match = reflect.DeepEqual(data, expected)
+		}
+
+		if !match {
+			t.Fatalf("Received:\n\t%v\ndoes not equal expected:\n\t%v"+
+				"\nfor iteration: %d\non channel: %s",
+				data, expected, i, subs.Channel())
+		}
+	}
+}
+
+func TestAll(t *testing.T) {
+	// Setup
+	lc, err := lcm.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lc.Destroy()
+
+	// The 5 LCM test cases
+	testcases := []struct {
+		name       string // Name of testcase
+		iterations int    // Number of iterations TC will do
+		publish    string
+		subscribe  string
+		generate   generatorFunc
+		typ        tester
+		step       int
+	}{
+		{
+			"echo test",
+			10000,
+			"TEST_ECHO",
+			"TEST_ECHO_REPLY",
+			echoGenerate,
+			&echo{},
+			0,
+		},
+		{
+			"primitive_t test",
+			1000,
+			"test_lcmtest_primitives_t",
+			"test_lcmtest_primitives_t_reply",
+			primitiveTGenerate,
+			&lcmtest.LcmtestPrimitivesT{},
+			1,
+		},
+		{
+			"primitives_list_t",
+			100,
+			"test_lcmtest_primitives_list_t",
+			"test_lcmtest_primitives_list_t_reply",
+			primitivesListTGenerate,
+			&lcmtest.LcmtestPrimitivesListT{},
+			1,
+		},
+		{
+			"node_t",
+			7,
+			"test_lcmtest_node_t",
+			"test_lcmtest_node_t_reply",
+			nodeTGenerate,
+			&lcmtest.LcmtestNodeT{},
+			1,
+		},
+		{
+			"multidim_array_t",
+			5,
+			"test_lcmtest_multidim_array_t",
+			"test_lcmtest_multidim_array_t_reply",
+			multidimArrayTGenerate,
+			&lcmtest.LcmtestMultidimArrayT{},
+			1,
+		},
+		{
+			"cross_package_t",
+			1000,
+			"test_lcmtest2_cross_package_t",
+			"test_lcmtest2_cross_package_t_reply",
+			crossPackageTGenerate,
+			&lcmtest2.Lcmtest2CrossPackageT{},
+			1,
+		},
+	}
+
+	// Run the table tests
+	for _, tc := range testcases {
+		t.Run(tc.name, test(lc, tc.iterations, tc.publish, tc.subscribe,
+			tc.generate, tc.typ, tc.step))
+	}
+}

--- a/test/types/CMakeLists.txt
+++ b/test/types/CMakeLists.txt
@@ -9,6 +9,9 @@ endif()
 if(LCM_ENABLE_LUA)
   set(lua_args LUA_SOURCES lua_sources)
 endif()
+if(LCM_ENABLE_GO)
+  set(go_args GO_SOURCES go_sources)
+endif()
 
 lcm_wrap_types(
   C_EXPORT lcmtest
@@ -18,6 +21,7 @@ lcm_wrap_types(
   ${python_args}
   ${java_args}
   ${lua_args}
+  ${go_args}
   lcmtest/bools_t.lcm
   lcmtest/byte_array_t.lcm
   lcmtest/comments_t.lcm


### PR DESCRIPTION
Hi, this patch set contains backend support and code generation output for the Go language [golang](https://golang.org/) through the `-g` option.
The golang code generation implements the golang BinaryMarshaller interface in order to be as idiomatic as possible.

The patch set incorporates and is dependent on the changes that are part of the pull requests #217, #218, #219. Thus they should be merged before this pull request is considered.

Co-authored with @TacoVox