### PR TITLE
Formatting of examples and test

### DIFF
--- a/examples/c/listener-async.c
+++ b/examples/c/listener-async.c
@@ -14,45 +14,41 @@
 // On a system with pkg-config, you can also use:
 //  $ gcc -o listener-async listener-async.c `pkg-config --cflags --libs lcm`
 
-#include <stdio.h>
 #include <inttypes.h>
-#include <sys/select.h>
 #include <lcm/lcm.h>
+#include <stdio.h>
+#include <sys/select.h>
 #include "exlcm_example_t.h"
 
-static void
-my_handler(const lcm_recv_buf_t *rbuf, const char * channel, 
-        const exlcm_example_t * msg, void * user)
+static void my_handler(const lcm_recv_buf_t *rbuf, const char *channel, const exlcm_example_t *msg,
+                       void *user)
 {
     int i;
     printf("Received message on channel \"%s\":\n", channel);
-    printf("  timestamp   = %"PRId64"\n", msg->timestamp);
-    printf("  position    = (%f, %f, %f)\n",
-            msg->position[0], msg->position[1], msg->position[2]);
-    printf("  orientation = (%f, %f, %f, %f)\n",
-            msg->orientation[0], msg->orientation[1], msg->orientation[2],
-            msg->orientation[3]);
+    printf("  timestamp   = %" PRId64 "\n", msg->timestamp);
+    printf("  position    = (%f, %f, %f)\n", msg->position[0], msg->position[1], msg->position[2]);
+    printf("  orientation = (%f, %f, %f, %f)\n", msg->orientation[0], msg->orientation[1],
+           msg->orientation[2], msg->orientation[3]);
     printf("  ranges:");
-    for(i = 0; i < msg->num_ranges; i++)
+    for (i = 0; i < msg->num_ranges; i++)
         printf(" %d", msg->ranges[i]);
     printf("\n");
     printf("  name        = '%s'\n", msg->name);
     printf("  enabled     = %d\n", msg->enabled);
 }
 
