### PR TITLE
Removed implicit string conversion from const char* to std::string during subscription handling

### DIFF
--- a/lcm/lcm-cpp-impl.hpp
+++ b/lcm/lcm-cpp-impl.hpp
@@ -28,6 +28,7 @@ class LCMTypedSubscription : public Subscription {
     {
         typedef LCMTypedSubscription<MessageType, ContextClass> SubsClass;
         SubsClass *subs = static_cast<SubsClass *>(user_data);
+        subs->channel_name_workspace = channel;
         MessageType msg;
         int status = msg.decode(rbuf->data, 0, rbuf->data_size);
         if (status < 0) {
@@ -35,7 +36,7 @@ class LCMTypedSubscription : public Subscription {
             return;
         }
         const ReceiveBuffer rb = {rbuf->data, rbuf->data_size, rbuf->recv_utime};
-        subs->handler(&rb, subs->channel(channel), &msg, subs->context);
+        subs->handler(&rb, subs->channel_name_workspace, &msg, subs->context);
     }
 };
 
@@ -50,9 +51,9 @@ class LCMUntypedSubscription : public Subscription {
     {
         typedef LCMUntypedSubscription<ContextClass> SubsClass;
         SubsClass *subs = static_cast<SubsClass *>(user_data);
-        subs->channel = channel;
+        subs->channel_name_workspace = channel;
         const ReceiveBuffer rb = {rbuf->data, rbuf->data_size, rbuf->recv_utime};
-        subs->handler(&rb, subs->channel, subs->context);
+        subs->handler(&rb, subs->channel_name_workspace, subs->context);
     }
 };
 
@@ -75,8 +76,8 @@ class LCMMHSubscription : public Subscription {
             return;
         }
         const ReceiveBuffer rb = {rbuf->data, rbuf->data_size, rbuf->recv_utime};
-        subs->channel = channel;
-        (subs->handler->*subs->handlerMethod)(&rb, subs->channel, &msg);
+        subs->channel_name_workspace = channel;
+        (subs->handler->*subs->handlerMethod)(&rb, subs->channel_name_workspace, &msg);
     }
 };
 
@@ -92,9 +93,9 @@ class LCMMHUntypedSubscription : public Subscription {
     {
         LCMMHUntypedSubscription<MessageHandlerClass> *subs =
             static_cast<LCMMHUntypedSubscription<MessageHandlerClass> *>(user_data);
-        subs->channel = channel;
+        subs->channel_name_workspace = channel;
         const ReceiveBuffer rb = {rbuf->data, rbuf->data_size, rbuf->recv_utime};
-        (subs->handler->*subs->handlerMethod)(&rb, subs->channel);
+        (subs->handler->*subs->handlerMethod)(&rb, subs->channel_name_workspace);
     }
 };
 
@@ -110,7 +111,7 @@ class LCMLambdaSubscription : public Subscription {
     {
         LCMLambdaSubscription<MessageType> *subs =
             static_cast<LCMLambdaSubscription<MessageType> *>(user_data);
-        subs->channel = channel;
+        subs->channel_name_workspace = channel;
         MessageType msg;
         int status = msg.decode(rbuf->data, 0, rbuf->data_size);
         if (status < 0) {
@@ -118,7 +119,7 @@ class LCMLambdaSubscription : public Subscription {
             return;
         }
         const ReceiveBuffer rb = {rbuf->data, rbuf->data_size, rbuf->recv_utime};
-        (subs->handler)(&rb, subs->channel, &msg);
+        (subs->handler)(&rb, subs->channel_name_workspace, &msg);
     }
 };
 #endif

--- a/lcm/lcm-cpp-impl.hpp
+++ b/lcm/lcm-cpp-impl.hpp
@@ -28,7 +28,7 @@ class LCMTypedSubscription : public Subscription {
     {
         typedef LCMTypedSubscription<MessageType, ContextClass> SubsClass;
         SubsClass *subs = static_cast<SubsClass *>(user_data);
-        subs->channel_name_workspace = channel;
+        subs->channel_buf = channel;
         MessageType msg;
         int status = msg.decode(rbuf->data, 0, rbuf->data_size);
         if (status < 0) {
@@ -36,7 +36,7 @@ class LCMTypedSubscription : public Subscription {
             return;
         }
         const ReceiveBuffer rb = {rbuf->data, rbuf->data_size, rbuf->recv_utime};
-        subs->handler(&rb, subs->channel_name_workspace, &msg, subs->context);
+        subs->handler(&rb, subs->channel_buf, &msg, subs->context);
     }
 };
 
@@ -51,9 +51,9 @@ class LCMUntypedSubscription : public Subscription {
     {
         typedef LCMUntypedSubscription<ContextClass> SubsClass;
         SubsClass *subs = static_cast<SubsClass *>(user_data);
-        subs->channel_name_workspace = channel;
+        subs->channel_buf = channel;
         const ReceiveBuffer rb = {rbuf->data, rbuf->data_size, rbuf->recv_utime};
-        subs->handler(&rb, subs->channel_name_workspace, subs->context);
+        subs->handler(&rb, subs->channel_buf, subs->context);
     }
 };
 
@@ -76,8 +76,8 @@ class LCMMHSubscription : public Subscription {
             return;
         }
         const ReceiveBuffer rb = {rbuf->data, rbuf->data_size, rbuf->recv_utime};
-        subs->channel_name_workspace = channel;
-        (subs->handler->*subs->handlerMethod)(&rb, subs->channel_name_workspace, &msg);
+        subs->channel_buf = channel;
+        (subs->handler->*subs->handlerMethod)(&rb, subs->channel_buf, &msg);
     }
 };
 
