### PR TITLE
Don't import the same package multiple times in generated Go code.

### DIFF
--- a/lcmgen/emit_go.c
+++ b/lcmgen/emit_go.c
@@ -619,7 +619,7 @@ static void emit_go_lcm_imports(FILE *f, lcmgen_t *lcm, lcm_struct_t *ls)
             continue;
 
         int imported = FALSE;
-        for (int j = i - 1; j > 0; j--) {
+        for (int j = i - 1; j >= 0; j--) {
             lcm_member_t *lm_ = (lcm_member_t *) g_ptr_array_index(ls->members, j);
 
             if (strcmp(lm->type->package, lm_->type->package) == 0)


### PR DESCRIPTION
For this definition:
```
package GoGen;

struct Bug
{
  PkgA.A  a;
  PkgA.B  b;
}
```
The Go code generator generates two import statements for PkgA:
```
// THIS IS AN AUTOMATICALLY GENERATED FILE.  DO NOT MODIFY
// BY HAND!!
//
// Generated by lcm-gen

package GoGen

import (
	"encoding/binary"
	"fmt"
	"math"
	"math/bits"
	"PkgA"
	"PkgA"
)
...
```
This results in Go compile error:
```
src/GoGen/Bug.go:14:2: PkgA redeclared as imported package name
	previous declaration at src/GoGen/Bug.go:13:2
```
This Dockerfile can be used to reproduce the issue:
```
FROM golang:1.10

RUN apt-get update && apt-get install -y \
    build-essential \
    libglib2.0-dev \
    cmake \
    python-dev \
    python-epydoc \
    openjdk-8-jdk \
    lua5.2-dev \
    doxygen

RUN git clone --branch v1.4.0 --depth 1 https://github.com/lcm-proj/lcm.git && \
    mkdir lcm/build && \
    cd lcm/build && \
    cmake .. && \
    make all && \
    make install && \
    cd ../.. && \
    rm -r ./lcm

RUN echo "package GoGen; struct Bug { PkgA.A  a; PkgA.B  b; }" > /Bug.lcm && \
    echo "package PkgA; struct A { double number_a; } struct B { double number_b; }" > /PkgA.lcm && \
    lcm-gen --go --go-path /go/src/ /Bug.lcm && lcm-gen --go --go-path /go/src/ /PkgA.lcm

RUN go build GoGen
```