-int
-main(int argc, char ** argv)
+int main(int argc, char **argv)
 {
-    lcm_t * lcm;
+    lcm_t *lcm;
 
     lcm = lcm_create(NULL);
-    if(!lcm)
+    if (!lcm)
         return 1;
 
-    exlcm_example_t_subscription_t * sub =
+    exlcm_example_t_subscription_t *sub =
         exlcm_example_t_subscribe(lcm, "EXAMPLE", &my_handler, NULL);
 
-    while(1) {
+    while (1) {
         // setup the LCM file descriptor for waiting.
         int lcm_fd = lcm_get_fileno(lcm);
         fd_set fds;
@@ -60,16 +56,16 @@ main(int argc, char ** argv)
         FD_SET(lcm_fd, &fds);
 
         // wait a limited amount of time for an incoming message
-        struct timeval timeout = { 
+        struct timeval timeout = {
             1,  // seconds
             0   // microseconds
         };
         int status = select(lcm_fd + 1, &fds, 0, 0, &timeout);
 
-        if(0 == status) {
+        if (0 == status) {
             // no messages
             printf("waiting for message\n");
-        } else if(FD_ISSET(lcm_fd, &fds)) {
+        } else if (FD_ISSET(lcm_fd, &fds)) {
             // LCM has events ready to be processed.
             lcm_handle(lcm);
         }

--- a/examples/c/listener-glib.c
+++ b/examples/c/listener-glib.c
@@ -7,59 +7,53 @@
 //
 //  (note that in the above line, ` is a backtick, not a normal quote mark ')
 
+#include <glib.h>
+#include <lcm/lcm.h>
 #include <stdio.h>
 #include <sys/select.h>
-#include <lcm/lcm.h>
-#include <glib.h>
 #include "exlcm_example_t.h"
 
 typedef struct _state_t {
-    GMainLoop* mainloop;
-    lcm_t* lcm;
+    GMainLoop *mainloop;
+    lcm_t *lcm;
 } state_t;
 
-static void
-on_example_msg(const lcm_recv_buf_t *rbuf, const char * channel, 
-        const exlcm_example_t * msg, void * user)
+static void on_example_msg(const lcm_recv_buf_t *rbuf, const char *channel,
+                           const exlcm_example_t *msg, void *user)
 {
     int i;
     printf("Received message on channel \"%s\":\n", channel);
-    printf("  timestamp   = %lld\n", (long long)msg->timestamp);
-    printf("  position    = (%f, %f, %f)\n",
-            msg->position[0], msg->position[1], msg->position[2]);
-    printf("  orientation = (%f, %f, %f, %f)\n",
-            msg->orientation[0], msg->orientation[1], msg->orientation[2],
-            msg->orientation[3]);
+    printf("  timestamp   = %lld\n", (long long) msg->timestamp);
+    printf("  position    = (%f, %f, %f)\n", msg->position[0], msg->position[1], msg->position[2]);
+    printf("  orientation = (%f, %f, %f, %f)\n", msg->orientation[0], msg->orientation[1],
+           msg->orientation[2], msg->orientation[3]);
     printf("  ranges:");
-    for(i = 0; i < msg->num_ranges; i++)
+    for (i = 0; i < msg->num_ranges; i++)
         printf(" %d", msg->ranges[i]);
     printf("\n");
     printf("  name        = '%s'\n", msg->name);
     printf("  enabled     = %d\n", msg->enabled);
 }
 
-static gboolean
-on_lcm(GIOChannel *source, GIOCondition cond, void *user_data)
+static gboolean on_lcm(GIOChannel *source, GIOCondition cond, void *user_data)
 {
-    state_t* state = (state_t*) user_data;
-    if(0 != lcm_handle(state->lcm))
+    state_t *state = (state_t *) user_data;
+    if (0 != lcm_handle(state->lcm))
         g_main_loop_quit(state->mainloop);
     return TRUE;
 }
 
-static gboolean 
-on_timeout(void* user_data)
+static gboolean on_timeout(void *user_data)
 {
     printf("Timer fired\n");
     return TRUE;
 }
 
-int
-main(int argc, char ** argv)
+int main(int argc, char **argv)
 {
-    state_t* state = calloc(1, sizeof(state_t));
+    state_t *state = calloc(1, sizeof(state_t));
     state->lcm = lcm_create(NULL);
-    if(!state->lcm)
+    if (!state->lcm)
         return 1;
 
     // subscribe to messages
@@ -67,8 +61,8 @@ main(int argc, char ** argv)
 
     // attach LCM to the GLib event loop
     state->mainloop = g_main_loop_new(NULL, TRUE);
-    GIOChannel* ioc = g_io_channel_unix_new(lcm_get_fileno(state->lcm));
-    guint sid = g_io_add_watch(ioc, G_IO_IN, (GIOFunc)on_lcm, state);
+    GIOChannel *ioc = g_io_channel_unix_new(lcm_get_fileno(state->lcm));
+    guint sid = g_io_add_watch(ioc, G_IO_IN, (GIOFunc) on_lcm, state);
 
     // add a periodic timer to call a function every 1000 ms.
     g_timeout_add(1000, on_timeout, state);

--- a/examples/c/listener.c
+++ b/examples/c/listener.c
@@ -8,41 +8,37 @@
 // On a system with pkg-config, you can also use:
 //  $ gcc -o listener listener.c `pkg-config --cflags --libs lcm`
 
-#include <stdio.h>
 #include <inttypes.h>
 #include <lcm/lcm.h>
+#include <stdio.h>
 #include "exlcm_example_t.h"
 
-static void
-my_handler(const lcm_recv_buf_t *rbuf, const char * channel, 
-        const exlcm_example_t * msg, void * user)
+static void my_handler(const lcm_recv_buf_t *rbuf, const char *channel, const exlcm_example_t *msg,
+                       void *user)
 {
     int i;
     printf("Received message on channel \"%s\":\n", channel);
-    printf("  timestamp   = %"PRId64"\n", msg->timestamp);
-    printf("  position    = (%f, %f, %f)\n",
-            msg->position[0], msg->position[1], msg->position[2]);
-    printf("  orientation = (%f, %f, %f, %f)\n",
-            msg->orientation[0], msg->orientation[1], msg->orientation[2],
-            msg->orientation[3]);
+    printf("  timestamp   = %" PRId64 "\n", msg->timestamp);
+    printf("  position    = (%f, %f, %f)\n", msg->position[0], msg->position[1], msg->position[2]);
+    printf("  orientation = (%f, %f, %f, %f)\n", msg->orientation[0], msg->orientation[1],
+           msg->orientation[2], msg->orientation[3]);
     printf("  ranges:");
-    for(i = 0; i < msg->num_ranges; i++)
+    for (i = 0; i < msg->num_ranges; i++)
         printf(" %d", msg->ranges[i]);
     printf("\n");
     printf("  name        = '%s'\n", msg->name);
     printf("  enabled     = %d\n", msg->enabled);
 }
 
-int
-main(int argc, char ** argv)
+int main(int argc, char **argv)
 {
-    lcm_t * lcm = lcm_create(NULL);
-    if(!lcm)
+    lcm_t *lcm = lcm_create(NULL);
+    if (!lcm)
         return 1;
 
     exlcm_example_t_subscribe(lcm, "EXAMPLE", &my_handler, NULL);
 
-    while(1)
+    while (1)
         lcm_handle(lcm);
 
     lcm_destroy(lcm);

--- a/examples/c/read_log.c
+++ b/examples/c/read_log.c
@@ -10,49 +10,47 @@
 // On a system with pkg-config, you can also use:
 //  $ gcc -o read_log read_log.c `pkg-config --cflags --libs lcm`
 
-#include <stdio.h>
 #include <inttypes.h>
-#include <string.h>
 #include <lcm/lcm.h>
+#include <stdio.h>
+#include <string.h>
 
 #include "exlcm_example_t.h"
 
-int main(int argc, char ** argv)
+int main(int argc, char **argv)
 {
-    lcm_eventlog_t * log;
-    if(argc < 2) {
+    lcm_eventlog_t *log;
+    if (argc < 2) {
         fprintf(stderr, "usage: read_log <logfile>\n");
         return 1;
     }
 
     log = lcm_eventlog_create(argv[1], "r");
-    if(!log) {
+    if (!log) {
         fprintf(stderr, "couldn't open log file\n");
         return 1;
     }
 
-    while(1) {
+    while (1) {
         exlcm_example_t msg;
         int i;
         lcm_eventlog_event_t *event = lcm_eventlog_read_next_event(log);
 
-        if(!event)
+        if (!event)
             break;
 
-        if(0 != strcmp(event->channel, "EXAMPLE"))
+        if (0 != strcmp(event->channel, "EXAMPLE"))
             continue;
 
         exlcm_example_t_decode(event->data, 0, event->datalen, &msg);
 
         printf("Message:\n");
-        printf("  timestamp   = %"PRId64"\n", msg.timestamp);
-        printf("  position    = (%f, %f, %f)\n",
-                msg.position[0], msg.position[1], msg.position[2]);
-        printf("  orientation = (%f, %f, %f, %f)\n",
-                msg.orientation[0], msg.orientation[1], msg.orientation[2],
-                msg.orientation[3]);
+        printf("  timestamp   = %" PRId64 "\n", msg.timestamp);
+        printf("  position    = (%f, %f, %f)\n", msg.position[0], msg.position[1], msg.position[2]);
+        printf("  orientation = (%f, %f, %f, %f)\n", msg.orientation[0], msg.orientation[1],
+               msg.orientation[2], msg.orientation[3]);
         printf("  ranges:");
-        for(i = 0; i < msg.num_ranges; i++)
+        for (i = 0; i < msg.num_ranges; i++)
             printf(" %d", msg.ranges[i]);
         printf("\n");
         printf("  name        = '%s'\n", msg.name);

--- a/examples/c/send_message.c
+++ b/examples/c/send_message.c
@@ -8,26 +8,23 @@
 // On a system with pkg-config, you can also use:
 //  $ gcc -o send_message send_message.c `pkg-config --cflags --libs lcm`
 
-#include <stdio.h>
 #include <lcm/lcm.h>
+#include <stdio.h>
 
 #include "exlcm_example_t.h"
 
-int
-main(int argc, char ** argv)
+int main(int argc, char **argv)
 {
-    lcm_t * lcm = lcm_create(NULL);
-    if(!lcm)
+    lcm_t *lcm = lcm_create(NULL);
+    if (!lcm)
         return 1;
 
     exlcm_example_t my_data = {
-        .timestamp = 0,
-        .position = { 1, 2, 3 },
-        .orientation = { 1, 0, 0, 0 },
+        .timestamp = 0, .position = {1, 2, 3}, .orientation = {1, 0, 0, 0},
     };
     int16_t ranges[15];
     int i;
-    for(i = 0; i < 15; i++)
+    for (i = 0; i < 15; i++)
         ranges[i] = i;
 
     my_data.num_ranges = 15;

--- a/examples/cpp/listener.cpp
+++ b/examples/cpp/listener.cpp
@@ -13,37 +13,33 @@
 #include <lcm/lcm-cpp.hpp>
 #include "exlcm/example_t.hpp"
 
-class Handler 
-{
-    public:
-        ~Handler() {}
-
-        void handleMessage(const lcm::ReceiveBuffer* rbuf,
-                const std::string& chan, 
-                const exlcm::example_t* msg)
-        {
-            int i;
-            printf("Received message on channel \"%s\":\n", chan.c_str());
-            printf("  timestamp   = %lld\n", (long long)msg->timestamp);
-            printf("  position    = (%f, %f, %f)\n",
-                    msg->position[0], msg->position[1], msg->position[2]);
-            printf("  orientation = (%f, %f, %f, %f)\n",
-                    msg->orientation[0], msg->orientation[1], 
-                    msg->orientation[2], msg->orientation[3]);
-            printf("  ranges:");
-            for(i = 0; i < msg->num_ranges; i++)
-                printf(" %d", msg->ranges[i]);
-            printf("\n");
-            printf("  name        = '%s'\n", msg->name.c_str());
-            printf("  enabled     = %d\n", msg->enabled);
-        }
+class Handler {
+  public:
+    ~Handler() {}
+    void handleMessage(const lcm::ReceiveBuffer *rbuf, const std::string &chan,
+                       const exlcm::example_t *msg)
+    {
+        int i;
+        printf("Received message on channel \"%s\":\n", chan.c_str());
+        printf("  timestamp   = %lld\n", (long long) msg->timestamp);
+        printf("  position    = (%f, %f, %f)\n", msg->position[0], msg->position[1],
+               msg->position[2]);
+        printf("  orientation = (%f, %f, %f, %f)\n", msg->orientation[0], msg->orientation[1],
+               msg->orientation[2], msg->orientation[3]);
+        printf("  ranges:");
+        for (i = 0; i < msg->num_ranges; i++)
+            printf(" %d", msg->ranges[i]);
+        printf("\n");
+        printf("  name        = '%s'\n", msg->name.c_str());
+        printf("  enabled     = %d\n", msg->enabled);
+    }
 };
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
     lcm::LCM lcm;
 
-    if(!lcm.good())
+    if (!lcm.good())
         return 1;
 
     Handler handlerObject;

--- a/examples/cpp/listener.cpp
+++ b/examples/cpp/listener.cpp
@@ -49,7 +49,9 @@ int main(int argc, char** argv)
     Handler handlerObject;
     lcm.subscribe("EXAMPLE", &Handler::handleMessage, &handlerObject);
 
-    while(0 == lcm.handle());
+    while (0 == lcm.handle()) {
+        // Do nothing
+    }
 
     return 0;
 }

--- a/examples/cpp/read_log.cpp
+++ b/examples/cpp/read_log.cpp
@@ -16,46 +16,44 @@
 
 #include "exlcm/example_t.hpp"
 
-int main(int argc, char ** argv)
+int main(int argc, char **argv)
 {
-    if(argc < 2) {
+    if (argc < 2) {
         fprintf(stderr, "usage: read_log <logfile>\n");
         return 1;
     }
 
     // Open the log file.
     lcm::LogFile log(argv[1], "r");
-    if(!log.good()) {
+    if (!log.good()) {
         perror("LogFile");
         fprintf(stderr, "couldn't open log file %s\n", argv[1]);
         return 1;
     }
 
-    while(1) {
+    while (1) {
         // Read a log event.
         const lcm::LogEvent *event = log.readNextEvent();
-        if(!event)
+        if (!event)
             break;
 
         // Only process messages on the EXAMPLE channel.
-        if(event->channel != "EXAMPLE")
+        if (event->channel != "EXAMPLE")
             continue;
 
         // Try to decode the message.
         exlcm::example_t msg;
-        if(msg.decode(event->data, 0, event->datalen) != event->datalen)
+        if (msg.decode(event->data, 0, event->datalen) != event->datalen)
             continue;
 
         // Decode success!  Print out the message contents.
         printf("Message:\n");
-        printf("  timestamp   = %lld\n", (long long)msg.timestamp);
-        printf("  position    = (%f, %f, %f)\n",
-                msg.position[0], msg.position[1], msg.position[2]);
-        printf("  orientation = (%f, %f, %f, %f)\n",
-                msg.orientation[0], msg.orientation[1], msg.orientation[2],
-                msg.orientation[3]);
+        printf("  timestamp   = %lld\n", (long long) msg.timestamp);
+        printf("  position    = (%f, %f, %f)\n", msg.position[0], msg.position[1], msg.position[2]);
+        printf("  orientation = (%f, %f, %f, %f)\n", msg.orientation[0], msg.orientation[1],
+               msg.orientation[2], msg.orientation[3]);
         printf("  ranges:");
-        for(int i = 0; i < msg.num_ranges; i++)
+        for (int i = 0; i < msg.num_ranges; i++)
             printf(" %d", msg.ranges[i]);
         printf("\n");
         printf("  name        = '%s'\n", msg.name.c_str());

--- a/examples/cpp/send_message.cpp
+++ b/examples/cpp/send_message.cpp
@@ -12,10 +12,10 @@
 
 #include "exlcm/example_t.hpp"
 
-int main(int argc, char ** argv)
+int main(int argc, char **argv)
 {
     lcm::LCM lcm;
-    if(!lcm.good())
+    if (!lcm.good())
         return 1;
 
     exlcm::example_t my_data;
@@ -32,7 +32,7 @@ int main(int argc, char ** argv)
 
     my_data.num_ranges = 15;
     my_data.ranges.resize(my_data.num_ranges);
-    for(int i = 0; i < my_data.num_ranges; i++)
+    for (int i = 0; i < my_data.num_ranges; i++)
         my_data.ranges[i] = i;
 
     my_data.name = "example string";

--- a/format_code.sh
+++ b/format_code.sh
@@ -24,14 +24,33 @@
 
 LCM_ROOT="$(cd $(dirname "$0") && pwd)"
 
+# format_c_cpp_dir_r DIR [EXCUDE_PATTERN...]
+#
+# Formats all C and C++ sources in a directory recursively. DIR is the source
+# directory for the recursive formatting. The optional EXCLUDE_PATTERN is an
+# Extended Regex matched against each file path, where the file is excluded from
+# formatting if it matches. There can be multiple exclude patterns.
+
 function format_c_cpp_dir_r {
-    find "$1" -regex '.*\.\(c\|h\)\(pp\)?' -print0 | xargs -0 clang-format -i
+    include_dir="$1"
+    exclude_patterns=("${@:2}")
+    if [ "${#exclude_patterns[@]}" -eq 0 ]; then
+        # Use an empty pattern to not match anything
+        exclude_patterns="^$"
+    fi
+    exclude_pattern_opts=""
+    for exclude_pattern in "${exclude_patterns[@]}"; do
+        exclude_pattern_opts="${exclude_pattern_opts} -e \"${exclude_pattern}\" "
+    done
+    find "$1" -regex '.*\.\(c\|h\)\(pp\)?' \
+        | eval "grep -E -v" "${exclude_pattern_opts}" \
+        | xargs clang-format -i
 }
 
-format_c_cpp_dir_r "${LCM_ROOT}/lcm"
+format_c_cpp_dir_r "${LCM_ROOT}/lcm" "/lcmtypes/"
 format_c_cpp_dir_r "${LCM_ROOT}/lcmgen"
-#format_c_cpp_dir_r "${LCM_ROOT}/lcm-examples"
-#format_c_cpp_dir_r "${LCM_ROOT}/lcm-test"
+format_c_cpp_dir_r "${LCM_ROOT}/examples"
+format_c_cpp_dir_r "${LCM_ROOT}/test" "/gtest/"
 #format_c_cpp_dir_r "${LCM_ROOT}/lcm-logger"
 #format_c_cpp_dir_r "${LCM_ROOT}/lcm-python"
 #format_c_cpp_dir_r "${LCM_ROOT}/lcm-lua"

--- a/test/c/client.cpp
+++ b/test/c/client.cpp
@@ -1,56 +1,59 @@
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <time.h>
 #include <gtest/gtest.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
 
 #include <lcm/lcm.h>
 
 #include "common.h"
 
-#define info(...) do { printf("c_client: "); printf(__VA_ARGS__); printf("\n"); } while(0)
+#define info(...)             \
+    do {                      \
+        printf("c_client: "); \
+        printf(__VA_ARGS__);  \
+        printf("\n");         \
+    } while (0)
 
-static lcm_t* g_lcm = NULL;
+static lcm_t *g_lcm = NULL;
 
 // ====================================== node_t test
-#define MAKE_CLIENT_TEST(type, num_iters) \
-\
-static int g_##type##_response_count = 0; \
-\
-static void \
-type##_handler(const lcm_recv_buf_t* rbuf, const char* channel, \
-        const type* msg, void* user) \
-{ \
-    if(!check_##type(msg, g_##type##_response_count + 1)) { \
-        return; \
-    } \
-    g_##type##_response_count++; \
-} \
-\
-static int \
-do_##type##_test(void) \
-{ \
-    type msg; \
-    type##_subscription_t* subs = type##_subscribe(g_lcm, \
-            "test_" #type "_reply", type##_handler, NULL); \
-    g_##type##_response_count = 0; \
-    int result = 1; \
-    int iter; \
-    for(iter=0; iter<num_iters && result; iter++) { \
-        fill_##type(iter, &msg); \
-        type##_publish(g_lcm, "test_" #type, &msg); \
-        if(!lcm_handle_timeout(g_lcm, 500)) { \
-            info(#type " test: Timeout waiting for reply"); \
-            result = 0; \
-        } else if(g_##type##_response_count != iter+1) { \
-            info(#type " test: failed on iteration %d", iter); \
-            result = 0; \
-        } \
-        clear_##type(&msg); \
-    } \
-    type##_unsubscribe(g_lcm, subs); \
-    return result; \
-}
+#define MAKE_CLIENT_TEST(type, num_iters)                                                        \
+                                                                                                 \
+    static int g_##type##_response_count = 0;                                                    \
+                                                                                                 \
+    static void type##_handler(const lcm_recv_buf_t *rbuf, const char *channel, const type *msg, \
+                               void *user)                                                       \
+    {                                                                                            \
+        if (!check_##type(msg, g_##type##_response_count + 1)) {                                 \
+            return;                                                                              \
+        }                                                                                        \
+        g_##type##_response_count++;                                                             \
+    }                                                                                            \
+                                                                                                 \
+    static int do_##type##_test(void)                                                            \
+    {                                                                                            \
+        type msg;                                                                                \
+        type##_subscription_t *subs =                                                            \
+            type##_subscribe(g_lcm, "test_" #type "_reply", type##_handler, NULL);               \
+        g_##type##_response_count = 0;                                                           \
+        int result = 1;                                                                          \
+        int iter;                                                                                \
+        for (iter = 0; iter < num_iters && result; iter++) {                                     \
+            fill_##type(iter, &msg);                                                             \
+            type##_publish(g_lcm, "test_" #type, &msg);                                          \
+            if (!lcm_handle_timeout(g_lcm, 500)) {                                               \
+                info(#type " test: Timeout waiting for reply");                                  \
+                result = 0;                                                                      \
+            } else if (g_##type##_response_count != iter + 1) {                                  \
+                info(#type " test: failed on iteration %d", iter);                               \
+                result = 0;                                                                      \
+            }                                                                                    \
+            clear_##type(&msg);                                                                  \
+        }                                                                                        \
+        type##_unsubscribe(g_lcm, subs);                                                         \
+        return result;                                                                           \
+    }
 
 MAKE_CLIENT_TEST(lcmtest2_cross_package_t, 100);
 MAKE_CLIENT_TEST(lcmtest_multidim_array_t, 5);
@@ -61,14 +64,13 @@ MAKE_CLIENT_TEST(lcmtest_primitives_t, 1000);
 // ================================= echo test
 int g_echo_response_count = 0;
 int g_echo_msg_len = 0;
-uint8_t* g_echo_data = NULL;
+uint8_t *g_echo_data = NULL;
 
-static void
-echo_handler(const lcm_recv_buf_t *rbuf, const char * channel, void * user)
+static void echo_handler(const lcm_recv_buf_t *rbuf, const char *channel, void *user)
 {
-    if(rbuf->data_size != g_echo_msg_len)
+    if (rbuf->data_size != g_echo_msg_len)
         return;
-    if(memcmp(rbuf->data, g_echo_data, rbuf->data_size))
+    if (memcmp(rbuf->data, g_echo_data, rbuf->data_size))
         return;
     g_echo_response_count++;
 }
@@ -81,24 +83,23 @@ TEST(LCM_C, EchoTest)
 
     int maxlen = 10000;
     int minlen = 10;
-    g_echo_data = (uint8_t*) malloc(maxlen);
-    lcm_subscription_t* subs = lcm_subscribe(g_lcm, "TEST_ECHO_REPLY", echo_handler, NULL);
+    g_echo_data = (uint8_t *) malloc(maxlen);
+    lcm_subscription_t *subs = lcm_subscribe(g_lcm, "TEST_ECHO_REPLY", echo_handler, NULL);
     g_echo_response_count = 0;
 
     int iter;
-    for(iter=0; iter<100; iter++)
-    {
+    for (iter = 0; iter < 100; iter++) {
         g_echo_msg_len = rand() % (maxlen - minlen) + minlen;
         int i;
-        for(i=0; i<g_echo_msg_len; i++)
+        for (i = 0; i < g_echo_msg_len; i++)
             g_echo_data[i] = rand() % 256;
 
         lcm_publish(g_lcm, "TEST_ECHO", g_echo_data, g_echo_msg_len);
 
         ASSERT_GT(lcm_handle_timeout(g_lcm, 500), 0);
-        ASSERT_EQ(g_echo_response_count, iter+1);
+        ASSERT_EQ(g_echo_response_count, iter + 1);
 
-        if(g_echo_response_count != iter+1) {
+        if (g_echo_response_count != iter + 1) {
             info("echo test failed to receive response on iteration %d", iter);
             lcm_unsubscribe(g_lcm, subs);
             free(g_echo_data);

--- a/test/c/common.c
+++ b/test/c/common.c
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include <inttypes.h>
+#include <stdio.h>
 
 #ifndef WIN32
 #include <sys/select.h>
@@ -10,12 +10,16 @@ typedef int SOCKET;
 
 #include "common.h"
 
-#define info(...) do { fprintf(stderr, "server: "); fprintf(stderr, __VA_ARGS__); } while(0)
+#define info(...)                     \
+    do {                              \
+        fprintf(stderr, "server: ");  \
+        fprintf(stderr, __VA_ARGS__); \
+    } while (0)
 
-#define CHECK_FIELD(field, expected, fmt) \
-    if((field) != (expected)) { \
+#define CHECK_FIELD(field, expected, fmt)                                                       \
+    if ((field) != (expected)) {                                                                \
         info("Expected " #field " to be: " fmt ", got " fmt " instead\n", (expected), (field)); \
-        return 0; \
+        return 0;                                                                               \
     }
 
 #if defined(_MSC_VER) && _MSC_VER < 1900
@@ -51,18 +55,16 @@ inline int c99_snprintf(char *outBuf, size_t size, const char *format, ...)
 
 // Avoid clashing with predefined _strdup
 #ifndef _MSC_VER
-char*
-_strdup(const char* src)
+char *_strdup(const char *src)
 {
     int len = strlen(src);
-    char* result = malloc(len + 1);
-    memcpy(result, src, len+1);
+    char *result = malloc(len + 1);
+    memcpy(result, src, len + 1);
     return result;
 }
 #endif
 
-int
-check_lcmtest_multidim_array_t(const lcmtest_multidim_array_t* msg, int expected)
+int check_lcmtest_multidim_array_t(const lcmtest_multidim_array_t *msg, int expected)
 {
     CHECK_FIELD(msg->size_a, expected, "%d");
     CHECK_FIELD(msg->size_b, expected, "%d");
@@ -71,9 +73,9 @@ check_lcmtest_multidim_array_t(const lcmtest_multidim_array_t* msg, int expected
     int i, j, k;
     int n = 0;
     // data
-    for(i=0; i<msg->size_a; i++) {
-        for(j=0; j<msg->size_b; j++) {
-            for(k=0; k<msg->size_c; k++) {
+    for (i = 0; i < msg->size_a; i++) {
+        for (j = 0; j < msg->size_b; j++) {
+            for (k = 0; k < msg->size_c; k++) {
                 CHECK_FIELD(msg->data[i][j][k], n, "%d");
                 n++;
             }
@@ -83,11 +85,12 @@ check_lcmtest_multidim_array_t(const lcmtest_multidim_array_t* msg, int expected
     // strarray
     char expected_buf[80];
     n = 0;
-    for(i=0; i<2; i++) {
-        for(k=0; k<msg->size_c; k++) {
+    for (i = 0; i < 2; i++) {
+        for (k = 0; k < msg->size_c; k++) {
             snprintf(expected_buf, 79, "%d", n);
-            if(strcmp(expected_buf, msg->strarray[i][k])) {
-                info("Expected msg->strarray[%d][%d] to be %s, got %s instead\n", i, k, expected_buf, msg->strarray[i][k]);
+            if (strcmp(expected_buf, msg->strarray[i][k])) {
+                info("Expected msg->strarray[%d][%d] to be %s, got %s instead\n", i, k,
+                     expected_buf, msg->strarray[i][k]);
                 return 0;
             }
             n++;
@@ -97,22 +100,21 @@ check_lcmtest_multidim_array_t(const lcmtest_multidim_array_t* msg, int expected
     return 1;
 }
 
-void
-fill_lcmtest_multidim_array_t(int num, lcmtest_multidim_array_t* msg)
+void fill_lcmtest_multidim_array_t(int num, lcmtest_multidim_array_t *msg)
 {
     msg->size_a = num;
     msg->size_b = num;
     msg->size_c = num;
 
-    msg->data = (int32_t***) malloc(num * sizeof(int32_t***));
+    msg->data = (int32_t ***) malloc(num * sizeof(int32_t ***));
     int i, j, k;
     int n = 0;
     // data
-    for(i=0; i<num; i++) {
-        msg->data[i] = (int32_t**) malloc(num * sizeof(int32_t**));
-        for(j=0; j<num; j++) {
-            msg->data[i][j] = (int32_t*) malloc(num * sizeof(int32_t));
-            for(k=0; k<num; k++) {
+    for (i = 0; i < num; i++) {
+        msg->data[i] = (int32_t **) malloc(num * sizeof(int32_t **));
+        for (j = 0; j < num; j++) {
+            msg->data[i][j] = (int32_t *) malloc(num * sizeof(int32_t));
+            for (k = 0; k < num; k++) {
                 msg->data[i][j][k] = n;
                 n++;
             }
@@ -121,11 +123,11 @@ fill_lcmtest_multidim_array_t(int num, lcmtest_multidim_array_t* msg)
 
     char buf[80];
     // strarray
-    msg->strarray = (char***) malloc(2 * sizeof(char***));
+    msg->strarray = (char ***) malloc(2 * sizeof(char ***));
     n = 0;
-    for(i=0; i<2; i++) {
-        msg->strarray[i] = (char**) malloc(msg->size_c * sizeof(char**));
-        for(k=0; k<msg->size_c; k++) {
+    for (i = 0; i < 2; i++) {
+        msg->strarray[i] = (char **) malloc(msg->size_c * sizeof(char **));
+        for (k = 0; k < msg->size_c; k++) {
             snprintf(buf, 79, "%d", n);
             msg->strarray[i][k] = _strdup(buf);
             n++;
@@ -133,13 +135,12 @@ fill_lcmtest_multidim_array_t(int num, lcmtest_multidim_array_t* msg)
     }
 }
 
-void
-clear_lcmtest_multidim_array_t(lcmtest_multidim_array_t* msg)
+void clear_lcmtest_multidim_array_t(lcmtest_multidim_array_t *msg)
 {
     int i, j, k;
     // data
-    for(i=0; i<msg->size_a; i++) {
-        for(j=0; j<msg->size_b; j++) {
+    for (i = 0; i < msg->size_a; i++) {
+        for (j = 0; j < msg->size_b; j++) {
             free(msg->data[i][j]);
         }
         free(msg->data[i]);
@@ -147,8 +148,8 @@ clear_lcmtest_multidim_array_t(lcmtest_multidim_array_t* msg)
     free(msg->data);
 
     // strarray
-    for(i=0; i<2; i++) {
-        for(k=0; k<msg->size_c; k++) {
+    for (i = 0; i < 2; i++) {
+        for (k = 0; k < msg->size_c; k++) {
             free(msg->strarray[i][k]);
         }
         free(msg->strarray[i]);
@@ -156,85 +157,80 @@ clear_lcmtest_multidim_array_t(lcmtest_multidim_array_t* msg)
     free(msg->strarray);
 }
 
-int
-check_lcmtest_node_t(const lcmtest_node_t* msg, int expected)
+int check_lcmtest_node_t(const lcmtest_node_t *msg, int expected)
 {
     CHECK_FIELD(msg->num_children, expected, "%d");
-    if(!msg->num_children)
+    if (!msg->num_children)
         return 1;
 
     int i;
-    for(i=0; i<msg->num_children; i++) {
-        const lcmtest_node_t* child = &msg->children[i];
-        if(!check_lcmtest_node_t(child, msg->num_children - 1))
+    for (i = 0; i < msg->num_children; i++) {
+        const lcmtest_node_t *child = &msg->children[i];
+        if (!check_lcmtest_node_t(child, msg->num_children - 1))
             return 0;
     }
     return 1;
 }
 
-void
-fill_lcmtest_node_t(int num_children, lcmtest_node_t* result)
+void fill_lcmtest_node_t(int num_children, lcmtest_node_t *result)
 {
     result->num_children = num_children;
-    if(!num_children) {
+    if (!num_children) {
         result->children = NULL;
         return;
     }
-    result->children =
-        (lcmtest_node_t*) malloc(num_children * sizeof(lcmtest_node_t));
-    for(int i=0; i<num_children; i++) {
-        fill_lcmtest_node_t(num_children-1, &result->children[i]);
+    result->children = (lcmtest_node_t *) malloc(num_children * sizeof(lcmtest_node_t));
+    for (int i = 0; i < num_children; i++) {
+        fill_lcmtest_node_t(num_children - 1, &result->children[i]);
     }
 }
 
-void
-clear_lcmtest_node_t(lcmtest_node_t* msg)
+void clear_lcmtest_node_t(lcmtest_node_t *msg)
 {
-    for(int i=0; i<msg->num_children; i++) {
+    for (int i = 0; i < msg->num_children; i++) {
         clear_lcmtest_node_t(&msg->children[i]);
     }
     free(msg->children);
 }
 
-int check_lcmtest_primitives_list_t(const lcmtest_primitives_list_t* msg, int expected)
+int check_lcmtest_primitives_list_t(const lcmtest_primitives_list_t *msg, int expected)
 {
     CHECK_FIELD(msg->num_items, expected, "%d");
-    for(int n=0; n<expected; n++)
-    {
-        const lcmtest_primitives_t* ex = &msg->items[n];
+    for (int n = 0; n < expected; n++) {
+        const lcmtest_primitives_t *ex = &msg->items[n];
         CHECK_FIELD(ex->i8, -(n % 100), "%d");
         CHECK_FIELD(ex->i16, -n * 10, "%d");
-        CHECK_FIELD(ex->i64, (int64_t)(-n * 10000), "%"PRId64);
-        CHECK_FIELD(ex->position[0], (double)-n, "%f");
-        CHECK_FIELD(ex->position[1], (double)-n, "%f");
-        CHECK_FIELD(ex->position[2], (double)-n, "%f");
-        CHECK_FIELD(ex->orientation[0], (double)-n, "%f");
-        CHECK_FIELD(ex->orientation[1], (double)-n, "%f");
-        CHECK_FIELD(ex->orientation[2], (double)-n, "%f");
-        CHECK_FIELD(ex->orientation[3], (double)-n, "%f");
+        CHECK_FIELD(ex->i64, (int64_t)(-n * 10000), "%" PRId64);
+        CHECK_FIELD(ex->position[0], (double) -n, "%f");
+        CHECK_FIELD(ex->position[1], (double) -n, "%f");
+        CHECK_FIELD(ex->position[2], (double) -n, "%f");
+        CHECK_FIELD(ex->orientation[0], (double) -n, "%f");
+        CHECK_FIELD(ex->orientation[1], (double) -n, "%f");
+        CHECK_FIELD(ex->orientation[2], (double) -n, "%f");
+        CHECK_FIELD(ex->orientation[3], (double) -n, "%f");
         CHECK_FIELD(ex->num_ranges, n, "%d");
         int i;
-        for(i=0; i<n; i++)
+        for (i = 0; i < n; i++)
             CHECK_FIELD(ex->ranges[i], -i, "%d");
         char expected_name[100];
         sprintf(expected_name, "%d", -n);
-        if(strcmp(expected_name, ex->name)) {
-            info("Expected msg->items[%d].name to be %s, got %s instead\n", n, expected_name, ex->name);
+        if (strcmp(expected_name, ex->name)) {
+            info("Expected msg->items[%d].name to be %s, got %s instead\n", n, expected_name,
+                 ex->name);
             return 0;
         }
-        CHECK_FIELD(ex->enabled, (int)((n+1)%2), "%d");
+        CHECK_FIELD(ex->enabled, (int) ((n + 1) % 2), "%d");
     }
     return 1;
 }
 
-void
-fill_lcmtest_primitives_list_t(int num, lcmtest_primitives_list_t* msg)
+void fill_lcmtest_primitives_list_t(int num, lcmtest_primitives_list_t *msg)
 {
     int n;
     msg->num_items = num;
-    msg->items = (lcmtest_primitives_t*) malloc(msg->num_items * sizeof(lcmtest_primitives_t));
-    for(n=0; n<num; n++) {
-        lcmtest_primitives_t* ex = &msg->items[n];
+    msg->items = (lcmtest_primitives_t *) malloc(msg->num_items * sizeof(lcmtest_primitives_t));
+    for (n = 0; n < num; n++) {
+        lcmtest_primitives_t *ex = &msg->items[n];
         ex->i8 = -(n % 100);
         ex->i16 = -n * 10;
         ex->i64 = -n * 10000;
@@ -246,59 +242,56 @@ fill_lcmtest_primitives_list_t(int num, lcmtest_primitives_list_t* msg)
         ex->orientation[2] = -n;
         ex->orientation[3] = -n;
         ex->num_ranges = n;
-        ex->ranges = (int16_t*)malloc(n * sizeof(int16_t));
+        ex->ranges = (int16_t *) malloc(n * sizeof(int16_t));
         int i;
-        for(i=0; i<n; i++) {
+        for (i = 0; i < n; i++) {
             ex->ranges[i] = -i;
         }
         char name[100];
         snprintf(name, 99, "%d", -n);
         ex->name = _strdup(name);
-        ex->enabled = (n+1) % 2;
+        ex->enabled = (n + 1) % 2;
     }
 }
 
-void
-clear_lcmtest_primitives_list_t(lcmtest_primitives_list_t* msg)
+void clear_lcmtest_primitives_list_t(lcmtest_primitives_list_t *msg)
 {
     int n;
-    for(n=0; n<msg->num_items; n++) {
+    for (n = 0; n < msg->num_items; n++) {
         free(msg->items[n].ranges);
         free(msg->items[n].name);
     }
     free(msg->items);
 }
 
-int
-check_lcmtest_primitives_t(const lcmtest_primitives_t* msg, int expected)
+int check_lcmtest_primitives_t(const lcmtest_primitives_t *msg, int expected)
 {
     int n = expected;
-    CHECK_FIELD(msg->i8,  n % 100, "%d");
+    CHECK_FIELD(msg->i8, n % 100, "%d");
     CHECK_FIELD(msg->i16, n * 10, "%d");
-    CHECK_FIELD(msg->i64, (int64_t)(n * 10000), "%"PRId64);
-    CHECK_FIELD(msg->position[0], (double)n, "%f");
-    CHECK_FIELD(msg->position[1], (double)n, "%f");
-    CHECK_FIELD(msg->position[2], (double)n, "%f");
-    CHECK_FIELD(msg->orientation[0], (double)n, "%f");
-    CHECK_FIELD(msg->orientation[1], (double)n, "%f");
-    CHECK_FIELD(msg->orientation[2], (double)n, "%f");
-    CHECK_FIELD(msg->orientation[3], (double)n, "%f");
+    CHECK_FIELD(msg->i64, (int64_t)(n * 10000), "%" PRId64);
+    CHECK_FIELD(msg->position[0], (double) n, "%f");
+    CHECK_FIELD(msg->position[1], (double) n, "%f");
+    CHECK_FIELD(msg->position[2], (double) n, "%f");
+    CHECK_FIELD(msg->orientation[0], (double) n, "%f");
+    CHECK_FIELD(msg->orientation[1], (double) n, "%f");
+    CHECK_FIELD(msg->orientation[2], (double) n, "%f");
+    CHECK_FIELD(msg->orientation[3], (double) n, "%f");
     CHECK_FIELD(msg->num_ranges, n, "%d");
     int i;
-    for(i=0; i<n; i++)
+    for (i = 0; i < n; i++)
         CHECK_FIELD(msg->ranges[i], i, "%d");
     char expected_name[100];
     sprintf(expected_name, "%d", n);
-    if(strcmp(expected_name, msg->name)) {
+    if (strcmp(expected_name, msg->name)) {
         info("Expected msg->expected_name to be %s, got %s instead\n", expected_name, msg->name);
         return 0;
     }
-    CHECK_FIELD(msg->enabled, (int)(n%2), "%d");
+    CHECK_FIELD(msg->enabled, (int) (n % 2), "%d");
     return 1;
 }
 
-void
-fill_lcmtest_primitives_t(int n, lcmtest_primitives_t* msg)
+void fill_lcmtest_primitives_t(int n, lcmtest_primitives_t *msg)
 {
     msg->i8 = n % 100;
     msg->i16 = n * 10;
@@ -311,9 +304,9 @@ fill_lcmtest_primitives_t(int n, lcmtest_primitives_t* msg)
     msg->orientation[2] = n;
     msg->orientation[3] = n;
     msg->num_ranges = n;
-    msg->ranges = (int16_t*)malloc(n * sizeof(int16_t));
+    msg->ranges = (int16_t *) malloc(n * sizeof(int16_t));
     int i;
-    for(i=0; i<n; i++)
+    for (i = 0; i < n; i++)
         msg->ranges[i] = i;
     char name_buf[80];
     snprintf(name_buf, 79, "%d", n);
@@ -321,56 +314,48 @@ fill_lcmtest_primitives_t(int n, lcmtest_primitives_t* msg)
     msg->enabled = n % 2;
 }
 
-void
-clear_lcmtest_primitives_t(lcmtest_primitives_t* msg)
+void clear_lcmtest_primitives_t(lcmtest_primitives_t *msg)
 {
     free(msg->ranges);
     free(msg->name);
 }
 
-int
-check_lcmtest2_cross_package_t(const lcmtest2_cross_package_t* msg, int expected)
+int check_lcmtest2_cross_package_t(const lcmtest2_cross_package_t *msg, int expected)
 {
     return check_lcmtest_primitives_t(&msg->primitives, expected) &&
-        check_lcmtest2_another_type_t(&msg->another, expected);
+           check_lcmtest2_another_type_t(&msg->another, expected);
 }
 
-void
-fill_lcmtest2_cross_package_t(int n, lcmtest2_cross_package_t* msg)
+void fill_lcmtest2_cross_package_t(int n, lcmtest2_cross_package_t *msg)
 {
     fill_lcmtest_primitives_t(n, &msg->primitives);
     fill_lcmtest2_another_type_t(n, &msg->another);
 }
 
-void
-clear_lcmtest2_cross_package_t(lcmtest2_cross_package_t* msg)
+void clear_lcmtest2_cross_package_t(lcmtest2_cross_package_t *msg)
 {
     clear_lcmtest_primitives_t(&msg->primitives);
     clear_lcmtest2_another_type_t(&msg->another);
 }
 
-int
-check_lcmtest2_another_type_t(const lcmtest2_another_type_t* msg, int expected)
+int check_lcmtest2_another_type_t(const lcmtest2_another_type_t *msg, int expected)
 {
     int n = expected;
     CHECK_FIELD(msg->val, n, "%d");
     return 1;
 }
 
-void
-fill_lcmtest2_another_type_t(int n, lcmtest2_another_type_t* msg)
+void fill_lcmtest2_another_type_t(int n, lcmtest2_another_type_t *msg)
 {
     msg->val = n;
 }
 
-void
-clear_lcmtest2_another_type_t(lcmtest2_another_type_t* msg)
+void clear_lcmtest2_another_type_t(lcmtest2_another_type_t *msg)
 {
     return;
 }
 
-char*
-make_tmpnam()
+char *make_tmpnam()
 {
 #ifndef WIN32
     return tmpnam(NULL);
@@ -379,8 +364,7 @@ make_tmpnam()
 #endif
 }
 
-void
-free_tmpnam(char* tmpnam)
+void free_tmpnam(char *tmpnam)
 {
 #ifdef WIN32
     free(tmpnam);

--- a/test/c/common.h
+++ b/test/c/common.h
@@ -5,42 +5,42 @@
 extern "C" {
 #endif
 
-#include "lcmtest_primitives_t.h"
-#include "lcmtest_primitives_list_t.h"
-#include "lcmtest_node_t.h"
-#include "lcmtest_multidim_array_t.h"
 #include "lcmtest2_cross_package_t.h"
+#include "lcmtest_multidim_array_t.h"
+#include "lcmtest_node_t.h"
+#include "lcmtest_primitives_list_t.h"
+#include "lcmtest_primitives_t.h"
 
 #ifndef _MSC_VER
-char* _strdup(const char* src);
+char *_strdup(const char *src);
 #endif
 
-int check_lcmtest_multidim_array_t(const lcmtest_multidim_array_t* msg, int expected);
-void fill_lcmtest_multidim_array_t(int num_children, lcmtest_multidim_array_t* result);
-void clear_lcmtest_multidim_array_t(lcmtest_multidim_array_t* msg);
+int check_lcmtest_multidim_array_t(const lcmtest_multidim_array_t *msg, int expected);
+void fill_lcmtest_multidim_array_t(int num_children, lcmtest_multidim_array_t *result);
+void clear_lcmtest_multidim_array_t(lcmtest_multidim_array_t *msg);
 
-int check_lcmtest_node_t(const lcmtest_node_t* msg, int expected);
-void fill_lcmtest_node_t(int num_children, lcmtest_node_t* result);
-void clear_lcmtest_node_t(lcmtest_node_t* msg);
+int check_lcmtest_node_t(const lcmtest_node_t *msg, int expected);
+void fill_lcmtest_node_t(int num_children, lcmtest_node_t *result);
+void clear_lcmtest_node_t(lcmtest_node_t *msg);
 
-int check_lcmtest_primitives_list_t(const lcmtest_primitives_list_t* msg, int expected);
-void fill_lcmtest_primitives_list_t(int num, lcmtest_primitives_list_t* msg);
-void clear_lcmtest_primitives_list_t(lcmtest_primitives_list_t* msg);
+int check_lcmtest_primitives_list_t(const lcmtest_primitives_list_t *msg, int expected);
+void fill_lcmtest_primitives_list_t(int num, lcmtest_primitives_list_t *msg);
+void clear_lcmtest_primitives_list_t(lcmtest_primitives_list_t *msg);
 
-int check_lcmtest_primitives_t(const lcmtest_primitives_t* msg, int expected);
-void fill_lcmtest_primitives_t(int n, lcmtest_primitives_t* msg);
-void clear_lcmtest_primitives_t(lcmtest_primitives_t* msg);
+int check_lcmtest_primitives_t(const lcmtest_primitives_t *msg, int expected);
+void fill_lcmtest_primitives_t(int n, lcmtest_primitives_t *msg);
+void clear_lcmtest_primitives_t(lcmtest_primitives_t *msg);
 
-int check_lcmtest2_cross_package_t(const lcmtest2_cross_package_t* msg, int expected);
-void fill_lcmtest2_cross_package_t(int n, lcmtest2_cross_package_t* msg);
-void clear_lcmtest2_cross_package_t(lcmtest2_cross_package_t* msg);
+int check_lcmtest2_cross_package_t(const lcmtest2_cross_package_t *msg, int expected);
+void fill_lcmtest2_cross_package_t(int n, lcmtest2_cross_package_t *msg);
+void clear_lcmtest2_cross_package_t(lcmtest2_cross_package_t *msg);
 
-int check_lcmtest2_another_type_t(const lcmtest2_another_type_t* msg, int expected);
-void fill_lcmtest2_another_type_t(int n, lcmtest2_another_type_t* msg);
-void clear_lcmtest2_another_type_t(lcmtest2_another_type_t* msg);
+int check_lcmtest2_another_type_t(const lcmtest2_another_type_t *msg, int expected);
+void fill_lcmtest2_another_type_t(int n, lcmtest2_another_type_t *msg);
+void clear_lcmtest2_another_type_t(lcmtest2_another_type_t *msg);
 
-char* make_tmpnam();
-void free_tmpnam(char* tmpnam);
+char *make_tmpnam();
+void free_tmpnam(char *tmpnam);
 
 #ifdef __cplusplus
 }

--- a/test/c/eventlog_test.cpp
+++ b/test/c/eventlog_test.cpp
@@ -1,37 +1,39 @@
+#include <gtest/gtest.h>
 #include <stdlib.h>
 #include <string.h>
-#include <gtest/gtest.h>
 
 #include <lcm/lcm.h>
 #include "common.h"
 
-TEST(LCM_C, EventLogBasic) {
+TEST(LCM_C, EventLogBasic)
+{
     // Open and close a log file.
-    char* fname = make_tmpnam();
+    char *fname = make_tmpnam();
 
-    lcm_eventlog_t* wlog = lcm_eventlog_create(fname, "w");
-    EXPECT_NE((void*)NULL, wlog);
+    lcm_eventlog_t *wlog = lcm_eventlog_create(fname, "w");
+    EXPECT_NE((void *) NULL, wlog);
     lcm_eventlog_destroy(wlog);
 
     free_tmpnam(fname);
 }
 
-TEST(LCM_C, EventLogWriteRead) {
+TEST(LCM_C, EventLogWriteRead)
+{
     // Write some events to a log, then read them back in and check what was
     // read is the same as what was written.
-    char* fname = make_tmpnam();
+    char *fname = make_tmpnam();
 
-    lcm_eventlog_t* wlog = lcm_eventlog_create(fname, "w");
-    EXPECT_NE((void*)NULL, wlog);
+    lcm_eventlog_t *wlog = lcm_eventlog_create(fname, "w");
+    EXPECT_NE((void *) NULL, wlog);
 
-    const char* channel = "CHANNEL_TEST";
+    const char *channel = "CHANNEL_TEST";
     const int channellen = strlen(channel);
     const int datalen = 256;
     char data[datalen];
 
     lcm_eventlog_event_t event;
     event.channellen = channellen;
-    event.channel = const_cast<char*>(channel);
+    event.channel = const_cast<char *>(channel);
     event.datalen = datalen;
     event.data = data;
 
@@ -39,7 +41,7 @@ TEST(LCM_C, EventLogWriteRead) {
     const int num_events = 100;
     char next_byte = 5;
     for (int event_num = 0; event_num < num_events; ++event_num) {
-      event.timestamp = event_num;
+        event.timestamp = event_num;
         for (int byte_num = 0; byte_num < datalen; ++byte_num) {
             data[byte_num] = next_byte;
             next_byte += byte_increment;
@@ -50,14 +52,14 @@ TEST(LCM_C, EventLogWriteRead) {
     lcm_eventlog_destroy(wlog);
 
     // Read the data back in
-    lcm_eventlog_t* rlog = lcm_eventlog_create(fname, "r");
-    EXPECT_NE((void*)NULL, rlog);
+    lcm_eventlog_t *rlog = lcm_eventlog_create(fname, "r");
+    EXPECT_NE((void *) NULL, rlog);
 
-    lcm_eventlog_event_t* revent = NULL;
+    lcm_eventlog_event_t *revent = NULL;
     char expected_next_byte = 5;
     for (int event_num = 0; event_num < num_events; ++event_num) {
         revent = lcm_eventlog_read_next_event(rlog);
-        EXPECT_NE((void*)NULL, revent);
+        EXPECT_NE((void *) NULL, revent);
 
         EXPECT_EQ(channellen, revent->channellen);
         EXPECT_EQ(datalen, revent->datalen);
@@ -67,11 +69,10 @@ TEST(LCM_C, EventLogWriteRead) {
 
         bool bytes_match = true;
         if (datalen == revent->datalen) {
-          for (int byte_num = 0; byte_num < datalen; ++byte_num) {
-              bytes_match &=
-                (((const char*)revent->data)[byte_num] == expected_next_byte);
-              expected_next_byte += byte_increment;
-          }
+            for (int byte_num = 0; byte_num < datalen; ++byte_num) {
+                bytes_match &= (((const char *) revent->data)[byte_num] == expected_next_byte);
+                expected_next_byte += byte_increment;
+            }
         }
         EXPECT_TRUE(bytes_match);
         lcm_eventlog_free_event(revent);
@@ -81,15 +82,16 @@ TEST(LCM_C, EventLogWriteRead) {
     free_tmpnam(fname);
 }
 
-TEST(LCM_C, EventLogCorrupt) {
+TEST(LCM_C, EventLogCorrupt)
+{
     // Tests detection of corrupt data.
-    char* fname = make_tmpnam();
+    char *fname = make_tmpnam();
 
-    lcm_eventlog_t* wlog = lcm_eventlog_create(fname, "w");
-    ASSERT_NE((void*)NULL, wlog);
+    lcm_eventlog_t *wlog = lcm_eventlog_create(fname, "w");
+    ASSERT_NE((void *) NULL, wlog);
 
     // Write two valid events, then garbage, then another valid event.
-    const char* channel = "CHANNEL_TEST";
+    const char *channel = "CHANNEL_TEST";
     const int channellen = strlen(channel);
     const int datalen = 256;
     char data[datalen];
@@ -98,7 +100,7 @@ TEST(LCM_C, EventLogCorrupt) {
     lcm_eventlog_event_t event;
     event.timestamp = 0;
     event.channellen = channellen;
-    event.channel = const_cast<char*>(channel);
+    event.channel = const_cast<char *>(channel);
     event.datalen = datalen;
     event.data = data;
 
@@ -115,15 +117,15 @@ TEST(LCM_C, EventLogCorrupt) {
     lcm_eventlog_destroy(wlog);
 
     // Now try reading the corrupt log back in.
-    lcm_eventlog_t* rlog = lcm_eventlog_create(fname, "r");
+    lcm_eventlog_t *rlog = lcm_eventlog_create(fname, "r");
     // First event should be valid.
-    lcm_eventlog_event_t* revent = lcm_eventlog_read_next_event(rlog);
-    ASSERT_NE((void*)NULL, revent);
+    lcm_eventlog_event_t *revent = lcm_eventlog_read_next_event(rlog);
+    ASSERT_NE((void *) NULL, revent);
     lcm_eventlog_free_event(revent);
 
     // Second event is not because it's not followed by EOF or an event header.
     revent = lcm_eventlog_read_next_event(rlog);
-    EXPECT_EQ((void*)NULL, revent);
+    EXPECT_EQ((void *) NULL, revent);
 
     lcm_eventlog_destroy(rlog);
     free_tmpnam(fname);

--- a/test/c/memq_test.cpp
+++ b/test/c/memq_test.cpp
@@ -1,11 +1,12 @@
+#include <gtest/gtest.h>
 #include <stdlib.h>
 #include <string.h>
-#include <gtest/gtest.h>
 
 #include <lcm/lcm.h>
 
-TEST(LCM_C, MemqConstructDestroy) {
-    lcm_t* lcm = lcm_create("memq://");
+TEST(LCM_C, MemqConstructDestroy)
+{
+    lcm_t *lcm = lcm_create("memq://");
     EXPECT_TRUE(lcm != NULL);
     lcm_destroy(lcm);
 }
@@ -15,16 +16,17 @@ struct MemqSimpleState {
     bool handled;
 };
 
-void MemqSimpleHandler(const lcm_recv_buf_t* rbuf, const char* channel,
-        void* user_data) {
-    std::vector<uint8_t>* received_buf = (std::vector<uint8_t>*)user_data;
+void MemqSimpleHandler(const lcm_recv_buf_t *rbuf, const char *channel, void *user_data)
+{
+    std::vector<uint8_t> *received_buf = (std::vector<uint8_t> *) user_data;
     received_buf->resize(rbuf->data_size);
     memcpy(&(*received_buf)[0], rbuf->data, rbuf->data_size);
 }
 
-TEST(LCM_C, MemqSimple) {
+TEST(LCM_C, MemqSimple)
+{
     // Publish a single message, then subscribe to it and check it's read.
-    lcm_t* lcm = lcm_create("memq://");
+    lcm_t *lcm = lcm_create("memq://");
     const int buf_size = 1024;
     std::vector<uint8_t> buf(buf_size);
     std::vector<uint8_t> received_buf;
@@ -46,18 +48,19 @@ TEST(LCM_C, MemqSimple) {
     lcm_destroy(lcm);
 }
 
-void MemqBufferedHandler(const lcm_recv_buf_t* rbuf, const char* channel,
-        void* user_data) {
-    std::vector<std::vector<uint8_t> >* received_buffers =
-        (std::vector<std::vector<uint8_t> >*)user_data;
+void MemqBufferedHandler(const lcm_recv_buf_t *rbuf, const char *channel, void *user_data)
+{
+    std::vector<std::vector<uint8_t> > *received_buffers =
+        (std::vector<std::vector<uint8_t> > *) user_data;
     std::vector<uint8_t> buf(rbuf->data_size);
     memcpy(&buf[0], rbuf->data, rbuf->data_size);
     received_buffers->push_back(buf);
 }
 
-TEST(LCM_C, MemqBuffered) {
+TEST(LCM_C, MemqBuffered)
+{
     // Publish many messages so that they get buffered up, then read them all.
-    lcm_t* lcm = lcm_create("memq://");
+    lcm_t *lcm = lcm_create("memq://");
     std::vector<std::vector<uint8_t> > received_buffers;
 
     lcm_subscribe(lcm, "channel", MemqBufferedHandler, &received_buffers);
@@ -66,7 +69,7 @@ TEST(LCM_C, MemqBuffered) {
     int buf_size = 100;
     std::vector<std::vector<uint8_t> > buffers(num_bufs);
     for (int buf_num = 0; buf_num < num_bufs; ++buf_num) {
-        std::vector<uint8_t>& buf = buffers[buf_num];
+        std::vector<uint8_t> &buf = buffers[buf_num];
         buf.resize(buf_size);
         for (int byte_index = 0; byte_index < buf_size; ++byte_index) {
             buf[byte_index] = rand() % 255;
@@ -83,33 +86,34 @@ TEST(LCM_C, MemqBuffered) {
     lcm_destroy(lcm);
 }
 
-void MemqTimeoutHandler(const lcm_recv_buf_t* rbuf, const char* channel,
-        void* user_data) {
-    int* msg_handled = (int*)user_data;
+void MemqTimeoutHandler(const lcm_recv_buf_t *rbuf, const char *channel, void *user_data)
+{
+    int *msg_handled = (int *) user_data;
     *msg_handled = 1;
 }
 
-TEST(LCM_C, MemqTimeout) {
-  // Test various usages of lcm_handle_timeout() using the memq provider
-  lcm_t* lcm = lcm_create("memq://");
+TEST(LCM_C, MemqTimeout)
+{
+    // Test various usages of lcm_handle_timeout() using the memq provider
+    lcm_t *lcm = lcm_create("memq://");
 
-  // No messages available.  Call should timeout immediately.
-  EXPECT_EQ(0, lcm_handle_timeout(lcm, 0));
+    // No messages available.  Call should timeout immediately.
+    EXPECT_EQ(0, lcm_handle_timeout(lcm, 0));
 
-  // No messages available.  Call should timeout in a few ms.
-  EXPECT_EQ(0, lcm_handle_timeout(lcm, 10));
+    // No messages available.  Call should timeout in a few ms.
+    EXPECT_EQ(0, lcm_handle_timeout(lcm, 10));
 
-  // Invalid timeout specification should result in an error.
-  EXPECT_GT(0, lcm_handle_timeout(lcm, -1));
+    // Invalid timeout specification should result in an error.
+    EXPECT_GT(0, lcm_handle_timeout(lcm, -1));
 
-  // Subscribe to and publish on a channel.  Expect that the message gets
-  // handled with an ample timeout.
-  int msg_handled = 0;
-  lcm_subscribe(lcm, "channel", MemqTimeoutHandler, &msg_handled);
-  lcm_publish(lcm, "channel", "", 0);
-  EXPECT_LT(0, lcm_handle_timeout(lcm, 10000));
+    // Subscribe to and publish on a channel.  Expect that the message gets
+    // handled with an ample timeout.
+    int msg_handled = 0;
+    lcm_subscribe(lcm, "channel", MemqTimeoutHandler, &msg_handled);
+    lcm_publish(lcm, "channel", "", 0);
+    EXPECT_LT(0, lcm_handle_timeout(lcm, 10000));
 
-  EXPECT_EQ(1, msg_handled);
+    EXPECT_EQ(1, msg_handled);
 
-  lcm_destroy(lcm);
+    lcm_destroy(lcm);
 }

--- a/test/c/server.c
+++ b/test/c/server.c
@@ -133,7 +133,9 @@ int main(int argc, char** argv)
     lcmtest2_cross_package_t_subscribe(g_lcm, "test_lcmtest2_cross_package_t",
           &lcmtest2_cross_package_t_handler, NULL);
 
-    while (lcm_handle(g_lcm) == 0 && !g_quit) {}
+    while (lcm_handle(g_lcm) == 0 && !g_quit) {
+        // Do nothing
+    }
 
     lcm_destroy(g_lcm);
     return 0;

--- a/test/c/server.c
+++ b/test/c/server.c
@@ -1,10 +1,10 @@
+#include <lcm/lcm.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <lcm/lcm.h>
 
 #include "common.h"
 
-static lcm_t* g_lcm = NULL;
+static lcm_t *g_lcm = NULL;
 static int g_quit = 0;
 static int g_lcmtest_primitives_t_count = 0;
 static int g_lcmtest_primitives_list_t_count = 0;
@@ -12,8 +12,8 @@ static int g_lcmtest_node_t_count = 0;
 static int g_lcmtest_multidim_array_t_count = 0;
 static int g_lcmtest2_cross_package_t_count = 0;
 
-static void
-reset_counts() {
+static void reset_counts()
+{
     g_lcmtest_primitives_t_count = 0;
     g_lcmtest_primitives_list_t_count = 0;
     g_lcmtest_node_t_count = 0;
@@ -21,10 +21,8 @@ reset_counts() {
     g_lcmtest2_cross_package_t_count = 0;
 }
 
-static void
-lcmtest_primitives_t_handler(const lcm_recv_buf_t* rbuf,
-    const char* channel,
-    const lcmtest_primitives_t* msg, void* user)
+static void lcmtest_primitives_t_handler(const lcm_recv_buf_t *rbuf, const char *channel,
+                                         const lcmtest_primitives_t *msg, void *user)
 {
     // Reset all counts (maybe)
     if (msg->i64 == 0) {
@@ -32,106 +30,87 @@ lcmtest_primitives_t_handler(const lcm_recv_buf_t* rbuf,
     }
 
     lcmtest_primitives_t reply;
-    fill_lcmtest_primitives_t(g_lcmtest_primitives_t_count + 1,
-        &reply);
-    lcmtest_primitives_t_publish(g_lcm,
-        "test_lcmtest_primitives_t_reply", &reply);
+    fill_lcmtest_primitives_t(g_lcmtest_primitives_t_count + 1, &reply);
+    lcmtest_primitives_t_publish(g_lcm, "test_lcmtest_primitives_t_reply", &reply);
     clear_lcmtest_primitives_t(&reply);
     g_lcmtest_primitives_t_count++;
 }
 
-static void
-lcmtest_primitives_list_t_handler(const lcm_recv_buf_t* rbuf,
-    const char* channel,
-    const lcmtest_primitives_list_t* msg, void* user)
+static void lcmtest_primitives_list_t_handler(const lcm_recv_buf_t *rbuf, const char *channel,
+                                              const lcmtest_primitives_list_t *msg, void *user)
 {
     lcmtest_primitives_list_t reply;
-    fill_lcmtest_primitives_list_t(g_lcmtest_primitives_list_t_count + 1,
-        &reply);
-    lcmtest_primitives_list_t_publish(g_lcm,
-        "test_lcmtest_primitives_list_t_reply", &reply);
+    fill_lcmtest_primitives_list_t(g_lcmtest_primitives_list_t_count + 1, &reply);
+    lcmtest_primitives_list_t_publish(g_lcm, "test_lcmtest_primitives_list_t_reply", &reply);
     clear_lcmtest_primitives_list_t(&reply);
     g_lcmtest_primitives_list_t_count++;
 }
 
-static void
-lcmtest_node_t_handler(const lcm_recv_buf_t* rbuf,
-    const char* channel,
-    const lcmtest_node_t* msg, void* user)
+static void lcmtest_node_t_handler(const lcm_recv_buf_t *rbuf, const char *channel,
+                                   const lcmtest_node_t *msg, void *user)
 {
     lcmtest_node_t reply;
-    fill_lcmtest_node_t(g_lcmtest_node_t_count + 1,
-        &reply);
-    lcmtest_node_t_publish(g_lcm, "test_lcmtest_node_t_reply",
-        &reply);
+    fill_lcmtest_node_t(g_lcmtest_node_t_count + 1, &reply);
+    lcmtest_node_t_publish(g_lcm, "test_lcmtest_node_t_reply", &reply);
     clear_lcmtest_node_t(&reply);
     g_lcmtest_node_t_count++;
 }
 
-static void
-lcmtest_multidim_array_t_handler(const lcm_recv_buf_t* rbuf,
-    const char* channel,
-    const lcmtest_multidim_array_t* msg, void* user)
+static void lcmtest_multidim_array_t_handler(const lcm_recv_buf_t *rbuf, const char *channel,
+                                             const lcmtest_multidim_array_t *msg, void *user)
 {
     lcmtest_multidim_array_t reply;
-    fill_lcmtest_multidim_array_t(g_lcmtest_multidim_array_t_count + 1,
-        &reply);
-    lcmtest_multidim_array_t_publish(g_lcm,
-        "test_lcmtest_multidim_array_t_reply", &reply);
+    fill_lcmtest_multidim_array_t(g_lcmtest_multidim_array_t_count + 1, &reply);
+    lcmtest_multidim_array_t_publish(g_lcm, "test_lcmtest_multidim_array_t_reply", &reply);
     clear_lcmtest_multidim_array_t(&reply);
     g_lcmtest_multidim_array_t_count++;
 }
 
-static void
-lcmtest2_cross_package_t_handler(const lcm_recv_buf_t* rbuf,
-    const char* channel, const lcmtest2_cross_package_t* msg, void* user)
+static void lcmtest2_cross_package_t_handler(const lcm_recv_buf_t *rbuf, const char *channel,
+                                             const lcmtest2_cross_package_t *msg, void *user)
 {
     lcmtest2_cross_package_t reply;
-    fill_lcmtest2_cross_package_t(g_lcmtest2_cross_package_t_count + 1,
-        &reply);
-    lcmtest2_cross_package_t_publish(g_lcm,
-        "test_lcmtest2_cross_package_t_reply", &reply);
+    fill_lcmtest2_cross_package_t(g_lcmtest2_cross_package_t_count + 1, &reply);
+    lcmtest2_cross_package_t_publish(g_lcm, "test_lcmtest2_cross_package_t_reply", &reply);
     clear_lcmtest2_cross_package_t(&reply);
     g_lcmtest2_cross_package_t_count++;
 }
 
-static void
-echo_handler(const lcm_recv_buf_t *rbuf, const char* channel, void* user)
+static void echo_handler(const lcm_recv_buf_t *rbuf, const char *channel, void *user)
 {
     lcm_publish(g_lcm, "TEST_ECHO_REPLY", rbuf->data, rbuf->data_size);
 }
 
-static void
-quit_handler() {
+static void quit_handler()
+{
     g_quit = 1;
 }
 
 // ============================
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
     g_lcm = lcm_create(NULL);
-    if(!g_lcm)
+    if (!g_lcm)
         return 1;
 
-    lcm_subscribe(g_lcm, "TEST_QUIT", (lcm_msg_handler_t)&quit_handler, NULL);
+    lcm_subscribe(g_lcm, "TEST_QUIT", (lcm_msg_handler_t) &quit_handler, NULL);
 
     lcm_subscribe(g_lcm, "TEST_ECHO", &echo_handler, NULL);
 
     lcmtest_primitives_t_subscribe(g_lcm, "test_lcmtest_primitives_t",
-          &lcmtest_primitives_t_handler, NULL);
+                                   &lcmtest_primitives_t_handler, NULL);
 
     lcmtest_primitives_list_t_subscribe(g_lcm, "test_lcmtest_primitives_list_t",
-          &lcmtest_primitives_list_t_handler, NULL);
+                                        &lcmtest_primitives_list_t_handler, NULL);
 
-    lcmtest_node_t_subscribe(g_lcm, "test_lcmtest_node_t",
-          &lcmtest_node_t_handler, NULL);
+    lcmtest_node_t_subscribe(g_lcm, "test_lcmtest_node_t", &lcmtest_node_t_handler, NULL);
 
     lcmtest_multidim_array_t_subscribe(g_lcm, "test_lcmtest_multidim_array_t",
-          &lcmtest_multidim_array_t_handler, NULL);
+                                       &lcmtest_multidim_array_t_handler, NULL);
 
     lcmtest2_cross_package_t_subscribe(g_lcm, "test_lcmtest2_cross_package_t",
-          &lcmtest2_cross_package_t_handler, NULL);
+                                       &lcmtest2_cross_package_t_handler, NULL);
 
     while (lcm_handle(g_lcm) == 0 && !g_quit) {
         // Do nothing

--- a/test/c/udpm_test.cpp
+++ b/test/c/udpm_test.cpp
@@ -6,52 +6,54 @@
 
 #include <lcm/lcm.h>
 
-TEST(LCM_C, InvalidCreation) {
-  lcm_t* lcm = lcm_create("udpm://asdf");
-  EXPECT_EQ(NULL, lcm);
+TEST(LCM_C, InvalidCreation)
+{
+    lcm_t *lcm = lcm_create("udpm://asdf");
+    EXPECT_EQ(NULL, lcm);
 
-  lcm = lcm_create("udpm://0.0.0.0");
-  EXPECT_EQ(NULL, lcm);
+    lcm = lcm_create("udpm://0.0.0.0");
+    EXPECT_EQ(NULL, lcm);
 
-  lcm = lcm_create("udpm://239.255.1.1:65536");
-  EXPECT_EQ(NULL, lcm);
+    lcm = lcm_create("udpm://239.255.1.1:65536");
+    EXPECT_EQ(NULL, lcm);
 }
 
 #ifndef WIN32
-static void
-empty_handler(const lcm_recv_buf_t* /* unused */, const char* /* unused */, void * /* unused */)
+static void empty_handler(const lcm_recv_buf_t * /* unused */, const char * /* unused */,
+                          void * /* unused */)
 {
 }
 
-TEST(LCM_C, QueueSize) {
-  lcm_t* lcm = lcm_create(NULL);
-  ASSERT_NE((void*)NULL, lcm);
+TEST(LCM_C, QueueSize)
+{
+    lcm_t *lcm = lcm_create(NULL);
+    ASSERT_NE((void *) NULL, lcm);
 
-  lcm_subscription_t* subs = lcm_subscribe(lcm, "channel", empty_handler, NULL);
-  EXPECT_EQ(0, lcm_subscription_get_queue_size(subs));
+    lcm_subscription_t *subs = lcm_subscribe(lcm, "channel", empty_handler, NULL);
+    EXPECT_EQ(0, lcm_subscription_get_queue_size(subs));
 
-  // Set a small queue size
-  lcm_subscription_set_queue_capacity(subs, 5);
+    // Set a small queue size
+    lcm_subscription_set_queue_capacity(subs, 5);
 
-  // publish a bunch of messages
-  for (int i = 0; i < 10; i++) {
-    lcm_publish(lcm, "channel", "", 0);
-  }
+    // publish a bunch of messages
+    for (int i = 0; i < 10; i++) {
+        lcm_publish(lcm, "channel", "", 0);
+    }
 
-  // sleep for 100 ms. Assume that this is enough time for the messages to get
-  // queued up.
-  struct timespec sleeptime;
-  sleeptime.tv_sec = 0;
-  sleeptime.tv_nsec = 100000000;
-  nanosleep(&sleeptime, NULL);
+    // sleep for 100 ms. Assume that this is enough time for the messages to get
+    // queued up.
+    struct timespec sleeptime;
+    sleeptime.tv_sec = 0;
+    sleeptime.tv_nsec = 100000000;
+    nanosleep(&sleeptime, NULL);
 
-  // Handle messages one by one
-  for (int i = 5; i > 0; i--) {
-    EXPECT_EQ(i, lcm_subscription_get_queue_size(subs));
-    ASSERT_GT(lcm_handle_timeout(lcm, 500), 0);
-    EXPECT_EQ(i - 1, lcm_subscription_get_queue_size(subs));
-  }
+    // Handle messages one by one
+    for (int i = 5; i > 0; i--) {
+        EXPECT_EQ(i, lcm_subscription_get_queue_size(subs));
+        ASSERT_GT(lcm_handle_timeout(lcm, 500), 0);
+        EXPECT_EQ(i - 1, lcm_subscription_get_queue_size(subs));
+    }
 
-  lcm_destroy(lcm);
+    lcm_destroy(lcm);
 }
 #endif

--- a/test/cpp/client.cpp
+++ b/test/cpp/client.cpp
@@ -1,150 +1,159 @@
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <time.h>
 #include <gtest/gtest.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
 
 #include <lcm/lcm.h>
 
 #include "common.hpp"
 
-#define info(...) do { printf("cpp_client: "); printf(__VA_ARGS__); \
-  printf("\n"); } while(0)
+#define info(...)               \
+    do {                        \
+        printf("cpp_client: "); \
+        printf(__VA_ARGS__);    \
+        printf("\n");           \
+    } while (0)
 
 class EchoTest {
- public:
-  EchoTest()
-      : lcm_(),
-        num_trials_(100),
-        echo_msg_len_(0),
-        echo_data_(NULL),
-        response_count_(0),
-        subscription_(),
-        test_channel_("TEST_ECHO") {
-  }
+  public:
+    EchoTest()
+        : lcm_(),
+          num_trials_(100),
+          echo_msg_len_(0),
+          echo_data_(NULL),
+          response_count_(0),
+          subscription_(),
+          test_channel_("TEST_ECHO")
+    {
+    }
 
-  bool Run(void) {
-    int maxlen = 10000;
-    int minlen = 10;
-    echo_data_ = (uint8_t*) malloc(maxlen);
-    subscription_ = lcm_.subscribe(test_channel_ + "_REPLY",
-                                    &EchoTest::Handler, this);
-    response_count_ = 0;
+    bool Run(void)
+    {
+        int maxlen = 10000;
+        int minlen = 10;
+        echo_data_ = (uint8_t *) malloc(maxlen);
+        subscription_ = lcm_.subscribe(test_channel_ + "_REPLY", &EchoTest::Handler, this);
+        response_count_ = 0;
 
-    for (int iter = 0; iter < num_trials_; iter++) {
-      echo_msg_len_ = rand() % (maxlen - minlen) + minlen;
-      for (int i = 0; i < echo_msg_len_; i++)
-        echo_data_[i] = rand() % 256;
+        for (int iter = 0; iter < num_trials_; iter++) {
+            echo_msg_len_ = rand() % (maxlen - minlen) + minlen;
+            for (int i = 0; i < echo_msg_len_; i++)
+                echo_data_[i] = rand() % 256;
 
-      lcm_.publish(test_channel_, echo_data_, echo_msg_len_);
+            lcm_.publish(test_channel_, echo_data_, echo_msg_len_);
 
-      if (lcm_.handleTimeout(500) <= 0 || (response_count_ != iter + 1)) {
-        info("echo test failed to receive response on iteration %d", iter);
+            if (lcm_.handleTimeout(500) <= 0 || (response_count_ != iter + 1)) {
+                info("echo test failed to receive response on iteration %d", iter);
+                free(echo_data_);
+                return false;
+            }
+        }
+
+        lcm_.unsubscribe(subscription_);
         free(echo_data_);
-        return false;
-      }
+        return true;
     }
 
-    lcm_.unsubscribe(subscription_);
-    free(echo_data_);
-    return true;
-  }
+  private:
+    void Handler(const lcm::ReceiveBuffer *rbuf, const std::string &channel)
+    {
+        if (rbuf->data_size != echo_msg_len_)
+            return;
+        if (memcmp(rbuf->data, echo_data_, rbuf->data_size))
+            return;
+        response_count_++;
+    }
 
- private:
-  void Handler(const lcm::ReceiveBuffer *rbuf, const std::string& channel) {
-    if (rbuf->data_size != echo_msg_len_)
-      return;
-    if (memcmp(rbuf->data, echo_data_, rbuf->data_size))
-      return;
-    response_count_++;
-  }
-
-  lcm::LCM lcm_;
-  int num_trials_;
-  int echo_msg_len_;
-  uint8_t* echo_data_;
-  int response_count_;
-  lcm::Subscription* subscription_;
-  std::string test_channel_;
+    lcm::LCM lcm_;
+    int num_trials_;
+    int echo_msg_len_;
+    uint8_t *echo_data_;
+    int response_count_;
+    lcm::Subscription *subscription_;
+    std::string test_channel_;
 };
 
-TEST(LCM_CPP, Echo) {
-  srand(time(NULL));
+TEST(LCM_CPP, Echo)
+{
+    srand(time(NULL));
 
-  EXPECT_TRUE(EchoTest().Run());
+    EXPECT_TRUE(EchoTest().Run());
 }
 
-template<class LcmType>
+template <class LcmType>
 class TypedTest {
- public:
-  TypedTest(const std::string test_name, int num_trials)
-      : lcm_(),
-      response_count_(0),
-      num_trials_(num_trials),
-      subscription_(),
-      test_channel_(test_name) {
-  }
-
-  bool Run(void) {
-    LcmType msg;
-    lcm::Subscription* subscription = lcm_.subscribe(
-        test_channel_ + "_reply", &TypedTest<LcmType>::Handler, this);
-    bool result = true;
-    for (int trial = 0; trial < num_trials_ && result; trial++) {
-      FillLcmType(trial, &msg);
-      lcm_.publish(test_channel_, &msg);
-      if (lcm_.handleTimeout(500) <= 0) {
-        info("%s test: Timeout waiting for reply", test_channel_.c_str());
-        result = false;
-        break;
-      } else if (response_count_ != trial + 1) {
-        info("%s test: failed on iteration %d", test_channel_.c_str(), trial);
-        result = false;
-        break;
-      }
-      ClearLcmType(&msg);
+  public:
+    TypedTest(const std::string test_name, int num_trials)
+        : lcm_(),
+          response_count_(0),
+          num_trials_(num_trials),
+          subscription_(),
+          test_channel_(test_name)
+    {
     }
-    lcm_.unsubscribe(subscription);
-    return result;
-  }
 
- private:
-  void Handler(const lcm::ReceiveBuffer* rbuf, const std::string& channel,
-               const LcmType* msg) {
-    if (CheckLcmType(msg, response_count_ + 1)) {
-      response_count_++;
-      return;
+    bool Run(void)
+    {
+        LcmType msg;
+        lcm::Subscription *subscription =
+            lcm_.subscribe(test_channel_ + "_reply", &TypedTest<LcmType>::Handler, this);
+        bool result = true;
+        for (int trial = 0; trial < num_trials_ && result; trial++) {
+            FillLcmType(trial, &msg);
+            lcm_.publish(test_channel_, &msg);
+            if (lcm_.handleTimeout(500) <= 0) {
+                info("%s test: Timeout waiting for reply", test_channel_.c_str());
+                result = false;
+                break;
+            } else if (response_count_ != trial + 1) {
+                info("%s test: failed on iteration %d", test_channel_.c_str(), trial);
+                result = false;
+                break;
+            }
+            ClearLcmType(&msg);
+        }
+        lcm_.unsubscribe(subscription);
+        return result;
     }
-  }
 
-  lcm::LCM lcm_;
-  int response_count_;
-  int num_trials_;
-  lcm::Subscription* subscription_;
-  std::string test_channel_;
+  private:
+    void Handler(const lcm::ReceiveBuffer *rbuf, const std::string &channel, const LcmType *msg)
+    {
+        if (CheckLcmType(msg, response_count_ + 1)) {
+            response_count_++;
+            return;
+        }
+    }
+
+    lcm::LCM lcm_;
+    int response_count_;
+    int num_trials_;
+    lcm::Subscription *subscription_;
+    std::string test_channel_;
 };
 
-TEST(LCM_CPP, primitives_t) {
-    EXPECT_TRUE(TypedTest<lcmtest::primitives_t>("test_lcmtest_primitives_t",
-                                          1000).Run());
+TEST(LCM_CPP, primitives_t)
+{
+    EXPECT_TRUE(TypedTest<lcmtest::primitives_t>("test_lcmtest_primitives_t", 1000).Run());
 }
 
-TEST(LCM_CPP, primitives_list_t) {
-    EXPECT_TRUE(TypedTest<lcmtest::primitives_list_t>(
-                "test_lcmtest_primitives_list_t", 100).Run());
+TEST(LCM_CPP, primitives_list_t)
+{
+    EXPECT_TRUE(TypedTest<lcmtest::primitives_list_t>("test_lcmtest_primitives_list_t", 100).Run());
 }
 
-TEST(LCM_CPP, node_t) {
-    EXPECT_TRUE(TypedTest<lcmtest::node_t>("test_lcmtest_node_t",
-                                          7).Run());
+TEST(LCM_CPP, node_t)
+{
+    EXPECT_TRUE(TypedTest<lcmtest::node_t>("test_lcmtest_node_t", 7).Run());
 }
 
-TEST(LCM_CPP, multidim_array_t) {
-    EXPECT_TRUE(TypedTest<lcmtest::multidim_array_t>(
-          "test_lcmtest_multidim_array_t", 5).Run());
+TEST(LCM_CPP, multidim_array_t)
+{
+    EXPECT_TRUE(TypedTest<lcmtest::multidim_array_t>("test_lcmtest_multidim_array_t", 5).Run());
 }
 
-TEST(LCM_CPP, cross_package_t) {
-    EXPECT_TRUE(TypedTest<lcmtest2::cross_package_t>(
-          "test_lcmtest2_cross_package_t", 100).Run());
+TEST(LCM_CPP, cross_package_t)
+{
+    EXPECT_TRUE(TypedTest<lcmtest2::cross_package_t>("test_lcmtest2_cross_package_t", 100).Run());
 }

--- a/test/cpp/common.cpp
+++ b/test/cpp/common.cpp
@@ -1,15 +1,19 @@
-#include <stdio.h>
 #include <inttypes.h>
+#include <stdio.h>
 
 #include "common.hpp"
 
-#define info(...) do { fprintf(stderr, "cpp_client: "); \
-  fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); } while(0)
+#define info(...)                        \
+    do {                                 \
+        fprintf(stderr, "cpp_client: "); \
+        fprintf(stderr, __VA_ARGS__);    \
+        fprintf(stderr, "\n");           \
+    } while (0)
 
-#define CHECK_FIELD(field, expected, fmt) \
-    if((field) != (expected)) { \
+#define CHECK_FIELD(field, expected, fmt)                                                     \
+    if ((field) != (expected)) {                                                              \
         info("Expected " #field " to be: " fmt ", got " fmt " instead", (expected), (field)); \
-        return 0; \
+        return 0;                                                                             \
     }
 
 #if defined(_MSC_VER) && _MSC_VER < 1900
@@ -43,166 +47,172 @@ inline int c99_snprintf(char *outBuf, size_t size, const char *format, ...)
 
 #endif
 
-int CheckLcmType(const lcmtest::multidim_array_t* msg, int expected) {
-  CHECK_FIELD(msg->size_a, expected, "%d");
-  CHECK_FIELD(msg->size_b, expected, "%d");
-  CHECK_FIELD(msg->size_c, expected, "%d");
+int CheckLcmType(const lcmtest::multidim_array_t *msg, int expected)
+{
+    CHECK_FIELD(msg->size_a, expected, "%d");
+    CHECK_FIELD(msg->size_b, expected, "%d");
+    CHECK_FIELD(msg->size_c, expected, "%d");
 
-  int i, j, k;
-  int n = 0;
-  // data
-  for (i = 0; i < msg->size_a; i++) {
-    for (j = 0; j < msg->size_b; j++) {
-      for (k = 0; k < msg->size_c; k++) {
-        CHECK_FIELD(msg->data[i][j][k], n, "%d");
-        n++;
-      }
+    int i, j, k;
+    int n = 0;
+    // data
+    for (i = 0; i < msg->size_a; i++) {
+        for (j = 0; j < msg->size_b; j++) {
+            for (k = 0; k < msg->size_c; k++) {
+                CHECK_FIELD(msg->data[i][j][k], n, "%d");
+                n++;
+            }
+        }
     }
-  }
 
-  // strarray
-  char expected_buf[80];
-  n = 0;
-  for (i = 0; i < 2; i++) {
-    for (k = 0; k < msg->size_c; k++) {
-      snprintf(expected_buf, 79, "%d", n);
-      if (strcmp(expected_buf, msg->strarray[i][k].c_str())) {
-        info("Expected msg->strarray[%d][%d] to be %s, got %s instead", i, k,
-             expected_buf, msg->strarray[i][k].c_str());
-        return 0;
-      }
-      n++;
+    // strarray
+    char expected_buf[80];
+    n = 0;
+    for (i = 0; i < 2; i++) {
+        for (k = 0; k < msg->size_c; k++) {
+            snprintf(expected_buf, 79, "%d", n);
+            if (strcmp(expected_buf, msg->strarray[i][k].c_str())) {
+                info("Expected msg->strarray[%d][%d] to be %s, got %s instead", i, k, expected_buf,
+                     msg->strarray[i][k].c_str());
+                return 0;
+            }
+            n++;
+        }
     }
-  }
 
-  return 1;
-}
-
-void FillLcmType(int num, lcmtest::multidim_array_t* msg) {
-  msg->size_a = num;
-  msg->size_b = num;
-  msg->size_c = num;
-
-  msg->data.resize(num);
-  int i, j, k;
-  int n = 0;
-  // data
-  for (i = 0; i < num; i++) {
-    msg->data[i].resize(num);
-    for (j = 0; j < num; j++) {
-      msg->data[i][j].resize(num);
-      for (k = 0; k < num; k++) {
-        msg->data[i][j][k] = n;
-        n++;
-      }
-    }
-  }
-
-  char buf[80];
-  // strarray
-  msg->strarray.resize(2);
-  n = 0;
-  for (i = 0; i < 2; i++) {
-    msg->strarray[i].resize(msg->size_c);
-    for (k = 0; k < msg->size_c; k++) {
-      snprintf(buf, 79, "%d", n);
-      msg->strarray[i][k] = buf;
-      n++;
-    }
-  }
-}
-
-void ClearLcmType(lcmtest::multidim_array_t* msg) {
-  int i, j, k;
-  // data
-  for (i = 0; i < msg->size_a; i++) {
-    for (j = 0; j < msg->size_b; j++) {
-      msg->data[i][j].clear();
-    }
-    msg->data[i].clear();
-  }
-  msg->data.clear();
-
-  // strarray
-  for (i = 0; i < 2; i++) {
-    for (k = 0; k < msg->size_c; k++) {
-      msg->strarray[i][k].clear();
-    }
-    msg->strarray[i].clear();
-  }
-}
-
-int CheckLcmType(const lcmtest::node_t* msg, int expected) {
-  CHECK_FIELD(msg->num_children, expected, "%d");
-  if (!msg->num_children)
     return 1;
-
-  int i;
-  for (i = 0; i < msg->num_children; i++) {
-    const lcmtest::node_t* child = &msg->children[i];
-    if (!CheckLcmType(child, msg->num_children - 1))
-      return 0;
-  }
-  return 1;
 }
 
-void FillLcmType(int num_children, lcmtest::node_t* result) {
-  result->num_children = num_children;
-  if (!num_children) {
-    result->children.clear();
-    return;
-  }
-  result->children.resize(num_children);
-  for (int i = 0; i < num_children; i++) {
-    FillLcmType(num_children - 1, &result->children[i]);
-  }
+void FillLcmType(int num, lcmtest::multidim_array_t *msg)
+{
+    msg->size_a = num;
+    msg->size_b = num;
+    msg->size_c = num;
+
+    msg->data.resize(num);
+    int i, j, k;
+    int n = 0;
+    // data
+    for (i = 0; i < num; i++) {
+        msg->data[i].resize(num);
+        for (j = 0; j < num; j++) {
+            msg->data[i][j].resize(num);
+            for (k = 0; k < num; k++) {
+                msg->data[i][j][k] = n;
+                n++;
+            }
+        }
+    }
+
+    char buf[80];
+    // strarray
+    msg->strarray.resize(2);
+    n = 0;
+    for (i = 0; i < 2; i++) {
+        msg->strarray[i].resize(msg->size_c);
+        for (k = 0; k < msg->size_c; k++) {
+            snprintf(buf, 79, "%d", n);
+            msg->strarray[i][k] = buf;
+            n++;
+        }
+    }
 }
 
-void ClearLcmType(lcmtest::node_t* msg) {
-  for (int i = 0; i < msg->num_children; i++) {
-    ClearLcmType(&msg->children[i]);
-  }
-  msg->children.clear();
+void ClearLcmType(lcmtest::multidim_array_t *msg)
+{
+    int i, j, k;
+    // data
+    for (i = 0; i < msg->size_a; i++) {
+        for (j = 0; j < msg->size_b; j++) {
+            msg->data[i][j].clear();
+        }
+        msg->data[i].clear();
+    }
+    msg->data.clear();
+
+    // strarray
+    for (i = 0; i < 2; i++) {
+        for (k = 0; k < msg->size_c; k++) {
+            msg->strarray[i][k].clear();
+        }
+        msg->strarray[i].clear();
+    }
 }
 
-int CheckLcmType(const lcmtest::primitives_list_t* msg, int expected)
+int CheckLcmType(const lcmtest::node_t *msg, int expected)
+{
+    CHECK_FIELD(msg->num_children, expected, "%d");
+    if (!msg->num_children)
+        return 1;
+
+    int i;
+    for (i = 0; i < msg->num_children; i++) {
+        const lcmtest::node_t *child = &msg->children[i];
+        if (!CheckLcmType(child, msg->num_children - 1))
+            return 0;
+    }
+    return 1;
+}
+
+void FillLcmType(int num_children, lcmtest::node_t *result)
+{
+    result->num_children = num_children;
+    if (!num_children) {
+        result->children.clear();
+        return;
+    }
+    result->children.resize(num_children);
+    for (int i = 0; i < num_children; i++) {
+        FillLcmType(num_children - 1, &result->children[i]);
+    }
+}
+
+void ClearLcmType(lcmtest::node_t *msg)
+{
+    for (int i = 0; i < msg->num_children; i++) {
+        ClearLcmType(&msg->children[i]);
+    }
+    msg->children.clear();
+}
+
+int CheckLcmType(const lcmtest::primitives_list_t *msg, int expected)
 {
     CHECK_FIELD(msg->num_items, expected, "%d");
-    for(int n=0; n<expected; n++)
-    {
-        const lcmtest::primitives_t* ex = &msg->items[n];
+    for (int n = 0; n < expected; n++) {
+        const lcmtest::primitives_t *ex = &msg->items[n];
         CHECK_FIELD(ex->i8, -(n % 100), "%d");
         CHECK_FIELD(ex->i16, -n * 10, "%d");
         CHECK_FIELD(ex->i64, (int64_t)(-n * 10000), "%jd");
-        CHECK_FIELD(ex->position[0], (double)-n, "%f");
-        CHECK_FIELD(ex->position[1], (double)-n, "%f");
-        CHECK_FIELD(ex->position[2], (double)-n, "%f");
-        CHECK_FIELD(ex->orientation[0], (double)-n, "%f");
-        CHECK_FIELD(ex->orientation[1], (double)-n, "%f");
-        CHECK_FIELD(ex->orientation[2], (double)-n, "%f");
-        CHECK_FIELD(ex->orientation[3], (double)-n, "%f");
+        CHECK_FIELD(ex->position[0], (double) -n, "%f");
+        CHECK_FIELD(ex->position[1], (double) -n, "%f");
+        CHECK_FIELD(ex->position[2], (double) -n, "%f");
+        CHECK_FIELD(ex->orientation[0], (double) -n, "%f");
+        CHECK_FIELD(ex->orientation[1], (double) -n, "%f");
+        CHECK_FIELD(ex->orientation[2], (double) -n, "%f");
+        CHECK_FIELD(ex->orientation[3], (double) -n, "%f");
         CHECK_FIELD(ex->num_ranges, n, "%d");
         int i;
-        for(i=0; i<n; i++)
+        for (i = 0; i < n; i++)
             CHECK_FIELD(ex->ranges[i], -i, "%d");
         char expected_name[100];
         sprintf(expected_name, "%d", -n);
-        if(strcmp(expected_name, ex->name.c_str())) {
-            info("Expected msg->items[%d].name to be %s, got %s instead", n, expected_name, ex->name.c_str());
+        if (strcmp(expected_name, ex->name.c_str())) {
+            info("Expected msg->items[%d].name to be %s, got %s instead", n, expected_name,
+                 ex->name.c_str());
             return 0;
         }
-        CHECK_FIELD(ex->enabled, (int)((n+1)%2), "%d");
+        CHECK_FIELD(ex->enabled, (int) ((n + 1) % 2), "%d");
     }
     return 1;
 }
 
-void FillLcmType(int num, lcmtest::primitives_list_t* msg)
+void FillLcmType(int num, lcmtest::primitives_list_t *msg)
 {
     int n;
     msg->num_items = num;
     msg->items.resize(msg->num_items);
-    for(n=0; n<num; n++) {
-        lcmtest::primitives_t* ex = &msg->items[n];
+    for (n = 0; n < num; n++) {
+        lcmtest::primitives_t *ex = &msg->items[n];
         ex->i8 = -(n % 100);
         ex->i16 = -n * 10;
         ex->i64 = -n * 10000;
@@ -216,102 +226,108 @@ void FillLcmType(int num, lcmtest::primitives_list_t* msg)
         ex->num_ranges = n;
         ex->ranges.resize(n);
         int i;
-        for(i=0; i<n; i++) {
+        for (i = 0; i < n; i++) {
             ex->ranges[i] = -i;
         }
         char name[100];
         snprintf(name, 99, "%d", -n);
         ex->name = name;
-        ex->enabled = (n+1) % 2;
+        ex->enabled = (n + 1) % 2;
     }
 }
 
-void ClearLcmType(lcmtest::primitives_list_t* msg)
+void ClearLcmType(lcmtest::primitives_list_t *msg)
 {
     msg->items.clear();
 }
 
-int CheckLcmType(const lcmtest::primitives_t* msg, int expected) {
-  int n = expected;
-  CHECK_FIELD(msg->i8, n % 100, "%d");
-  CHECK_FIELD(msg->i16, n * 10, "%d");
-  CHECK_FIELD(msg->i64, (int64_t )(n * 10000), "%jd");
-  CHECK_FIELD(msg->position[0], (double )n, "%f");
-  CHECK_FIELD(msg->position[1], (double )n, "%f");
-  CHECK_FIELD(msg->position[2], (double )n, "%f");
-  CHECK_FIELD(msg->orientation[0], (double )n, "%f");
-  CHECK_FIELD(msg->orientation[1], (double )n, "%f");
-  CHECK_FIELD(msg->orientation[2], (double )n, "%f");
-  CHECK_FIELD(msg->orientation[3], (double )n, "%f");
-  CHECK_FIELD(msg->num_ranges, n, "%d");
-  int i;
-  for (i = 0; i < n; i++)
-    CHECK_FIELD(msg->ranges[i], i, "%d");
-  char expected_name[100];
-  sprintf(expected_name, "%d", n);
-  if (strcmp(expected_name, msg->name.c_str())) {
-    info("Expected msg->expected_name to be %s, got %s instead",
-         expected_name, msg->name.c_str());
-    return 0;
-  }
-  CHECK_FIELD(msg->enabled, (int )(n % 2), "%d");
-  return 1;
+int CheckLcmType(const lcmtest::primitives_t *msg, int expected)
+{
+    int n = expected;
+    CHECK_FIELD(msg->i8, n % 100, "%d");
+    CHECK_FIELD(msg->i16, n * 10, "%d");
+    CHECK_FIELD(msg->i64, (int64_t)(n * 10000), "%jd");
+    CHECK_FIELD(msg->position[0], (double) n, "%f");
+    CHECK_FIELD(msg->position[1], (double) n, "%f");
+    CHECK_FIELD(msg->position[2], (double) n, "%f");
+    CHECK_FIELD(msg->orientation[0], (double) n, "%f");
+    CHECK_FIELD(msg->orientation[1], (double) n, "%f");
+    CHECK_FIELD(msg->orientation[2], (double) n, "%f");
+    CHECK_FIELD(msg->orientation[3], (double) n, "%f");
+    CHECK_FIELD(msg->num_ranges, n, "%d");
+    int i;
+    for (i = 0; i < n; i++)
+        CHECK_FIELD(msg->ranges[i], i, "%d");
+    char expected_name[100];
+    sprintf(expected_name, "%d", n);
+    if (strcmp(expected_name, msg->name.c_str())) {
+        info("Expected msg->expected_name to be %s, got %s instead", expected_name,
+             msg->name.c_str());
+        return 0;
+    }
+    CHECK_FIELD(msg->enabled, (int) (n % 2), "%d");
+    return 1;
 }
 
-void FillLcmType(int n, lcmtest::primitives_t* msg) {
-  msg->i8 = n % 100;
-  msg->i16 = n * 10;
-  msg->i64 = n * 10000;
-  msg->position[0] = n;
-  msg->position[1] = n;
-  msg->position[2] = n;
-  msg->orientation[0] = n;
-  msg->orientation[1] = n;
-  msg->orientation[2] = n;
-  msg->orientation[3] = n;
-  msg->num_ranges = n;
-  msg->ranges.resize(n);
-  int i;
-  for (i = 0; i < n; i++)
-    msg->ranges[i] = i;
-  char name_buf[80];
-  snprintf(name_buf, 79, "%d", n);
-  msg->name = name_buf;
-  msg->enabled = n % 2;
+void FillLcmType(int n, lcmtest::primitives_t *msg)
+{
+    msg->i8 = n % 100;
+    msg->i16 = n * 10;
+    msg->i64 = n * 10000;
+    msg->position[0] = n;
+    msg->position[1] = n;
+    msg->position[2] = n;
+    msg->orientation[0] = n;
+    msg->orientation[1] = n;
+    msg->orientation[2] = n;
+    msg->orientation[3] = n;
+    msg->num_ranges = n;
+    msg->ranges.resize(n);
+    int i;
+    for (i = 0; i < n; i++)
+        msg->ranges[i] = i;
+    char name_buf[80];
+    snprintf(name_buf, 79, "%d", n);
+    msg->name = name_buf;
+    msg->enabled = n % 2;
 }
 
-void ClearLcmType(lcmtest::primitives_t* msg) {
-  msg->ranges.clear();
-  msg->name.clear();
+void ClearLcmType(lcmtest::primitives_t *msg)
+{
+    msg->ranges.clear();
+    msg->name.clear();
 }
 
-int CheckLcmType(const lcmtest2::cross_package_t* msg, int expected) {
-  return CheckLcmType(&msg->primitives, expected) &&
-      CheckLcmType(&msg->another, expected);
+int CheckLcmType(const lcmtest2::cross_package_t *msg, int expected)
+{
+    return CheckLcmType(&msg->primitives, expected) && CheckLcmType(&msg->another, expected);
 }
 
-void FillLcmType(int n, lcmtest2::cross_package_t* msg) {
-  FillLcmType(n, &msg->primitives);
-  FillLcmType(n, &msg->another);
+void FillLcmType(int n, lcmtest2::cross_package_t *msg)
+{
+    FillLcmType(n, &msg->primitives);
+    FillLcmType(n, &msg->another);
 }
 
-void ClearLcmType(lcmtest2::cross_package_t* msg) {
-  ClearLcmType(&msg->primitives);
-  ClearLcmType(&msg->another);
+void ClearLcmType(lcmtest2::cross_package_t *msg)
+{
+    ClearLcmType(&msg->primitives);
+    ClearLcmType(&msg->another);
 }
 
-int CheckLcmType(const lcmtest2::another_type_t* msg, int expected) {
+int CheckLcmType(const lcmtest2::another_type_t *msg, int expected)
+{
     int n = expected;
     CHECK_FIELD(msg->val, n, "%d");
     return 1;
 }
 
-void FillLcmType(int n, lcmtest2::another_type_t* msg)
+void FillLcmType(int n, lcmtest2::another_type_t *msg)
 {
     msg->val = n;
 }
 
-void ClearLcmType(lcmtest2::another_type_t* msg)
+void ClearLcmType(lcmtest2::another_type_t *msg)
 {
     return;
 }

--- a/test/cpp/common.hpp
+++ b/test/cpp/common.hpp
@@ -2,34 +2,34 @@
 #define __common_hpp__
 
 #include <lcm/lcm-cpp.hpp>
-#include "lcmtest/primitives_t.hpp"
-#include "lcmtest/primitives_list_t.hpp"
-#include "lcmtest/node_t.hpp"
 #include "lcmtest/multidim_array_t.hpp"
+#include "lcmtest/node_t.hpp"
+#include "lcmtest/primitives_list_t.hpp"
+#include "lcmtest/primitives_t.hpp"
 #include "lcmtest2/cross_package_t.hpp"
 
-int CheckLcmType(const lcmtest::multidim_array_t* msg, int expected);
-void FillLcmType(int num_children, lcmtest::multidim_array_t* result);
-void ClearLcmType(lcmtest::multidim_array_t* msg);
+int CheckLcmType(const lcmtest::multidim_array_t *msg, int expected);
+void FillLcmType(int num_children, lcmtest::multidim_array_t *result);
+void ClearLcmType(lcmtest::multidim_array_t *msg);
 
-int CheckLcmType(const lcmtest::node_t* msg, int expected);
-void FillLcmType(int num_children, lcmtest::node_t* result);
-void ClearLcmType(lcmtest::node_t* msg);
+int CheckLcmType(const lcmtest::node_t *msg, int expected);
+void FillLcmType(int num_children, lcmtest::node_t *result);
+void ClearLcmType(lcmtest::node_t *msg);
 
-int CheckLcmType(const lcmtest::primitives_list_t* msg, int expected);
-void FillLcmType(int num, lcmtest::primitives_list_t* msg);
-void ClearLcmType(lcmtest::primitives_list_t* msg);
+int CheckLcmType(const lcmtest::primitives_list_t *msg, int expected);
+void FillLcmType(int num, lcmtest::primitives_list_t *msg);
+void ClearLcmType(lcmtest::primitives_list_t *msg);
 
-int CheckLcmType(const lcmtest::primitives_t* msg, int expected);
-void FillLcmType(int n, lcmtest::primitives_t* msg);
-void ClearLcmType(lcmtest::primitives_t* msg);
+int CheckLcmType(const lcmtest::primitives_t *msg, int expected);
+void FillLcmType(int n, lcmtest::primitives_t *msg);
+void ClearLcmType(lcmtest::primitives_t *msg);
 
-int CheckLcmType(const lcmtest2::cross_package_t* msg, int expected);
-void FillLcmType(int n, lcmtest2::cross_package_t* msg);
-void ClearLcmType(lcmtest2::cross_package_t* msg);
+int CheckLcmType(const lcmtest2::cross_package_t *msg, int expected);
+void FillLcmType(int n, lcmtest2::cross_package_t *msg);
+void ClearLcmType(lcmtest2::cross_package_t *msg);
 
-int CheckLcmType(const lcmtest2::another_type_t* msg, int expected);
-void FillLcmType(int n, lcmtest2::another_type_t* msg);
-void ClearLcmType(lcmtest2::another_type_t* msg);
+int CheckLcmType(const lcmtest2::another_type_t *msg, int expected);
+void FillLcmType(int n, lcmtest2::another_type_t *msg);
+void ClearLcmType(lcmtest2::another_type_t *msg);
 
 #endif

--- a/test/cpp/memq_test.cpp
+++ b/test/cpp/memq_test.cpp
@@ -1,10 +1,11 @@
+#include <gtest/gtest.h>
 #include <stdlib.h>
 #include <string.h>
-#include <gtest/gtest.h>
 
 #include <lcm/lcm-cpp.hpp>
 
-TEST(LCM_CPP, MemqConstructDestroy) {
+TEST(LCM_CPP, MemqConstructDestroy)
+{
     lcm::LCM lcm("memq://");
     EXPECT_TRUE(lcm.good());
 }
@@ -14,14 +15,15 @@ struct MemqSimpleState {
     bool handled;
 };
 
-void MemqSimpleHandler(const lcm::ReceiveBuffer* rbuf,
-        const std::string& channel,
-        std::vector<uint8_t>* received_buf) {
+void MemqSimpleHandler(const lcm::ReceiveBuffer *rbuf, const std::string &channel,
+                       std::vector<uint8_t> *received_buf)
+{
     received_buf->resize(rbuf->data_size);
     memcpy(&(*received_buf)[0], rbuf->data, rbuf->data_size);
 }
 
-TEST(LCM_CPP, MemqSimple) {
+TEST(LCM_CPP, MemqSimple)
+{
     // Publish a single message, then subscribe to it and check it's read.
     lcm::LCM lcm("memq://");
     const int buf_size = 1024;
@@ -43,15 +45,16 @@ TEST(LCM_CPP, MemqSimple) {
     }
 }
 
-void MemqBufferedHandler(const lcm::ReceiveBuffer* rbuf,
-        const std::string& channel,
-        std::vector<std::vector<uint8_t> >* received_buffers) {
+void MemqBufferedHandler(const lcm::ReceiveBuffer *rbuf, const std::string &channel,
+                         std::vector<std::vector<uint8_t> > *received_buffers)
+{
     std::vector<uint8_t> buf(rbuf->data_size);
     memcpy(&buf[0], rbuf->data, rbuf->data_size);
     received_buffers->push_back(buf);
 }
 
-TEST(LCM_CPP, MemqBuffered) {
+TEST(LCM_CPP, MemqBuffered)
+{
     // Publish many messages so that they get buffered up, then read them all.
     lcm::LCM lcm("memq://");
     std::vector<std::vector<uint8_t> > received_buffers;
@@ -62,7 +65,7 @@ TEST(LCM_CPP, MemqBuffered) {
     int buf_size = 100;
     std::vector<std::vector<uint8_t> > buffers(num_bufs);
     for (int buf_num = 0; buf_num < num_bufs; ++buf_num) {
-        std::vector<uint8_t>& buf = buffers[buf_num];
+        std::vector<uint8_t> &buf = buffers[buf_num];
         buf.resize(buf_size);
         for (int byte_index = 0; byte_index < buf_size; ++byte_index) {
             buf[byte_index] = rand() % 255;
@@ -77,13 +80,14 @@ TEST(LCM_CPP, MemqBuffered) {
     EXPECT_EQ(buffers, received_buffers);
 }
 
-void MemqTimeoutHandler(const lcm::ReceiveBuffer* rbuf,
-        const std::string& channel,
-        bool* msg_handled) {
+void MemqTimeoutHandler(const lcm::ReceiveBuffer *rbuf, const std::string &channel,
+                        bool *msg_handled)
+{
     *msg_handled = true;
 }
 
-TEST(LCM_CPP, MemqTimeout) {
+TEST(LCM_CPP, MemqTimeout)
+{
     // Test various usages of lcm_handle_timeout() using the memq provider
     lcm::LCM lcm("memq://");
 


### PR DESCRIPTION
Formatting for `examples` and `test` directories. I also needed to update the formatting script to exclude things like the `gtest` directory.