### PR TITLE
Fix issues with out of order udp packets in udpm and mpdupm dropping messages.

### DIFF
--- a/lcm/lcm_mpudpm.c
+++ b/lcm/lcm_mpudpm.c
@@ -385,7 +385,6 @@ static int recv_message_fragment(lcm_mpudpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz
     lcm2_header_long_t *hdr = (lcm2_header_long_t *) lcmb->buf;
 
     // any existing fragment buffer for this message source?
-    lcm_frag_buf_t *fbuf = lcm_frag_buf_store_lookup(lcm->frag_bufs, &lcmb->from);
 
     uint32_t msg_seqno = ntohl(hdr->msg_seqno);
     uint32_t data_size = ntohl(hdr->msg_size);
@@ -395,8 +394,14 @@ static int recv_message_fragment(lcm_mpudpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz
     uint32_t frag_size = sz - sizeof(lcm2_header_long_t);
     char *data_start = (char *) (hdr + 1);
 
+    // any existing fragment buffer for this message source?
+    lcm_frag_key_t key;
+    key.from = &(lcmb->from);
+    key.msg_seqno = msg_seqno;
+    lcm_frag_buf_t *fbuf = lcm_frag_buf_store_lookup(lcm->frag_bufs, &key);
+
     // discard any stale fragments from previous messages
-    if (fbuf && ((fbuf->msg_seqno != msg_seqno) || (fbuf->data_size != data_size))) {
+    if (fbuf && (fbuf->data_size != data_size)) {
         lcm_frag_buf_store_remove(lcm->frag_bufs, fbuf);
         dbg(DBG_LCM, "Dropping message (missing %d fragments)\n", fbuf->fragments_remaining);
         fbuf = NULL;
@@ -407,33 +412,29 @@ static int recv_message_fragment(lcm_mpudpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz
         return 0;
     }
 
-    // create a new fragment buffer if necessary
-    // TODO(abachrac): this discards a msg if the first fragment is out of order
-    if (!fbuf && hdr->fragment_no == 0) {
-        char *channel = (char *) (hdr + 1);
+    //if this is the first packet, set some values
+    char *channel = NULL;
+    if (hdr->fragment_no == 0) {
+        channel = (char *) (hdr + 1);
         int channel_sz = strlen(channel);
         if (channel_sz > LCM_MAX_CHANNEL_NAME_LENGTH) {
             dbg(DBG_LCM, "bad channel name length\n");
             lcm->udp_discarded_bad++;
             return 0;
         }
-
-        // if the packet has no subscribers, drop the message now.
-        if (!lcm_has_handlers(lcm->lcm, channel) && !is_reserved_channel(channel))
-            return 0;
-
-        fbuf = lcm_frag_buf_new(*((struct sockaddr_in *) &lcmb->from), channel, msg_seqno,
-                                data_size, fragments_in_msg, lcmb->recv_utime);
-        lcm_frag_buf_store_add(lcm->frag_bufs, fbuf);
         data_start += channel_sz + 1;
         frag_size -= (channel_sz + 1);
     }
 
-    if (!fbuf) {
-        // received fragment for message we dropped (hopefully intentionally)
-        // TODO(abachrac): is there a way to distinguish between intentionally
-        // dropped, and packets being dropped due to out of order packet 0?
-        return 0;
+    // create a new fragment buffer if necessary
+    if(!fbuf){
+        fbuf = lcm_frag_buf_new(*((struct sockaddr_in *) &lcmb->from), msg_seqno,
+                                data_size, fragments_in_msg, lcmb->recv_utime);
+        lcm_frag_buf_store_add(lcm->frag_bufs, fbuf);
+    }
+
+    if (channel!=NULL) {
+        strncpy (fbuf->channel, channel, sizeof (fbuf->channel));
     }
 
 #ifdef __linux__

--- a/lcm/lcm_udpm.c
+++ b/lcm/lcm_udpm.c
@@ -232,9 +232,6 @@ static int _recv_message_fragment(lcm_udpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz)
 {
     lcm2_header_long_t *hdr = (lcm2_header_long_t *) lcmb->buf;
 
-    // any existing fragment buffer for this message source?
-    lcm_frag_buf_t *fbuf = lcm_frag_buf_store_lookup(lcm->frag_bufs, &lcmb->from);
-
     uint32_t msg_seqno = ntohl(hdr->msg_seqno);
     uint32_t data_size = ntohl(hdr->msg_size);
     uint32_t fragment_offset = ntohl(hdr->fragment_offset);
@@ -243,8 +240,14 @@ static int _recv_message_fragment(lcm_udpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz)
     uint32_t frag_size = sz - sizeof(lcm2_header_long_t);
     char *data_start = (char *) (hdr + 1);
 
+    // any existing fragment buffer for this message source?
+    lcm_frag_key_t key;
+    key.from = &(lcmb->from);
+    key.msg_seqno = msg_seqno;
+    lcm_frag_buf_t *fbuf = lcm_frag_buf_store_lookup(lcm->frag_bufs, &key);
+
     // discard any stale fragments from previous messages
-    if (fbuf && ((fbuf->msg_seqno != msg_seqno) || (fbuf->data_size != data_size))) {
+    if (fbuf && (fbuf->data_size != data_size)) {
         lcm_frag_buf_store_remove(lcm->frag_bufs, fbuf);
         dbg(DBG_LCM, "Dropping message (missing %d fragments)\n", fbuf->fragments_remaining);
         fbuf = NULL;
@@ -259,8 +262,10 @@ static int _recv_message_fragment(lcm_udpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz)
         return 0;
     }
 
-    // create a new fragment buffer if necessary
-    if (!fbuf && hdr->fragment_no == 0) {
+    //if this is the first packet, set some values
+    char *channel = NULL;
+    if (hdr->fragment_no == 0) {
+        channel = (char*) (hdr + 1);
         char *channel = (char *) (hdr + 1);
         int channel_sz = strlen(channel);
         if (channel_sz > LCM_MAX_CHANNEL_NAME_LENGTH) {
@@ -268,21 +273,20 @@ static int _recv_message_fragment(lcm_udpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz)
             lcm->udp_discarded_bad++;
             return 0;
         }
-
-        // if the packet has no subscribers, drop the message now.
-        if (!lcm_has_handlers(lcm->lcm, channel))
-            return 0;
-
-        fbuf = lcm_frag_buf_new(*((struct sockaddr_in *) &lcmb->from), channel, msg_seqno,
-                                data_size, fragments_in_msg, lcmb->recv_utime);
-        lcm_frag_buf_store_add(lcm->frag_bufs, fbuf);
         data_start += channel_sz + 1;
         frag_size -= (channel_sz + 1);
     }
 
-    if (!fbuf)
-        return 0;
+    if(!fbuf){
+        fbuf = lcm_frag_buf_new(*((struct sockaddr_in *) &lcmb->from), msg_seqno,
+                                data_size, fragments_in_msg, lcmb->recv_utime);
+        lcm_frag_buf_store_add(lcm->frag_bufs, fbuf);
+    }
 
+    if (channel!=NULL) {
+        strncpy (fbuf->channel, channel, sizeof (fbuf->channel));
+    }
+    
 #ifdef __linux__
     if (lcm->kernel_rbuf_sz < 262145 && data_size > lcm->kernel_rbuf_sz &&
         !lcm->warned_about_small_kernel_buf) {

--- a/lcm/udpm_util.h
+++ b/lcm/udpm_util.h
@@ -174,17 +174,23 @@ lcm_buf_t *lcm_buf_allocate_data(lcm_buf_queue_t *inbufs_empty, lcm_ringbuf_t **
 void lcm_buf_free_data(lcm_buf_t *lcmb, lcm_ringbuf_t *ringbuf);
 
 /******************** fragment buffer **********************/
-typedef struct _lcm_frag_buf {
-    char channel[LCM_MAX_CHANNEL_NAME_LENGTH + 1];
-    struct sockaddr_in from;
-    char *data;
-    uint32_t data_size;
-    uint16_t fragments_remaining;
+typedef struct _lcm_frag_key {
     uint32_t msg_seqno;
-    int64_t last_packet_utime;
+    struct   sockaddr_in *from;
+} lcm_frag_key_t;
+
+typedef struct _lcm_frag_buf {
+    char            channel[LCM_MAX_CHANNEL_NAME_LENGTH+1];
+    struct          sockaddr_in from;
+    char            *data;
+    uint32_t        data_size;
+    uint16_t        fragments_remaining;
+    uint32_t        msg_seqno;
+    int64_t         last_packet_utime;
+    lcm_frag_key_t  key;
 } lcm_frag_buf_t;
 
-lcm_frag_buf_t *lcm_frag_buf_new(struct sockaddr_in from, const char *channel, uint32_t msg_seqno,
+lcm_frag_buf_t *lcm_frag_buf_new(struct sockaddr_in from, uint32_t msg_seqno,
                                  uint32_t data_size, uint16_t nfragments,
                                  int64_t first_packet_utime);
 void lcm_frag_buf_destroy(lcm_frag_buf_t *fbuf);
@@ -199,7 +205,7 @@ typedef struct _lcm_frag_buf_store {
 
 lcm_frag_buf_store *lcm_frag_buf_store_new(uint32_t max_total_size, uint32_t max_n_frag_bufs);
 void lcm_frag_buf_store_destroy(lcm_frag_buf_store *store);
-lcm_frag_buf_t *lcm_frag_buf_store_lookup(lcm_frag_buf_store *store, struct sockaddr *key);
+lcm_frag_buf_t *lcm_frag_buf_store_lookup(lcm_frag_buf_store *store, lcm_frag_key_t* key);
 
 void lcm_frag_buf_store_remove(lcm_frag_buf_store *store, lcm_frag_buf_t *fbuf);
 void lcm_frag_buf_store_add(lcm_frag_buf_store *store, lcm_frag_buf_t *fbuf);


### PR DESCRIPTION
In using LCM I noticed message loss of packets greater than a UDP datagram occasionally. I was able to track it down due to receiving out of order fragments likely due to UDP. I pulled PR #175 into my local repository after noticing it was previously discovered, and after some extensive testing confirmed this resolved my issues. Opening this PR as there were some merge conflicts that needed resolution, and I did not have access to the original branch to resolve them.

Overview of changes, copied from this PR:
lcm_frag_buff type has an extra pointer and an extra uin32_t conatined within a new struct
More packets could potentially wind up in the fragment hash table
Hashing function has an additional multiplication
Hash pointer equality check has an additional condition