### PR TITLE
add package prefix check when generating C libraries in CMake

### DIFF
--- a/lcm-cmake/lcmUtilities.cmake
+++ b/lcm-cmake/lcmUtilities.cmake
@@ -301,8 +301,13 @@ function(lcm_wrap_types)
 
         # Determine output file name(s) and add to output variables
         if(DEFINED _C_HEADERS AND DEFINED _C_SOURCES)
-          _lcm_add_outputs(_C_HEADERS ${_package_pre}_${_type}.h)
-          _lcm_add_outputs(_C_SOURCES ${_package_pre}_${_type}.c)
+          if(DEFINED _package_pre)
+            _lcm_add_outputs(_C_HEADERS ${_package_pre}_${_type}.h)
+            _lcm_add_outputs(_C_SOURCES ${_package_pre}_${_type}.c)
+          else()
+            _lcm_add_outputs(_C_HEADERS ${_type}.h)
+            _lcm_add_outputs(_C_SOURCES ${_type}.c)
+          endif()
           if(_CREATE_CPP_AGGREGATE_HEADER)
             _lcm_add_aggregate_include("${_package_dir}.h"
               "${_package_pre}_${_type}.h")


### PR DESCRIPTION
if there is no package prefix, the old behavior would result in an underscore
'_' being erroneously prefixed to generated source code filenames. new behavior
will only concatenate the package prefix if the LCM message definition file in
question has specified a package.