### PR TITLE
Use STREQUAL instead of DEFINED to check if package is set in lcm file

### DIFF
--- a/lcm-cmake/lcmUtilities.cmake
+++ b/lcm-cmake/lcmUtilities.cmake
@@ -303,12 +303,12 @@ function(lcm_wrap_types)
 
         # Determine output file name(s) and add to output variables
         if(DEFINED _C_HEADERS AND DEFINED _C_SOURCES)
-          if(DEFINED _package_pre)
-            _lcm_add_outputs(_C_HEADERS ${_package_pre}_${_type}.h)
-            _lcm_add_outputs(_C_SOURCES ${_package_pre}_${_type}.c)
-          else()
+          if(_package_pre STREQUAL "")
             _lcm_add_outputs(_C_HEADERS ${_type}.h)
             _lcm_add_outputs(_C_SOURCES ${_type}.c)
+          else()
+            _lcm_add_outputs(_C_HEADERS ${_package_pre}_${_type}.h)
+            _lcm_add_outputs(_C_SOURCES ${_package_pre}_${_type}.c)
           endif()
           if(_CREATE_CPP_AGGREGATE_HEADER)
             _lcm_add_aggregate_include("${_package_dir}.h"


### PR DESCRIPTION
The fix in 27902c3 won't work when applied on top of f485e38414e71987d40cea17f289f0cc1759576e. This fix solves the problem 27902c3 was meant to solve.

Thanks