### PR TITLE
mpudpm: fix lock sequence while parsing packets

### DIFF
--- a/lcm/lcm_mpudpm.c
+++ b/lcm/lcm_mpudpm.c
@@ -733,6 +733,7 @@ static void *recv_thread(void *user)
                 if (sz < sizeof(lcm2_header_short_t)) {
                     // packet too short to be LCM
                     lcm->udp_discarded_bad++;
+                    g_static_mutex_lock(&lcm->receive_lock);
                     continue;
                 }
 
@@ -777,6 +778,7 @@ static void *recv_thread(void *user)
                 else {
                     dbg(DBG_LCM, "LCM: bad magic\n");
                     lcm->udp_discarded_bad++;
+                    g_static_mutex_lock(&lcm->receive_lock);
                     continue;
                 }
 


### PR DESCRIPTION
When parsing UDP packets that are not valid LCM messages, the
mpudpm module's error handling would get the internal locks into
an invalid state. When attempting to read the next UDP packet, it
would abort() with the following message on some platforms:

Attempt to unlock mutex that was not locked

Fix this by re-acquiring the receive lock during error handling
so the next unlock at the top of the recv loop will not crash.

Signed-off-by: Brian Kubisiak <brian@kubisiak.com>