### PR TITLE
Update CMakeLists.txt in lcm-logger

### DIFF
--- a/lcm-logger/CMakeLists.txt
+++ b/lcm-logger/CMakeLists.txt
@@ -6,7 +6,11 @@ target_link_libraries(lcm-logger
 )
 
 add_executable(lcm-logplayer lcm_logplayer.c)
-target_link_libraries(lcm-logplayer lcm ${lcm-winport})
+target_link_libraries(lcm-logplayer
+  lcm
+  ${lcm-winport}
+  GLib2::glib
+)
 
 install(TARGETS
   lcm-logger


### PR DESCRIPTION
I cross compile lcm-1.4.0 by :
cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=~/arm_toolchain.cmake
and there is an error when build lcm-logplayer
libglib-2.0.so.0, needed by ../lcm/liblcm.so.1.4.0, not found (try using -rpath or -rpath-link)


