### PR TITLE
Added selection of LCM provider to Go bindings.

### DIFF
--- a/lcm-go/lcm/lcm.go
+++ b/lcm-go/lcm/lcm.go
@@ -52,9 +52,23 @@ type LCM struct {
 	cPtr   *C.lcm_t
 }
 
-// New returns a new LCM instance. In case of a failure, an error is returned.
+// New returns a new LCM instance using the default provider as defined in the
+// C interface. In case of a failure, an error is returned.
 func New() (LCM, error) {
-	cPtr := C.lcm_create(nil)
+	return NewProvider("")
+}
+
+// NewProvider returns a new LCM instance using the specified provider. In case
+// of a failure, an error is returned.
+func NewProvider(provider string) (LCM, error) {
+	var cProvider *C.char
+	if len(provider) != 0 {
+		cProvider = C.CString(provider)
+		defer C.free(unsafe.Pointer(cProvider))
+	}
+
+	cPtr := C.lcm_create(cProvider)
+
 	if cPtr == nil {
 		return LCM{}, errors.New("could not create c pointer to lcm_t")
 	}

--- a/lcm-go/lcm/lcm_test.go
+++ b/lcm-go/lcm/lcm_test.go
@@ -17,16 +17,29 @@ var (
 	someBytes = []byte("abcdefghijklmnopqrstuvwxyz")
 )
 
-func TestLCM(t *testing.T) {
+func runTest(t *testing.T, provider string) {
 	// The amount of messages that we received.
 	messages := 1
+	var lcm LCM
+	var err error
 
 	// New LCM
-	lcm, err := New()
+	if len(provider) != 0 {
+		lcm, err = NewProvider(provider)
+	} else {
+		lcm, err = New()
+	}
+
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer lcm.Destroy()
+
+	defer func() {
+		err = lcm.Destroy()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	// Subscribe to "TEST" LCM channel using Go
 	subscription, err := lcm.Subscribe("TEST", messageGoal)
@@ -74,4 +87,16 @@ FOR_SELECT:
 	}
 
 	t.Log("received", "amount", messages)
+}
+
+func TestLCMDefaultProvider(t *testing.T) {
+	runTest(t, "")
+}
+
+func TestLCMProviderUDPM(t *testing.T) {
+	runTest(t, "udpm://239.255.76.67:7667?ttl=1")
+}
+
+func TestLCMProviderMemQ(t *testing.T) {
+	runTest(t, "memq://")
 }


### PR DESCRIPTION
The Go bindings did not allow the selection of the underlying LCM
provider. This change adds the possibility to select the desired
provider by passing the corresponding string to NewProvider().