### PR TITLE
Changes required to build LCM on Windows 10 with CMake + VS2017

### DIFF
--- a/cmake/FindGLib2.cmake
+++ b/cmake/FindGLib2.cmake
@@ -23,6 +23,10 @@ endfunction()
 function(_glib2_find_library VAR LIB)
   list(APPEND CMAKE_PREFIX_PATH $ENV{GLIB_PATH})
 
+  if(WIN32)
+	set(CMAKE_FIND_LIBRARY_SUFFIXES ".dll.a")
+	set(CMAKE_FIND_LIBRARY_PREFIXES "lib")
+  endif()
   find_library(GLIB2_${VAR}_LIBRARY NAMES ${LIB}-2.0 ${LIB})
   mark_as_advanced(GLIB2_${VAR}_LIBRARY)
 

--- a/lcm/windows/WinPorting.cpp
+++ b/lcm/windows/WinPorting.cpp
@@ -1,8 +1,8 @@
 
 #define _WIN32_WINNT 0x0501
-#include <Mswsock.h>
 #include <stdio.h>
 #include <winsock2.h>
+#include <Mswsock.h>
 
 #include "WinPorting.h"
 

--- a/lcmgen/emit_go.c
+++ b/lcmgen/emit_go.c
@@ -6,8 +6,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef WIN32
 #include <unistd.h>
+#endif
 #ifdef WIN32
+#define F_OK 0                /* Test for existence.  */
 #define __STDC_FORMAT_MACROS  // Enable integer types
 #endif
 


### PR DESCRIPTION
These are the minimum changes required to build LCM using CMake (3.12.4) and Visual Studio 2017 on a Windows 10 64-bit machine.

* FindGLib2.cmake does not find glib libraries by default if installed through MSYS2 (as recommended on the GTK+ link on the LCM website)
* Order of header includes matters in WinPorting.cpp
* Including <unistd.h> does not work on Windows, nor is "F_OK" defined.  That only works on Linux.