### PR TITLE
Remove deprecated garbage collection flag for `lcm-logplayer-gui`.

### DIFF
--- a/lcm-java/lcm-logplayer-gui.sh
+++ b/lcm-java/lcm-logplayer-gui.sh
@@ -20,4 +20,4 @@ fi
 [ -n "$CLASSPATH" ] && jars="$jars:$CLASSPATH"
 
 # Launch the applet
-exec java -server -Xincgc -Xmx64m -Xms32m -ea -cp "$jars" lcm.logging.LogPlayer "$@"
+exec java -server -Xmx64m -Xms32m -ea -cp "$jars" lcm.logging.LogPlayer "$@"


### PR DESCRIPTION
Remove the `-Xincgc` option from `lcm-logplayer-gui.sh`, since it is no longer supported (see [this](https://stackoverflow.com/questions/54854750/eclipse-unrecognized-option-xincgc)).

The JVM is correctly created now, and the GUI runs normally.

