### PR TITLE
Fixed destructor logic for LCM instance.

### DIFF
--- a/lcm-go/lcm/lcm.go
+++ b/lcm-go/lcm/lcm.go
@@ -165,16 +165,17 @@ func (lcm LCM) Publisher(channel string) (chan<- []byte, <-chan error) {
 // Destroy destroys an LCM object, so that it can be picked up by the garbage
 // collector. This method also unsubscribes to all channels that lcm previously
 // subscribed to.
-func (lcm LCM) Destroy() error {
+func (lcm *LCM) Destroy() error {
+	lcmInstance := *lcm
 	lcm.closed = true
 
 	C.lcm_destroy(lcm.cPtr)
 
-	if err := lcm.UnsubscribeAll(); err != nil {
+	if err := lcmInstance.UnsubscribeAll(); err != nil {
 		return err
 	}
 
-	delete(subscriptions, lcm)
+	delete(subscriptions, lcmInstance)
 
 	return nil
 }


### PR DESCRIPTION
Due to the modification of the passed LCM instance both the call to
UnsubscribeAll() and the deletion of the instance from the global list
of subscriptions failed. Additionally, the flag indicating a closed
channel was not set for the actual LCM instance.
This fixes lcm-proj#270.