### PR TITLE
Don't define GTEST_LINKED_AS_SHARED_LIBRARY for gtest_main target

### DIFF
--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(test_c_libs lcm-test-types-c lcm gtest gtest_main)
+set(test_c_libs lcm-test-types-c lcm gtest_main)
 
 add_executable(test-c-server server.c common.c)
 target_link_libraries(test-c-server lcm-test-types-c lcm)

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(test_cpp_libs lcm-test-types-cpp lcm gtest gtest_main)
+set(test_cpp_libs lcm-test-types-cpp lcm gtest_main)
 
 add_executable(test-cpp-client client.cpp common.cpp)
 lcm_target_link_libraries(test-cpp-client ${test_cpp_libs})

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -2,16 +2,20 @@ project(gtest)
 
 find_package(Threads)
 
-add_library(gtest src/gtest-all.cc)
+add_library(gtest EXCLUDE_FROM_ALL src/gtest-all.cc)
 target_link_libraries(gtest ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(gtest SYSTEM PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
-add_library(gtest_main src/gtest_main.cc)
-target_link_libraries(gtest_main gtest ${CMAKE_THREAD_LIBS_INIT})
+add_library(gtest_main src/gtest-all.cc src/gtest_main.cc)
+target_include_directories(gtest_main SYSTEM PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
+target_link_libraries(gtest_main ${CMAKE_THREAD_LIBS_INIT})
 
 if(BUILD_SHARED_LIBS)
   target_compile_definitions(gtest
-    PRIVATE GTEST_CREATE_SHARED_LIBRARY)
+    PRIVATE GTEST_CREATE_SHARED_LIBRARY
+    INTERFACE GTEST_LINKED_AS_SHARED_LIBRARY)
+
   target_compile_definitions(gtest_main
+    PRIVATE GTEST_CREATE_SHARED_LIBRARY
     INTERFACE GTEST_LINKED_AS_SHARED_LIBRARY)
 endif()

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -5,11 +5,13 @@ find_package(Threads)
 add_library(gtest src/gtest-all.cc)
 target_link_libraries(gtest ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(gtest SYSTEM PUBLIC ${PROJECT_SOURCE_DIR}/include)
-if(BUILD_SHARED_LIBS)
-  target_compile_definitions(gtest
-    PRIVATE GTEST_CREATE_SHARED_LIBRARY
-    INTERFACE GTEST_LINKED_AS_SHARED_LIBRARY)
-endif()
 
 add_library(gtest_main src/gtest_main.cc)
 target_link_libraries(gtest_main gtest ${CMAKE_THREAD_LIBS_INIT})
+
+if(BUILD_SHARED_LIBS)
+  target_compile_definitions(gtest
+    PRIVATE GTEST_CREATE_SHARED_LIBRARY)
+  target_compile_definitions(gtest_main
+    INTERFACE GTEST_LINKED_AS_SHARED_LIBRARY)
+endif()


### PR DESCRIPTION
Currently, `main()` in the `gtest_main` target becomes ill-formed due to the definition of `GTEST_API_`, which is conditioned on the `GTEST_LINKED_AS_SHARED_LIBRARY` compile definition.

The `gtest` target (before this change) adds the mentioned definition as an `INTERFACE` definition, which gets picked up by `gtest_main`, resulting in the _definition_ of the main function being declared as `__declspec(dllimport)` on Windows.

To keep the `INTERFACE` compile definitions of `GTEST_LINKED_AS_SHARED_LIBRARY` for both `gtest_main` and `gtest`, I've simply made them two separate targets that do not link to each other. Alternatively, the `gtest` target could be dropped altogether since it isn't needed, but I figured it could make sense to keep it around if it'll be needed later.

I'm not thrilled to have two separate targets for `gtest` and `gtest_main`, but it seems like the least bad solution if one wants to keep the `INTERFACE` definitions for both targets.