### PR TITLE
doc: Add option to build and install documentation

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,4 +1,11 @@
-add_custom_target(doc)
+if(LCM_ENABLE_DOC)
+  add_custom_target(doc ALL)
+  install(
+    DIRECTORY ${lcm_BINARY_DIR}/docs/html
+    DESTINATION /usr/share/doc/lcm-${LCM_VERSION})
+else()
+  add_custom_target(doc)
+endif()
 
 find_program(DOXYGEN_EXECUTABLE doxygen)
 if(NOT DOXYGEN_EXECUTABLE)


### PR DESCRIPTION
* Add `LCM_ENABLE_DOC` variable that pulls in the `doc` target as a build dependency and installs generated files to `/usr/share/doc/lcm-${LCM_VERSION}`.