### PR TITLE
 Fix #294 & go travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ addons:
             - cmake
             - default-jdk
             - python-all-dev
-            - golang
 
 jobs:
     include:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,10 +77,7 @@ endif()
 lcm_option(
   LCM_ENABLE_GO
   "Build Go utilities, bindings is source distributed"
-
-  # Disable until #294 is resolved
-  FALSE Go)
-  #  GO_FOUND Go)
+  GO_FOUND Go 1.10)
 
 option(LCM_ENABLE_TESTS "Build unit tests" ON)
 if(LCM_ENABLE_TESTS)

--- a/cmake/FindGo.cmake
+++ b/cmake/FindGo.cmake
@@ -1,30 +1,28 @@
 include(FindPackageHandleStandardArgs)
 
 find_program(
-  GO_EXECUTABLE go PATHS ENV GOROOT GOPATH GOBIN PATH_SUFFIXES bin
+  GO_EXECUTABLE go PATHS ENV GOROOT PATH_SUFFIXES bin
 )
 
-if (NOT GO_EXECUTABLE)
-  set(GO_EXECUTABLE "go")
-endif()
+if (GO_EXECUTABLE)
+  execute_process(
+    COMMAND ${GO_EXECUTABLE} version
+    OUTPUT_VARIABLE GO_VERSION_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
 
-execute_process(
-  COMMAND ${GO_EXECUTABLE} version
-  OUTPUT_VARIABLE GO_VERSION_OUTPUT
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-if(GO_VERSION_OUTPUT MATCHES "go([0-9]+[.0-9]*)[^ ]* ([^/]+)/(.*)")
-  set(GO_VERSION ${CMAKE_MATCH_1})
-  set(GO_PLATFORM ${CMAKE_MATCH_2})
-  set(GO_ARCH ${CMAKE_MATCH_3})
-elseif(GO_VERSION_OUTPUT MATCHES "go version devel .* ([^/]+)/(.*)")
-  set(GO_VERSION "99-devel")
-  set(GO_PLATFORM ${CMAKE_MATCH_1})
-  set(GO_ARCH ${CMAKE_MATCH_2})
-  message("WARNING: Development version of Go being used, can't determine compatibility.")
-else()
-  message("Unable to parse the Go version string: ${GO_VERSION_OUTPUT}")
+  if(GO_VERSION_OUTPUT MATCHES "go([0-9]+[.0-9]*)[^ ]* ([^/]+)/(.*)")
+    set(GO_VERSION ${CMAKE_MATCH_1})
+    set(GO_PLATFORM ${CMAKE_MATCH_2})
+    set(GO_ARCH ${CMAKE_MATCH_3})
+  elseif(GO_VERSION_OUTPUT MATCHES "go version devel .* ([^/]+)/(.*)")
+    set(GO_VERSION "99-devel")
+    set(GO_PLATFORM ${CMAKE_MATCH_1})
+    set(GO_ARCH ${CMAKE_MATCH_2})
+    message("WARNING: Development version of Go being used, can't determine compatibility.")
+  else()
+    message("Unable to parse the Go version string: ${GO_VERSION_OUTPUT}")
+  endif()
 endif()
 
 mark_as_advanced(GO_EXECUTABLE)

--- a/lcmgen/emit_go.c
+++ b/lcmgen/emit_go.c
@@ -321,16 +321,19 @@ static char *go_membername(lcm_struct_t *ls, const char *const str, int method)
 {
     char *membername = go_name(str);
 
-    // expose all fields because the field value is inside the real data
-    membername[0] = toupper(membername[0]);
-    if (method) {
+    if (lcm_find_member_with_named_dimension(ls, str, 0) >= ls->members->len) {
+        // If not a read-only attribute, uppercase it to export it.
+        membername[0] = toupper(membername[0]);
+    } else if (method) {
         // If read-only should be method invocation.
         size_t len = strlen(membername);
-        membername = realloc(membername, len + 6);
-        // add Get at the end to distinguish between field name and method
-        strcat(membername, "Get()");
-        membername[len+5] = '\0';
+        membername = realloc(membername, len + 3);
+        membername[0] = toupper(membername[0]);
+        membername[len++] = '(';
+        membername[len++] = ')';
+        membername[len++] = '\0';
     }
+
     return membername;
 }
 
@@ -566,12 +569,9 @@ static unsigned int emit_go_array_loops(FILE *f, lcmgen_t *lcm, lcm_struct_t *ls
             const char *type =
                 map_builtintype_name(lcm_find_member(ls, dim->size)->type->lctypename);
 
-            if (slice_emit){
-	        lcm_struct_t *ls_lm = lcm_find_struct(lcm, lm);
-		uint64_t lm_fingerprint = lcm_get_fingerprint(lcm, ls_lm);
+            if (slice_emit)
                 emit_go_slice_make(f, n + 1, ls->structname->package, lm, n, slicestr->str, size,
-                                   lm_fingerprint);
-	    }
+                                   fingerprint);
 
             emit(1 + n, "for i%d := %s(0); i%d < p.%s; i%d++ {", n, type, n, size, n);
 
@@ -949,7 +949,7 @@ static void emit_go_lcm_read_only_getters(FILE *f, lcmgen_t *lcm, lcm_struct_t *
         for (; i < ls->members->len;
              i = lcm_find_member_with_named_dimension(ls, lm->membername, i + 1)) {
             lcm_member_t *lm_ = (lcm_member_t *) g_ptr_array_index(ls->members, i);
-            char *membername = go_membername(ls, lm_->membername, FALSE);
+            char *membername = go_membername(ls, lm_->membername, TRUE);
 
             unsigned int j = lcm_find_named_dimension(f, ls, lm_, lm->membername, 0);
 

--- a/test/go/CMakeLists.txt
+++ b/test/go/CMakeLists.txt
@@ -1,9 +1,9 @@
-find_program(GO_EXECUTABLE go)
-
-if(PYTHON_EXECUTABLE AND GO_EXECUTABLE)
+if(PYTHON_EXECUTABLE)
   add_test(NAME Go::client_server COMMAND
     ${CMAKE_COMMAND} -E env
-      "GOPATH=${lcm_BINARY_DIR}/test/types/go:${GOPATH}"
+      "GOPATH=${lcm_BINARY_DIR}/test/types/go"
+      "CGO_CFLAGS=-I${CMAKE_SOURCE_DIR} -I${CMAKE_BINARY_DIR}/lcm"
+      "CGO_LDFLAGS=-L${CMAKE_BINARY_DIR}/lcm -Wl,-rpath,${CMAKE_BINARY_DIR}/lcm"
       ${PYTHON_EXECUTABLE}
       ${CMAKE_CURRENT_SOURCE_DIR}/../run_client_server_test.py
       $<TARGET_FILE:test-c-server>
@@ -11,5 +11,17 @@ if(PYTHON_EXECUTABLE AND GO_EXECUTABLE)
 endif()
 
 add_test(NAME Go::unit_test COMMAND
-  ${GO_EXECUTABLE} test -v ./...
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../lcm-go/)
+  ${CMAKE_COMMAND} -E env
+    "CGO_CFLAGS=-I${CMAKE_SOURCE_DIR} -I${CMAKE_BINARY_DIR}/lcm"
+    "CGO_LDFLAGS=-L${CMAKE_BINARY_DIR}/lcm -Wl,-rpath,${CMAKE_BINARY_DIR}/lcm"
+    ${GO_EXECUTABLE} test -v ./...
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../lcm-go/)
+
+if(GO_ARCH MATCHES "^amd64$" AND GO_PLATFORM MATCHES "^(linux|freebsd|darwin|windows)$")
+  add_test(NAME Go::unit_test::race_enabled COMMAND
+    ${CMAKE_COMMAND} -E env
+      "CGO_CFLAGS=-I${CMAKE_SOURCE_DIR} -I${CMAKE_BINARY_DIR}/lcm"
+      "CGO_LDFLAGS=-L${CMAKE_BINARY_DIR}/lcm -Wl,-rpath,${CMAKE_BINARY_DIR}/lcm"
+      ${GO_EXECUTABLE} test -v -race ./...
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../lcm-go/)
+endif()


### PR DESCRIPTION
Fixed #294 by the prior revert of 6e5da12.

Fixed the broken golang tests by:

* Added explicit path to header files and lib
* Set the LCM backend queue size to 0 to prevent message drops (as we
  are handling buffering, potential drops & drop count)
* Enabled verification of ordering of messages in the golang unit tests
* Wrapped lcm_handle() with a select as it was reading on invalid
  handle after destroy() is called.

Enable build of golang backend and set required go version to 1.10,
might work with older versions but Travis fails and its untested.