### PR TITLE
Add `get_hash()` to generated python classes

### DIFF
--- a/lcmgen/emit_python.c
+++ b/lcmgen/emit_python.c
@@ -634,6 +634,12 @@ static void emit_python_fingerprint(const lcmgen_t *lcm, FILE *f, lcm_struct_t *
     emit(1, "_get_packed_fingerprint = staticmethod(_get_packed_fingerprint)");
     // clang-format off
     fprintf (f, "\n");
+
+    emit(1, "@property");
+    emit(1, "def hash(self):");
+    emit(2,     "\"\"\"LCM hash for struct\"\"\"");
+    emit(2,     "return struct.unpack(\">Q\", %s._get_packed_fingerprint())[0]", sn);
+    fprintf(f, "\n");
 }
 
 static void

--- a/lcmgen/emit_python.c
+++ b/lcmgen/emit_python.c
@@ -635,9 +635,8 @@ static void emit_python_fingerprint(const lcmgen_t *lcm, FILE *f, lcm_struct_t *
     // clang-format off
     fprintf (f, "\n");
 
-    emit(1, "@property");
-    emit(1, "def hash(self):");
-    emit(2,     "\"\"\"LCM hash for struct\"\"\"");
+    emit(1, "def get_hash(self):");
+    emit(2,     "\"\"\"Get the LCM hash of the struct\"\"\"");
     emit(2,     "return struct.unpack(\">Q\", %s._get_packed_fingerprint())[0]", sn);
     fprintf(f, "\n");
 }


### PR DESCRIPTION
In response to #339 

I considered making it a function, `get_hash()`, a member variable, `hash`, or a property, `hash`. In the end I settled for a property since it is more elegant than the function and, in contrast to a member variable, it's read-only.