### PR TITLE
Circumvent LLVM problem with old style casts

### DIFF
--- a/lcm/lcm_coretypes.h
+++ b/lcm/lcm_coretypes.h
@@ -7,6 +7,17 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
+
+// Suppress warnings about C-style casts, since this code needs to build in
+// both C and C++ modes
+#if defined(__GNUC__) && defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
 extern "C" {
 #endif
 
@@ -554,6 +565,11 @@ struct _lcm_type_info_t
 
 #ifdef __cplusplus
 }
+#if defined(__GNUC__) && defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #endif
 
 #endif


### PR DESCRIPTION
@fbudin69500 filed a [bug at LLVM](https://bugs.llvm.org/show_bug.cgi?id=37350) which demonstrates this problem with clang.
Sorry to have not found in the previous PR.  
I don't think the [`pragma` is defined in MSVC](https://msdn.microsoft.com/en-us/library/d9x1s805.aspx), thus the `#if`.