### PR TITLE
Add LCM_CXX_11_ENABLED to doxygen compiler flags.

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -981,7 +981,7 @@ INCLUDE_FILE_PATTERNS  =
 # undefined via #undef or recursively expanded use the := operator
 # instead of the = operator.
 
-PREDEFINED             = LCM_EXPORT=
+PREDEFINED             = LCM_CXX_11_ENABLED LCM_EXPORT=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then
 # this tag can be used to specify a list of macro names that should be expanded.


### PR DESCRIPTION
The [official docs for the `LCM` class (C++)](https://lcm-proj.github.io/classlcm_1_1LCM.html) omit the [c++11 overload of `.subscribe()`](https://github.com/lcm-proj/lcm/blob/master/lcm/lcm-cpp.hpp#L426).

This PR asks that the `LCM_CXX_11_ENABLED` preprocessor directive be set in the doxyfile so that this overload appears in the generated API documentation.