### PR TITLE
Remove unused `_hash` member from python lcmtypes

### DIFF
--- a/lcmgen/emit_python.c
+++ b/lcmgen/emit_python.c
@@ -596,8 +596,6 @@ static void emit_python_init(const lcmgen_t *lcm, FILE *f, lcm_struct_t *lr)
 static void emit_python_fingerprint(const lcmgen_t *lcm, FILE *f, lcm_struct_t *ls)
 {
     const char *sn = ls->structname->shortname;
-    emit(1, "_hash = None");
-
     emit(1, "def _get_hash_recursive(parents):");
     emit(2, "if %s in parents: return 0", sn);
     for (unsigned int m = 0; m < ls->members->len; m++) {


### PR DESCRIPTION
`_hash` appears to be vestigial. `_packed_fingerprint` is the member that actually caches the computed lcm hash for the type.

Also, `_hash` is very close to python's magic `__hash__` method, so this is a confusing artifact that should be removed.