@@ -93,9 +93,9 @@ class LCMMHUntypedSubscription : public Subscription {
     {
         LCMMHUntypedSubscription<MessageHandlerClass> *subs =
             static_cast<LCMMHUntypedSubscription<MessageHandlerClass> *>(user_data);
-        subs->channel_name_workspace = channel;
+        subs->channel_buf = channel;
         const ReceiveBuffer rb = {rbuf->data, rbuf->data_size, rbuf->recv_utime};
-        (subs->handler->*subs->handlerMethod)(&rb, subs->channel_name_workspace);
+        (subs->handler->*subs->handlerMethod)(&rb, subs->channel_buf);
     }
 };
 
@@ -111,7 +111,7 @@ class LCMLambdaSubscription : public Subscription {
     {
         LCMLambdaSubscription<MessageType> *subs =
             static_cast<LCMLambdaSubscription<MessageType> *>(user_data);
-        subs->channel_name_workspace = channel;
+        subs->channel_buf = channel;
         MessageType msg;
         int status = msg.decode(rbuf->data, 0, rbuf->data_size);
         if (status < 0) {
@@ -119,7 +119,7 @@ class LCMLambdaSubscription : public Subscription {
             return;
         }
         const ReceiveBuffer rb = {rbuf->data, rbuf->data_size, rbuf->recv_utime};
-        (subs->handler)(&rb, subs->channel_name_workspace, &msg);
+        (subs->handler)(&rb, subs->channel_buf, &msg);
     }
 };
 #endif

--- a/lcm/lcm-cpp-impl.hpp
+++ b/lcm/lcm-cpp-impl.hpp
@@ -27,7 +27,7 @@ class LCMTypedSubscription : public Subscription {
     ContextClass context;
     void (*handler)(const ReceiveBuffer *rbuf, const std::string &channel, const MessageType *msg,
                     ContextClass context);
-    static void cb_func(const lcm_recv_buf_t *rbuf, const char *channel, void *user_data)
+    static void cb_func(const lcm_recv_buf_t *rbuf, const char *, void *user_data)
     {
         typedef LCMTypedSubscription<MessageType, ContextClass> SubsClass;
         SubsClass *subs = static_cast<SubsClass *>(user_data);
@@ -52,7 +52,7 @@ class LCMUntypedSubscription : public Subscription {
   private:
     ContextClass context;
     void (*handler)(const ReceiveBuffer *rbuf, const std::string &channel, ContextClass context);
-    static void cb_func(const lcm_recv_buf_t *rbuf, const char *channel, void *user_data)
+    static void cb_func(const lcm_recv_buf_t *rbuf, const char *, void *user_data)
     {
         typedef LCMUntypedSubscription<ContextClass> SubsClass;
         SubsClass *subs = static_cast<SubsClass *>(user_data);
@@ -72,7 +72,7 @@ class LCMMHSubscription : public Subscription {
     MessageHandlerClass *handler;
     void (MessageHandlerClass::*handlerMethod)(const ReceiveBuffer *rbuf,
                                                const std::string &channel, const MessageType *msg);
-    static void cb_func(const lcm_recv_buf_t *rbuf, const char *channel, void *user_data)
+    static void cb_func(const lcm_recv_buf_t *rbuf, const char *, void *user_data)
     {
         LCMMHSubscription<MessageType, MessageHandlerClass> *subs =
             static_cast<LCMMHSubscription<MessageType, MessageHandlerClass> *>(user_data);
@@ -98,7 +98,7 @@ class LCMMHUntypedSubscription : public Subscription {
     MessageHandlerClass *handler;
     void (MessageHandlerClass::*handlerMethod)(const ReceiveBuffer *rbuf,
                                                const std::string &channel);
-    static void cb_func(const lcm_recv_buf_t *rbuf, const char *channel, void *user_data)
+    static void cb_func(const lcm_recv_buf_t *rbuf, const char *, void *user_data)
     {
         LCMMHUntypedSubscription<MessageHandlerClass> *subs =
             static_cast<LCMMHUntypedSubscription<MessageHandlerClass> *>(user_data);
@@ -118,7 +118,7 @@ class LCMLambdaSubscription : public Subscription {
   private:
     using HandlerFunction = typename LCM::HandlerFunction<MessageType>;
     HandlerFunction handler;
-    static void cb_func(const lcm_recv_buf_t *rbuf, const char *channel, void *user_data)
+    static void cb_func(const lcm_recv_buf_t *rbuf, const char *, void *user_data)
     {
         LCMLambdaSubscription<MessageType> *subs =
             static_cast<LCMLambdaSubscription<MessageType> *>(user_data);

--- a/lcm/lcm-cpp.hpp
+++ b/lcm/lcm-cpp.hpp
@@ -524,9 +524,7 @@ class Subscription {
     friend class LCM;
 
   protected:
-    Subscription() {
-      channel_buf.reserve(LCM_MAX_CHANNEL_NAME_LENGTH);
-    };
+    Subscription() { channel_buf.reserve(LCM_MAX_CHANNEL_NAME_LENGTH); };
 
     /**
      * The underlying lcm_subscription_t object wrapped by this

--- a/lcm/lcm-cpp.hpp
+++ b/lcm/lcm-cpp.hpp
@@ -498,6 +498,8 @@ struct ReceiveBuffer {
  */
 class Subscription {
   public:
+    Subscription(const std::string& channel_in) : channel(channel_in) {}
+
     virtual ~Subscription() {}
     /**
      * @brief Adjusts the maximum number of received messages that can be
@@ -530,6 +532,9 @@ class Subscription {
      * subscription.
      */
     lcm_subscription_t *c_subs;
+
+    // The channel that `this` is subscribed to.
+    std::string channel;
 };
 
 /**

--- a/lcm/lcm-cpp.hpp
+++ b/lcm/lcm-cpp.hpp
@@ -525,7 +525,7 @@ class Subscription {
 
   protected:
     Subscription() {
-      channel_name_workspace.reserve(LCM_MAX_CHANNEL_NAME_LENGTH);
+      channel_buf.reserve(LCM_MAX_CHANNEL_NAME_LENGTH);
     };
 
     /**
@@ -538,7 +538,7 @@ class Subscription {
     // message handling. This string serves to eliminate a heap allocation that
     // would otherwise occur and which could preclude use in real-time
     // applications.
-    std::string channel_name_workspace;
+    std::string channel_buf;
 };
 
 /**

--- a/lcm/lcm-cpp.hpp
+++ b/lcm/lcm-cpp.hpp
@@ -524,7 +524,9 @@ class Subscription {
     friend class LCM;
 
   protected:
-    Subscription() { channel.reserve(LCM_MAX_CHANNEL_NAME_LENGTH); };
+    Subscription() {
+      channel_name_workspace.reserve(LCM_MAX_CHANNEL_NAME_LENGTH);
+    };
 
     /**
      * The underlying lcm_subscription_t object wrapped by this
@@ -532,8 +534,11 @@ class Subscription {
      */
     lcm_subscription_t *c_subs;
 
-    // The channel that `this` is subscribed to.
-    std::string channel;
+    // A "workspace" string that is overwritten with the channel name during
+    // message handling. This string serves to eliminate a heap allocation that
+    // would otherwise occur and which could preclude use in real-time
+    // applications.
+    std::string channel_name_workspace;
 };
 
 /**

--- a/lcm/lcm-cpp.hpp
+++ b/lcm/lcm-cpp.hpp
@@ -498,8 +498,6 @@ struct ReceiveBuffer {
  */
 class Subscription {
   public:
-    Subscription(const std::string& channel_in) : channel(channel_in) {}
-
     virtual ~Subscription() {}
     /**
      * @brief Adjusts the maximum number of received messages that can be
@@ -526,7 +524,8 @@ class Subscription {
     friend class LCM;
 
   protected:
-    Subscription(){};
+    Subscription() { channel.reserve(LCM_MAX_CHANNEL_NAME_LENGTH); };
+
     /**
      * The underlying lcm_subscription_t object wrapped by this
      * subscription.


### PR DESCRIPTION
Simply adds a member to Subscription for storing the string and passes the string back to the callback handler.

Fixes #313

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lcm-proj/lcm/314)
<!-- Reviewable:end -->
