### PR TITLE
Fix #371

### DIFF
--- a/lcm/lcm_tcpq.c
+++ b/lcm/lcm_tcpq.c
@@ -237,7 +237,10 @@ static lcm_provider_t *lcm_tcpq_create(lcm_t *parent, const char *network, const
     dbg(DBG_LCM, "Initializing LCM TCPQ provider context...\n");
     dbg(DBG_LCM, "Server address %s:%d\n", inet_ntoa(self->server_addr), ntohs(self->server_port));
 
-    _connect_to_server(self);
+    if (_connect_to_server(self) != 0) {
+        free(self);
+        self = NULL;
+    }
 
     return self;
 }


### PR DESCRIPTION
This minor commit fixes issue #371 by checking if a valid connection is made to the tcpq provider. If not the provider is freed and set to null. This ensures lcm_create frees the lcm structure and returns a NULL.