### PR TITLE
Fix compatibility with Python 3.11

### DIFF
--- a/lcm-python/module.c
+++ b/lcm-python/module.c
@@ -9,6 +9,11 @@
 #define Py_TYPE(ob) (((PyObject *) (ob))->ob_type)
 #endif
 
+// to support python 3.9.0a3 and earlier
+#if PY_VERSION_HEX < 0x030900A4
+#define Py_SET_TYPE(obj, type) ((Py_TYPE(obj) = (type)), (void)0)
+#endif
+
 extern PyTypeObject pylcmeventlog_type;
 extern PyTypeObject pylcm_type;
 extern PyTypeObject pylcm_subscription_type;
@@ -43,9 +48,9 @@ init_lcm(void)
 {
     PyObject *m;
 
-    Py_TYPE(&pylcmeventlog_type) = &PyType_Type;
-    Py_TYPE(&pylcm_type) = &PyType_Type;
-    Py_TYPE(&pylcm_subscription_type) = &PyType_Type;
+    Py_SET_TYPE(&pylcmeventlog_type, &PyType_Type);
+    Py_SET_TYPE(&pylcm_type, &PyType_Type);
+    Py_SET_TYPE(&pylcm_subscription_type, &PyType_Type);
 
     MOD_DEF(m, "_lcm", lcmmod_doc, lcmmod_methods);
 


### PR DESCRIPTION
While trying to migrate Homebrew formula to Python 3.11, I hit the following error:
```
/tmp/lcm-20221118-59422-1wlr2mm/lcm-1.4.0/lcm-python/module.c:46:34: error: expression is not assignable
    Py_TYPE(&pylcmeventlog_type) = &PyType_Type;
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
/tmp/lcm-20221118-59422-1wlr2mm/lcm-1.4.0/lcm-python/module.c:47:26: error: expression is not assignable
    Py_TYPE(&pylcm_type) = &PyType_Type;
    ~~~~~~~~~~~~~~~~~~~~ ^
/tmp/lcm-20221118-59422-1wlr2mm/lcm-1.4.0/lcm-python/module.c:48:39: error: expression is not assignable
    Py_TYPE(&pylcm_subscription_type) = &PyType_Type;
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
3 errors generated.
make[2]: *** [lcm-python/CMakeFiles/lcm-python.dir/module.c.o] Error 1
```

Added a fix used by other projects like:
- `boost` - https://github.com/boostorg/python/blob/develop/include/boost/python/detail/wrap_python.hpp#L232-L233
- `gobject-introspection` - https://gitlab.gnome.org/GNOME/gobject-introspection/-/blob/main/giscanner/giscannermodule.c#L52-54
- `numpy` - https://github.com/numpy/numpy/blob/main/numpy/core/include/numpy/npy_3kcompat.h#L90-L92