### PR TITLE
Always initialize context and handler before calling lcm_subscribe

### DIFF
--- a/lcm/lcm-cpp-impl.hpp
+++ b/lcm/lcm-cpp-impl.hpp
@@ -268,9 +268,9 @@ Subscription *LCM::subscribeFunction(const std::string &channel,
     }
     typedef LCMTypedSubscription<MessageType, ContextClass> SubsClass;
     SubsClass *sub = new SubsClass();
-    sub->c_subs = lcm_subscribe(lcm, channel.c_str(), SubsClass::cb_func, sub);
     sub->handler = handler;
     sub->context = context;
+    sub->c_subs = lcm_subscribe(lcm, channel.c_str(), SubsClass::cb_func, sub);
     subscriptions.push_back(sub);
     return sub;
 }
@@ -288,9 +288,9 @@ Subscription *LCM::subscribeFunction(const std::string &channel,
     }
     typedef LCMUntypedSubscription<ContextClass> SubsClass;
     SubsClass *sub = new SubsClass();
-    sub->c_subs = lcm_subscribe(lcm, channel.c_str(), SubsClass::cb_func, sub);
     sub->handler = handler;
     sub->context = context;
+    sub->c_subs = lcm_subscribe(lcm, channel.c_str(), SubsClass::cb_func, sub);
     subscriptions.push_back(sub);
     return sub;
 }


### PR DESCRIPTION
This avoids a race condition where a receiving thread could
potentially try to handle an incoming message (as far as the C
implementation is concerned, we're done subscribing) before the
handler is populated (and then trying to run a handler at address
0x0).