### PR TITLE
Fix GLib bitrot

### DIFF
--- a/lcm-logger/glib_util.c
+++ b/lcm-logger/glib_util.c
@@ -165,18 +165,18 @@ typedef struct {
 } glib_attached_lcm_t;
 
 static GHashTable *lcm_glib_sources = NULL;
-static GStaticMutex lcm_glib_sources_mutex = G_STATIC_MUTEX_INIT;
+static GMutex lcm_glib_sources_mutex;
 
 int glib_mainloop_attach_lcm(lcm_t *lcm)
 {
-    g_static_mutex_lock(&lcm_glib_sources_mutex);
+    g_mutex_lock(&lcm_glib_sources_mutex);
 
     if (!lcm_glib_sources) {
         lcm_glib_sources = g_hash_table_new(g_direct_hash, g_direct_equal);
     }
 
     if (g_hash_table_lookup(lcm_glib_sources, lcm)) {
-        g_static_mutex_unlock(&lcm_glib_sources_mutex);
+        g_mutex_unlock(&lcm_glib_sources_mutex);
         return -1;
     }
 
@@ -188,22 +188,22 @@ int glib_mainloop_attach_lcm(lcm_t *lcm)
 
     g_hash_table_insert(lcm_glib_sources, lcm, galcm);
 
-    g_static_mutex_unlock(&lcm_glib_sources_mutex);
+    g_mutex_unlock(&lcm_glib_sources_mutex);
     return 0;
 }
 
 int glib_mainloop_detach_lcm(lcm_t *lcm)
 {
-    g_static_mutex_lock(&lcm_glib_sources_mutex);
+    g_mutex_lock(&lcm_glib_sources_mutex);
     if (!lcm_glib_sources) {
-        g_static_mutex_unlock(&lcm_glib_sources_mutex);
+        g_mutex_unlock(&lcm_glib_sources_mutex);
         return -1;
     }
 
     glib_attached_lcm_t *galcm = (glib_attached_lcm_t *) g_hash_table_lookup(lcm_glib_sources, lcm);
 
     if (!galcm) {
-        g_static_mutex_unlock(&lcm_glib_sources_mutex);
+        g_mutex_unlock(&lcm_glib_sources_mutex);
         return -1;
     }
 
@@ -218,7 +218,7 @@ int glib_mainloop_detach_lcm(lcm_t *lcm)
         lcm_glib_sources = NULL;
     }
 
-    g_static_mutex_unlock(&lcm_glib_sources_mutex);
+    g_mutex_unlock(&lcm_glib_sources_mutex);
     return 0;
 }
 

--- a/lcm-logger/lcm_logger.c
+++ b/lcm-logger/lcm_logger.c
@@ -11,10 +11,9 @@
 
 #include <lcm/lcm.h>
 
-// GRegex was new in GLib 2.14.0
-#if GLIB_CHECK_VERSION(2, 14, 0)
+#if GLIB_CHECK_VERSION(2, 32, 0)
 #else
-#error "LCM requires a glib version >= 2.14.0"
+#error "LCM requires a glib version >= 2.32.0"
 #endif
 
 #ifdef WIN32

--- a/lcm/lcm.c
+++ b/lcm/lcm.c
@@ -22,8 +22,8 @@ typedef int SOCKET;
 #define LCM_DEFAULT_URL "udpm://239.255.76.67:7667?ttl=0"
 
 struct _lcm_t {
-    GStaticRecMutex mutex;         // guards data structures
-    GStaticRecMutex handle_mutex;  // only one thread allowed in lcm_handle at a time
+    GRecMutex mutex;         // guards data structures
+    GRecMutex handle_mutex;  // only one thread allowed in lcm_handle at a time
 
     GPtrArray *handlers_all;   // list containing *all* handlers
     GHashTable *handlers_map;  // map of channel name (string) to GPtrArray
@@ -116,8 +116,8 @@ lcm_t *lcm_create(const char *url)
     lcm->handlers_all = g_ptr_array_new();
     lcm->handlers_map = g_hash_table_new(g_str_hash, g_str_equal);
 
-    g_static_rec_mutex_init(&lcm->mutex);
-    g_static_rec_mutex_init(&lcm->handle_mutex);
+    g_rec_mutex_init(&lcm->mutex);
+    g_rec_mutex_init(&lcm->handle_mutex);
 
     lcm->provider = info->vtable->create(lcm, network, args);
     lcm->in_handle = 0;
@@ -186,8 +186,8 @@ void lcm_destroy(lcm_t *lcm)
     }
     g_ptr_array_free(lcm->handlers_all, TRUE);
 
-    g_static_rec_mutex_free(&lcm->handle_mutex);
-    g_static_rec_mutex_free(&lcm->mutex);
+    g_rec_mutex_clear(&lcm->handle_mutex);
+    g_rec_mutex_clear(&lcm->mutex);
     free(lcm);
 #ifdef WIN32
     WSACleanup();
@@ -198,12 +198,12 @@ int lcm_handle(lcm_t *lcm)
 {
     if (lcm->provider && lcm->vtable->handle) {
         int ret;
-        g_static_rec_mutex_lock(&lcm->handle_mutex);
+        g_rec_mutex_lock(&lcm->handle_mutex);
         assert(!lcm->in_handle);  // recursive calls to lcm_handle are not allowed
         lcm->in_handle = 1;
         ret = lcm->vtable->handle(lcm->provider);
         lcm->in_handle = 0;
-        g_static_rec_mutex_unlock(&lcm->handle_mutex);
+        g_rec_mutex_unlock(&lcm->handle_mutex);
         return ret;
     } else
         return -1;
@@ -310,17 +310,17 @@ lcm_subscription_t *lcm_subscribe(lcm_t *lcm, const char *channel, lcm_msg_handl
         free(h);
         return NULL;
     }
-    g_static_rec_mutex_lock(&lcm->mutex);
+    g_rec_mutex_lock(&lcm->mutex);
     g_ptr_array_add(lcm->handlers_all, h);
     g_hash_table_foreach(lcm->handlers_map, map_add_handler_callback, h);
-    g_static_rec_mutex_unlock(&lcm->mutex);
+    g_rec_mutex_unlock(&lcm->mutex);
 
     return h;
 }
 
 int lcm_unsubscribe(lcm_t *lcm, lcm_subscription_t *h)
 {
-    g_static_rec_mutex_lock(&lcm->mutex);
+    g_rec_mutex_lock(&lcm->mutex);
 
     // remove the handler from the master list
     int foundit = g_ptr_array_remove(lcm->handlers_all, h);
@@ -338,7 +338,7 @@ int lcm_unsubscribe(lcm_t *lcm, lcm_subscription_t *h)
             h->marked_for_deletion = 1;
     }
 
-    g_static_rec_mutex_unlock(&lcm->mutex);
+    g_rec_mutex_unlock(&lcm->mutex);
 
     return foundit ? 0 : -1;
 }
@@ -347,7 +347,7 @@ int lcm_unsubscribe(lcm_t *lcm, lcm_subscription_t *h)
 
 GPtrArray *lcm_get_handlers(lcm_t *lcm, const char *channel)
 {
-    g_static_rec_mutex_lock(&lcm->mutex);
+    g_rec_mutex_lock(&lcm->mutex);
     GPtrArray *handlers = (GPtrArray *) g_hash_table_lookup(lcm->handlers_map, channel);
     if (handlers)
         goto finished;
@@ -366,13 +366,13 @@ GPtrArray *lcm_get_handlers(lcm_t *lcm, const char *channel)
     }
 
 finished:
-    g_static_rec_mutex_unlock(&lcm->mutex);
+    g_rec_mutex_unlock(&lcm->mutex);
     return handlers;
 }
 
 int lcm_try_enqueue_message(lcm_t *lcm, const char *channel)
 {
-    g_static_rec_mutex_lock(&lcm->mutex);
+    g_rec_mutex_lock(&lcm->mutex);
     GPtrArray *handlers = lcm_get_handlers(lcm, channel);
     int num_keepers = 0;
     for (unsigned int i = 0; i < handlers->len; i++) {
@@ -383,24 +383,24 @@ int lcm_try_enqueue_message(lcm_t *lcm, const char *channel)
             num_keepers++;
         }
     }
-    g_static_rec_mutex_unlock(&lcm->mutex);
+    g_rec_mutex_unlock(&lcm->mutex);
     return num_keepers > 0;
 }
 
 int lcm_has_handlers(lcm_t *lcm, const char *channel)
 {
     int has_handlers = 1;
-    g_static_rec_mutex_lock(&lcm->mutex);
+    g_rec_mutex_lock(&lcm->mutex);
     GPtrArray *handlers = lcm_get_handlers(lcm, channel);
     if (!handlers || !handlers->len)
         has_handlers = 0;
-    g_static_rec_mutex_unlock(&lcm->mutex);
+    g_rec_mutex_unlock(&lcm->mutex);
     return has_handlers;
 }
 
 int lcm_dispatch_handlers(lcm_t *lcm, lcm_recv_buf_t *buf, const char *channel)
 {
-    g_static_rec_mutex_lock(&lcm->mutex);
+    g_rec_mutex_lock(&lcm->mutex);
 
     GPtrArray *handlers = lcm_get_handlers(lcm, channel);
 
@@ -420,9 +420,9 @@ int lcm_dispatch_handlers(lcm_t *lcm, lcm_recv_buf_t *buf, const char *channel)
         lcm_subscription_t *h = (lcm_subscription_t *) g_ptr_array_index(handlers, i);
         if (!h->marked_for_deletion && h->num_queued_messages > 0) {
             h->num_queued_messages--;
-            int depth = g_static_rec_mutex_unlock_full(&lcm->mutex);
+            g_rec_mutex_unlock(&lcm->mutex);
             h->handler(buf, channel, h->userdata);
-            g_static_rec_mutex_lock_full(&lcm->mutex, depth);
+            g_rec_mutex_lock(&lcm->mutex);
         }
     }
 
@@ -441,7 +441,7 @@ int lcm_dispatch_handlers(lcm_t *lcm, lcm_recv_buf_t *buf, const char *channel)
         g_hash_table_foreach(lcm->handlers_map, map_remove_handler_callback, h);
         lcm_handler_free(h);
     }
-    g_static_rec_mutex_unlock(&lcm->mutex);
+    g_rec_mutex_unlock(&lcm->mutex);
 
     return 0;
 }
@@ -492,16 +492,16 @@ int lcm_parse_url(const char *url, char **provider, char **network, GHashTable *
 
 int lcm_subscription_set_queue_capacity(lcm_subscription_t *subs, int num_messages)
 {
-    g_static_rec_mutex_lock(&subs->lcm->mutex);
+    g_rec_mutex_lock(&subs->lcm->mutex);
     subs->max_num_queued_messages = num_messages;
-    g_static_rec_mutex_unlock(&subs->lcm->mutex);
+    g_rec_mutex_unlock(&subs->lcm->mutex);
     return 0;
 }
 
 int lcm_subscription_get_queue_size(lcm_subscription_t *subs)
 {
-    g_static_rec_mutex_lock(&subs->lcm->mutex);
+    g_rec_mutex_lock(&subs->lcm->mutex);
     int result = subs->num_queued_messages;
-    g_static_rec_mutex_unlock(&subs->lcm->mutex);
+    g_rec_mutex_unlock(&subs->lcm->mutex);
     return result;
 }

--- a/lcm/lcm_file.c
+++ b/lcm/lcm_file.c
@@ -73,13 +73,6 @@ static void lcm_logprov_destroy(lcm_logprov_t *lr)
     free(lr);
 }
 
-static int64_t timestamp_now(void)
-{
-    GTimeVal tv;
-    g_get_current_time(&tv);
-    return (int64_t) tv.tv_sec * 1000000 + tv.tv_usec;
-}
-
 static void *timer_thread(void *user)
 {
     lcm_logprov_t *lr = (lcm_logprov_t *) user;
@@ -90,7 +83,7 @@ static void *timer_thread(void *user)
         if (abstime < 0)
             return NULL;
 
-        int64_t now = timestamp_now();
+        int64_t now = g_get_real_time();
 
         if (abstime > now) {
             int64_t sleep_utime = abstime - now;
@@ -266,7 +259,7 @@ static int lcm_logprov_handle(lcm_logprov_t *lr)
         return -1;
     }
 
-    int64_t now = timestamp_now();
+    int64_t now = g_get_real_time();
     /* Initialize the wall clock if this is the first time through */
     if (lr->next_clock_time < 0)
         lr->next_clock_time = now;
@@ -326,9 +319,7 @@ static int lcm_logprov_publish(lcm_logprov_t *lcm, const char *channel, const vo
     lcm_eventlog_event_t *le = (lcm_eventlog_event_t *) malloc(mem_sz);
     memset(le, 0, mem_sz);
 
-    GTimeVal tv;
-    g_get_current_time(&tv);
-    le->timestamp = (int64_t) tv.tv_sec * 1000000 + tv.tv_usec;
+    le->timestamp = (int64_t) g_get_real_time();
     ;
     le->channellen = channellen;
     le->datalen = datalen;

--- a/lcm/lcm_file.c
+++ b/lcm/lcm_file.c
@@ -223,7 +223,7 @@ static lcm_provider_t *lcm_logprov_create(lcm_t *parent, const char *target, con
         }
 
         /* Start the reader thread */
-        lr->timer_thread = g_thread_create(timer_thread, lr, TRUE, NULL);
+        lr->timer_thread = g_thread_new(NULL, timer_thread, lr);
         if (!lr->timer_thread) {
             fprintf(stderr, "Error: LCM failed to start timer thread\n");
             lcm_logprov_destroy(lr);

--- a/lcm/lcm_internal.h
+++ b/lcm/lcm_internal.h
@@ -4,10 +4,9 @@
 #include <glib.h>
 #include "lcm.h"
 
-// GRegex was new in GLib 2.14.0
-#if GLIB_CHECK_VERSION(2, 14, 0)
+#if GLIB_CHECK_VERSION(2, 32, 0)
 #else
-#error "LCM requires a glib version >= 2.14.0"
+#error "LCM requires a glib version >= 2.32.0"
 #endif
 
 #ifdef WIN32

--- a/lcm/lcm_memq.c
+++ b/lcm/lcm_memq.c
@@ -65,13 +65,6 @@ static void lcm_memq_destroy(lcm_memq_t *self)
     free(self);
 }
 
-static int64_t timestamp_now(void)
-{
-    GTimeVal tv;
-    g_get_current_time(&tv);
-    return (int64_t) tv.tv_sec * 1000000 + tv.tv_usec;
-}
-
 static lcm_provider_t *lcm_memq_create(lcm_t *parent, const char *target, const GHashTable *args)
 {
     lcm_memq_t *self = (lcm_memq_t *) calloc(1, sizeof(lcm_memq_t));
@@ -131,7 +124,7 @@ static int lcm_memq_publish(lcm_memq_t *self, const char *channel, const void *d
         return 0;
     }
     dbg(DBG_LCM, "Publishing to [%s] message size [%d]\n", channel, datalen);
-    memq_msg_t *msg = memq_msg_new(self->lcm, channel, data, datalen, timestamp_now());
+    memq_msg_t *msg = memq_msg_new(self->lcm, channel, data, datalen, g_get_real_time());
 
     g_mutex_lock(&self->mutex);
     int was_empty = g_queue_is_empty(self->queue);

--- a/lcm/lcm_mpudpm.c
+++ b/lcm/lcm_mpudpm.c
@@ -106,7 +106,7 @@ struct _lcm_provider_t {
     /***********************************************************
      *  begin variables guarded by receive_lock
      *  Access to the following members must be guarded by the receive_lock */
-    GStaticMutex receive_lock;
+    GMutex receive_lock;
 
     /* list of mpudpm_socket_t structs */
     GSList *recv_sockets;
@@ -138,7 +138,7 @@ struct _lcm_provider_t {
      *  Access to the following members must be guarded by the transmit_lock
      *  NOTE: If you need to hold both receive_lock and transmit_lock, then make sure
      *  that you lock receive_lock before transmit_lock to avoid deadlock*/
-    GStaticMutex transmit_lock;
+    GMutex transmit_lock;
 
     /* All traffic gets sent from a single socket */
     SOCKET send_fd;
@@ -168,8 +168,9 @@ struct _lcm_provider_t {
     /* synchronization variables used only while allocating receive resources
      */
     int8_t creating_read_thread;
-    GCond *create_read_thread_cond;
-    GMutex *create_read_thread_mutex;
+    GCond create_read_thread_cond;
+    GMutex create_read_thread_mutex;
+    GMutex *p_create_read_thread_mutex;
 
     /* other variables */
     lcm_frag_buf_store *frag_bufs;
@@ -285,11 +286,12 @@ void lcm_mpudpm_destroy(lcm_mpudpm_t *lcm)
     lcm_internal_pipe_close(lcm->notify_pipe[0]);
     lcm_internal_pipe_close(lcm->notify_pipe[1]);
 
-    g_static_mutex_free(&lcm->receive_lock);
-    g_static_mutex_free(&lcm->transmit_lock);
-    if (lcm->create_read_thread_mutex) {
-        g_mutex_free(lcm->create_read_thread_mutex);
-        g_cond_free(lcm->create_read_thread_cond);
+    g_mutex_clear(&lcm->receive_lock);
+    g_mutex_clear(&lcm->transmit_lock);
+    if (lcm->p_create_read_thread_mutex) {
+        g_mutex_clear(&lcm->create_read_thread_mutex);
+	lcm->p_create_read_thread_mutex = NULL;
+        g_cond_clear(&lcm->create_read_thread_cond);
     }
 
     if (lcm->regex_finder_re != NULL) {
@@ -480,9 +482,9 @@ static int recv_message_fragment(lcm_mpudpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz
         // yes, transfer the message into the lcm_buf_t
 
         // deallocate the ringbuffer-allocated buffer
-        g_static_mutex_lock(&lcm->receive_lock);
+        g_mutex_lock(&lcm->receive_lock);
         lcm_buf_free_data(lcmb, lcm->ringbuf);
-        g_static_mutex_unlock(&lcm->receive_lock);
+        g_mutex_unlock(&lcm->receive_lock);
 
         // transfer ownership of the message's payload buffer
         lcmb->buf = fbuf->data;
@@ -543,9 +545,9 @@ static void dispatch_complete_message(lcm_mpudpm_t *lcm, lcm_buf_t *lcmb, int ac
 {
     int handled_internal_message = 0;
     if (strcmp(lcmb->channel_name, CHANNEL_TO_PORT_MAP_REQUEST_CHANNEL) == 0) {
-        g_static_mutex_lock(&lcm->transmit_lock);
+        g_mutex_lock(&lcm->transmit_lock);
         publish_channel_mapping_update(lcm);
-        g_static_mutex_unlock(&lcm->transmit_lock);
+        g_mutex_unlock(&lcm->transmit_lock);
         // discard the received message
         handled_internal_message = 1;
     } else if (strcmp(lcmb->channel_name, CHANNEL_TO_PORT_MAP_UPDATE_CHANNEL) == 0) {
@@ -564,13 +566,13 @@ static void dispatch_complete_message(lcm_mpudpm_t *lcm, lcm_buf_t *lcmb, int ac
 
     if (handled_internal_message) {
         // one of the handlers above took it, so discard lcmb
-        g_static_mutex_lock(&lcm->receive_lock);
+        g_mutex_lock(&lcm->receive_lock);
         lcm_buf_free_data(lcmb, lcm->ringbuf);
         lcm_buf_enqueue(lcm->inbufs_empty, lcmb);
-        g_static_mutex_unlock(&lcm->receive_lock);
+        g_mutex_unlock(&lcm->receive_lock);
     } else {
         // enqueue the lcmb for handling by the user
-        g_static_mutex_lock(&lcm->receive_lock);
+        g_mutex_lock(&lcm->receive_lock);
 
         // if the newly received packet is a short packet, then resize the space
         // allocated in the ringbuffer to exactly match the amount of space
@@ -590,7 +592,7 @@ static void dispatch_complete_message(lcm_mpudpm_t *lcm, lcm_buf_t *lcmb, int ac
         }
         /* Queue the packet for future retrieval by lcm_handle (). */
         lcm_buf_enqueue(lcm->inbufs_filled, lcmb);
-        g_static_mutex_unlock(&lcm->receive_lock);
+        g_mutex_unlock(&lcm->receive_lock);
     }
 }
 
@@ -611,7 +613,7 @@ static void *recv_thread(void *user)
     // loop until we get an exit message on the thread_msg_pipe
     while (1) {
         // lock subscription lists so things don't change on us
-        g_static_mutex_lock(&lcm->receive_lock);
+        g_mutex_lock(&lcm->receive_lock);
 
         // setup file descriptors for select
         fd_set fds;
@@ -631,7 +633,7 @@ static void *recv_thread(void *user)
         lcm->recv_sockets_changed = 0;
 
         // unlock receive_lock while we wait for a message
-        g_static_mutex_unlock(&lcm->receive_lock);
+        g_mutex_unlock(&lcm->receive_lock);
 
         if (select(maxfd + 1, &fds, NULL, NULL, NULL) < 0) {
             perror("udp_read_packet -- select() failed:");
@@ -665,11 +667,11 @@ static void *recv_thread(void *user)
                 break;
             }
         }
-        g_static_mutex_lock(&lcm->receive_lock);
+        g_mutex_lock(&lcm->receive_lock);
         if (lcm->recv_sockets_changed) {
             // the set of receive sockets has changed, so we need to start
             // over
-            g_static_mutex_unlock(&lcm->receive_lock);
+            g_mutex_unlock(&lcm->receive_lock);
             continue;
         }
 
@@ -697,7 +699,7 @@ static void *recv_thread(void *user)
                 }
 
                 // unlock while we actually receive the incoming message
-                g_static_mutex_unlock(&lcm->receive_lock);
+                g_mutex_unlock(&lcm->receive_lock);
                 struct iovec vec;
                 vec.iov_base = lcmb->buf;
                 vec.iov_len = 65535;
@@ -733,7 +735,7 @@ static void *recv_thread(void *user)
                 if (sz < sizeof(lcm2_header_short_t)) {
                     // packet too short to be LCM
                     lcm->udp_discarded_bad++;
-                    g_static_mutex_lock(&lcm->receive_lock);
+                    g_mutex_lock(&lcm->receive_lock);
                     continue;
                 }
 
@@ -778,7 +780,7 @@ static void *recv_thread(void *user)
                 else {
                     dbg(DBG_LCM, "LCM: bad magic\n");
                     lcm->udp_discarded_bad++;
-                    g_static_mutex_lock(&lcm->receive_lock);
+                    g_mutex_lock(&lcm->receive_lock);
                     continue;
                 }
 
@@ -788,20 +790,20 @@ static void *recv_thread(void *user)
                     lcmb = NULL;
                 }
                 // lock to go back around the while loop
-                g_static_mutex_lock(&lcm->receive_lock);
+                g_mutex_lock(&lcm->receive_lock);
             }
 
             // we're done with this file descriptor
             // lock the receive lock to check whether the receive sockets have
             // changed and go back around the loop
-            g_static_mutex_lock(&lcm->receive_lock);
+            g_mutex_lock(&lcm->receive_lock);
             if (lcm->recv_sockets_changed) {
                 // the set of receive sockets may have changed, so we need to
                 // break and wait again on the appropriate set of sockets
                 break;
             }
         }
-        g_static_mutex_unlock(&lcm->receive_lock);
+        g_mutex_unlock(&lcm->receive_lock);
     }
 
     dbg(DBG_LCM, "read thread exiting\n");
@@ -844,14 +846,14 @@ int lcm_mpudpm_subscribe(lcm_mpudpm_t *lcm, const char *channel)
         // Request an update to the channel to port map
         dbg(DBG_LCM, "Requesting a channel to port map update\n");
         char *msg = "r";
-        g_static_mutex_lock(&lcm->transmit_lock);
+        g_mutex_lock(&lcm->transmit_lock);
         publish_message_internal(lcm, CHANNEL_TO_PORT_MAP_REQUEST_CHANNEL, (uint8_t *) msg,
                                  strlen(msg));
-        g_static_mutex_unlock(&lcm->transmit_lock);
+        g_mutex_unlock(&lcm->transmit_lock);
     } else {
         dbg(DBG_LCM, "Subscribing to single channel: %s\n", channel);
         // add it to our channel map
-        g_static_mutex_lock(&lcm->transmit_lock);
+        g_mutex_lock(&lcm->transmit_lock);
 
         void *lookup_value = g_hash_table_lookup(lcm->channel_to_port_map, channel);
         uint16_t port;
@@ -865,17 +867,17 @@ int lcm_mpudpm_subscribe(lcm_mpudpm_t *lcm, const char *channel)
         } else {
             port = GPOINTER_TO_UINT(lookup_value);
         }
-        g_static_mutex_unlock(&lcm->transmit_lock);
+        g_mutex_unlock(&lcm->transmit_lock);
 
-        g_static_mutex_lock(&lcm->receive_lock);
+        g_mutex_lock(&lcm->receive_lock);
         add_channel_to_subscriber(lcm, sub, sub->channel_string, port);
-        g_static_mutex_unlock(&lcm->receive_lock);
+        g_mutex_unlock(&lcm->receive_lock);
     }
 
     // add sub to the list of active subscribers
-    g_static_mutex_lock(&lcm->receive_lock);
+    g_mutex_lock(&lcm->receive_lock);
     lcm->subscribers = g_slist_prepend(lcm->subscribers, sub);
-    g_static_mutex_unlock(&lcm->receive_lock);
+    g_mutex_unlock(&lcm->receive_lock);
 
     // Do an update to set the ports used by this subscription
     // this is what will actually open the sockets if needed...
@@ -885,7 +887,7 @@ int lcm_mpudpm_subscribe(lcm_mpudpm_t *lcm, const char *channel)
 
 int lcm_mpudpm_unsubscribe(lcm_mpudpm_t *lcm, const char *channel)
 {
-    g_static_mutex_lock(&lcm->receive_lock);
+    g_mutex_lock(&lcm->receive_lock);
     GSList *chan_it = NULL;
     mpudpm_subscriber_t *chan_sub = NULL;
     for (GSList *it = lcm->subscribers; it != NULL; it = it->next) {
@@ -898,7 +900,7 @@ int lcm_mpudpm_unsubscribe(lcm_mpudpm_t *lcm, const char *channel)
     }
     if (chan_it == NULL) {
         dbg(DBG_LCM, "ERROR could not unsubscribe from %s, no subscriber found!\n", channel);
-        g_static_mutex_unlock(&lcm->receive_lock);
+        g_mutex_unlock(&lcm->receive_lock);
         return -1;
     }
 
@@ -916,7 +918,7 @@ int lcm_mpudpm_unsubscribe(lcm_mpudpm_t *lcm, const char *channel)
     }
     lcm->subscribers = g_slist_delete_link(lcm->subscribers, chan_it);
     mpudpm_subscriber_t_destroy(chan_sub);
-    g_static_mutex_unlock(&lcm->receive_lock);
+    g_mutex_unlock(&lcm->receive_lock);
     return 0;
 }
 
@@ -981,7 +983,7 @@ static void channel_port_mapping_update_handler(lcm_mpudpm_t *lcm,
                 msg->num_ports, lcm->params.num_mc_ports);
         return;
     }
-    g_static_mutex_lock(&lcm->transmit_lock);
+    g_mutex_lock(&lcm->transmit_lock);
     int8_t updated_channel_to_port_map = FALSE;
     for (int i = 0; i < msg->num_channels; i++) {
         void *lookup_value = g_hash_table_lookup(lcm->channel_to_port_map, msg->mapping[i].channel);
@@ -1005,7 +1007,7 @@ static void channel_port_mapping_update_handler(lcm_mpudpm_t *lcm,
         dbg(DBG_LCM, "Channel to port map is up to date\n");
         lcm->last_mapping_update_utime = recv_utime;
     }
-    g_static_mutex_unlock(&lcm->transmit_lock);
+    g_mutex_unlock(&lcm->transmit_lock);
 
     if (updated_channel_to_port_map) {
         update_subscription_ports(lcm);
@@ -1044,8 +1046,8 @@ static void add_channel_to_subscriber(lcm_mpudpm_t *lcm, mpudpm_subscriber_t *su
 static void update_subscription_ports(lcm_mpudpm_t *lcm)
 {
     // grab both locks in the proper order
-    g_static_mutex_lock(&lcm->receive_lock);
-    g_static_mutex_lock(&lcm->transmit_lock);
+    g_mutex_lock(&lcm->receive_lock);
+    g_mutex_lock(&lcm->transmit_lock);
 
     for (GSList *it = lcm->subscribers; it != NULL; it = it->next) {
         mpudpm_subscriber_t *sub = (mpudpm_subscriber_t *) it->data;
@@ -1076,8 +1078,8 @@ static void update_subscription_ports(lcm_mpudpm_t *lcm)
         }
     }
     // Release both locks in the proper order
-    g_static_mutex_unlock(&lcm->transmit_lock);
-    g_static_mutex_unlock(&lcm->receive_lock);
+    g_mutex_unlock(&lcm->transmit_lock);
+    g_mutex_unlock(&lcm->receive_lock);
 }
 
 // This function assumes that the caller is holding the transmit_lock
@@ -1097,9 +1099,9 @@ static int publish_message_internal(lcm_mpudpm_t *lcm, const char *channel, cons
     // Set up the receive thread to manage port mapping requests if needed
     if (!lcm->recv_thread_created_tx) {
         // release transmit lock while we setup the receive thread
-        g_static_mutex_unlock(&lcm->transmit_lock);
+        g_mutex_unlock(&lcm->transmit_lock);
         int status = setup_recv_parts(lcm);
-        g_static_mutex_lock(&lcm->transmit_lock);
+        g_mutex_lock(&lcm->transmit_lock);
         if (status < 0) {
             return -1;
         }
@@ -1247,9 +1249,9 @@ int lcm_mpudpm_publish(lcm_mpudpm_t *lcm, const char *channel, const void *data,
     }
 
     // acquire lock so that we can call the internal publish function
-    g_static_mutex_lock(&lcm->transmit_lock);
+    g_mutex_lock(&lcm->transmit_lock);
     int status = publish_message_internal(lcm, channel, data, datalen);
-    g_static_mutex_unlock(&lcm->transmit_lock);
+    g_mutex_unlock(&lcm->transmit_lock);
     return status;
 }
 
@@ -1273,12 +1275,12 @@ int lcm_mpudpm_handle(lcm_mpudpm_t *lcm)
     }
 
     /* Dequeue the next received packet */
-    g_static_mutex_lock(&lcm->receive_lock);
+    g_mutex_lock(&lcm->receive_lock);
     lcm_buf_t *lcmb = lcm_buf_dequeue(lcm->inbufs_filled);
 
     if (!lcmb) {
         fprintf(stderr, "Error: no packet available despite getting notification.\n");
-        g_static_mutex_unlock(&lcm->receive_lock);
+        g_mutex_unlock(&lcm->receive_lock);
         return -1;
     }
 
@@ -1287,7 +1289,7 @@ int lcm_mpudpm_handle(lcm_mpudpm_t *lcm)
     if (!lcm_buf_queue_is_empty(lcm->inbufs_filled))
         if (lcm_internal_pipe_write(lcm->notify_pipe[1], "+", 1) < 0)
             perror("write to notify");
-    g_static_mutex_unlock(&lcm->receive_lock);
+    g_mutex_unlock(&lcm->receive_lock);
 
     lcm_recv_buf_t rbuf;
     rbuf.data = (uint8_t *) lcmb->buf + lcmb->data_offset;
@@ -1304,10 +1306,10 @@ int lcm_mpudpm_handle(lcm_mpudpm_t *lcm)
         lcm_dispatch_handlers(lcm->lcm, &rbuf, lcmb->channel_name);
     }
 
-    g_static_mutex_lock(&lcm->receive_lock);
+    g_mutex_lock(&lcm->receive_lock);
     lcm_buf_free_data(lcmb, lcm->ringbuf);
     lcm_buf_enqueue(lcm->inbufs_empty, lcmb);
-    g_static_mutex_unlock(&lcm->receive_lock);
+    g_mutex_unlock(&lcm->receive_lock);
 
     return 0;
 }
@@ -1327,9 +1329,9 @@ static int mpudpm_self_test(lcm_mpudpm_t *lcm)
 
     // transmit a message
     char *msg = "lcm self test";
-    g_static_mutex_lock(&lcm->transmit_lock);
+    g_mutex_lock(&lcm->transmit_lock);
     publish_message_internal(lcm, SELF_TEST_CHANNEL, (uint8_t *) msg, strlen(msg));
-    g_static_mutex_unlock(&lcm->transmit_lock);
+    g_mutex_unlock(&lcm->transmit_lock);
 
     // wait one second for message to be received
     GTimeVal now, endtime;
@@ -1354,9 +1356,9 @@ static int mpudpm_self_test(lcm_mpudpm_t *lcm)
 
         g_get_current_time(&now);
         if (lcm_timeval_compare(&now, &next_retransmit) > 0) {
-            g_static_mutex_lock(&lcm->transmit_lock);
+            g_mutex_lock(&lcm->transmit_lock);
             status = publish_message_internal(lcm, SELF_TEST_CHANNEL, (uint8_t *) msg, strlen(msg));
-            g_static_mutex_unlock(&lcm->transmit_lock);
+            g_mutex_unlock(&lcm->transmit_lock);
             lcm_timeval_add(&now, &retransmit_interval, &next_retransmit);
         }
 
@@ -1514,7 +1516,7 @@ static void remove_recv_socket(lcm_mpudpm_t *lcm, mpudpm_socket_t *sock)
 
 static int setup_recv_parts(lcm_mpudpm_t *lcm)
 {
-    g_static_mutex_lock(&lcm->receive_lock);
+    g_mutex_lock(&lcm->receive_lock);
 
     // some thread synchronization code to ensure that only one thread sets up the
     // receive thread, and that all threads entering this function after the thread
@@ -1523,35 +1525,37 @@ static int setup_recv_parts(lcm_mpudpm_t *lcm)
         // check if this thread is the one creating the receive thread.
         // If so, just return.
         if (g_static_private_get(&CREATE_READ_THREAD_PKEY)) {
-            g_static_mutex_unlock(&lcm->receive_lock);
+            g_mutex_unlock(&lcm->receive_lock);
             return 0;
         }
 
-        // ugly bit with two mutexes because we can't use a GStaticRecMutex with a GCond
-        g_mutex_lock(lcm->create_read_thread_mutex);
-        g_static_mutex_unlock(&lcm->receive_lock);
+        // ugly bit with two mutexes because we can't use a GRecMutex with a GCond
+	// TODO: investigate whether this is still true
+        g_mutex_lock(lcm->p_create_read_thread_mutex);
+        g_mutex_unlock(&lcm->receive_lock);
 
         // wait for the thread creating the read thread to finish
         while (lcm->creating_read_thread) {
-            g_cond_wait(lcm->create_read_thread_cond, lcm->create_read_thread_mutex);
+            g_cond_wait(&lcm->create_read_thread_cond, lcm->p_create_read_thread_mutex);
         }
-        g_mutex_unlock(lcm->create_read_thread_mutex);
-        g_static_mutex_lock(&lcm->receive_lock);
+        g_mutex_unlock(lcm->p_create_read_thread_mutex);
+        g_mutex_lock(&lcm->receive_lock);
 
         // if we've gotten here, then either the read thread is created, or it
         // was not possible to do so.  Figure out which happened, and return.
         int result = lcm->recv_thread_created ? 0 : -1;
-        g_static_mutex_unlock(&lcm->receive_lock);
+        g_mutex_unlock(&lcm->receive_lock);
         return result;
     } else if (lcm->recv_thread_created) {
-        g_static_mutex_unlock(&lcm->receive_lock);
+        g_mutex_unlock(&lcm->receive_lock);
         return 0;
     }
 
     // no other thread is trying to create the read thread right now.  claim that task.
     lcm->creating_read_thread = 1;
-    lcm->create_read_thread_mutex = g_mutex_new();
-    lcm->create_read_thread_cond = g_cond_new();
+    g_mutex_init(&lcm->create_read_thread_mutex);
+    lcm->p_create_read_thread_mutex = &lcm->create_read_thread_mutex;
+    g_cond_init(&lcm->create_read_thread_cond);
 
     // mark this thread as the one creating the read thread
     g_static_private_set(&CREATE_READ_THREAD_PKEY, GINT_TO_POINTER(1), NULL);
@@ -1580,7 +1584,7 @@ static int setup_recv_parts(lcm_mpudpm_t *lcm)
     fcntl(lcm->thread_msg_pipe[1], F_SETFL, O_NONBLOCK);
 
     /* Start the reader thread */
-    lcm->read_thread = g_thread_create(recv_thread, lcm, TRUE, NULL);
+    lcm->read_thread = g_thread_new(NULL, recv_thread, lcm);
     if (!lcm->read_thread) {
         fprintf(stderr, "Error: LCM failed to start reader thread\n");
         goto setup_recv_thread_fail;
@@ -1599,12 +1603,12 @@ static int setup_recv_parts(lcm_mpudpm_t *lcm)
     dbg(DBG_LCM, "Publishing channel to port map updates every %.4f seconds\n",
         lcm->channel_to_port_map_update_period / 1.0e6);
 
-    g_static_mutex_unlock(&lcm->receive_lock);
+    g_mutex_unlock(&lcm->receive_lock);
 
     // conduct a self-test just to make sure everything is working.
     dbg(DBG_LCM, "LCM: conducting self test\n");
     int self_test_results = mpudpm_self_test(lcm);
-    g_static_mutex_lock(&lcm->receive_lock);
+    g_mutex_lock(&lcm->receive_lock);
 
     if (0 == self_test_results) {
         dbg(DBG_LCM, "LCM: self test successful\n");
@@ -1617,23 +1621,23 @@ static int setup_recv_parts(lcm_mpudpm_t *lcm)
     }
 
     // notify threads waiting for the read thread to be created
-    g_mutex_lock(lcm->create_read_thread_mutex);
+    g_mutex_lock(lcm->p_create_read_thread_mutex);
     lcm->creating_read_thread = 0;
-    g_cond_broadcast(lcm->create_read_thread_cond);
-    g_mutex_unlock(lcm->create_read_thread_mutex);
-    g_static_mutex_unlock(&lcm->receive_lock);
+    g_cond_broadcast(&lcm->create_read_thread_cond);
+    g_mutex_unlock(lcm->p_create_read_thread_mutex);
+    g_mutex_unlock(&lcm->receive_lock);
 
     // tell publishers that the receive thread has been created as well
-    g_static_mutex_lock(&lcm->transmit_lock);
+    g_mutex_lock(&lcm->transmit_lock);
     lcm->recv_thread_created_tx = 1;
-    g_static_mutex_unlock(&lcm->transmit_lock);
+    g_mutex_unlock(&lcm->transmit_lock);
 
     return self_test_results;
 
 setup_recv_thread_fail:
     destroy_recv_parts(lcm);
     fprintf(stderr, "ERROR creating receive thread!\n");
-    g_static_mutex_unlock(&lcm->receive_lock);
+    g_mutex_unlock(&lcm->receive_lock);
     return -1;
 }
 
@@ -1665,8 +1669,7 @@ lcm_provider_t *lcm_mpudpm_create(lcm_t *parent, const char *network, const GHas
 
     // synchronization variables used when allocating receive resources
     lcm->creating_read_thread = 0;
-    lcm->create_read_thread_mutex = NULL;
-    lcm->create_read_thread_cond = NULL;
+    lcm->p_create_read_thread_mutex = NULL;
 
     // internal notification pipe
     if (0 != lcm_internal_pipe_create(lcm->notify_pipe)) {
@@ -1676,8 +1679,8 @@ lcm_provider_t *lcm_mpudpm_create(lcm_t *parent, const char *network, const GHas
     }
     fcntl(lcm->notify_pipe[1], F_SETFL, O_NONBLOCK);
 
-    g_static_mutex_init(&lcm->receive_lock);
-    g_static_mutex_init(&lcm->transmit_lock);
+    g_mutex_init(&lcm->receive_lock);
+    g_mutex_init(&lcm->transmit_lock);
 
     dbg(DBG_LCM, "Initializing Multi-Port LCM UDP Multicast context...\n");
     dbg(DBG_LCM, "Multicast to %s on ports %d:%d\n", inet_ntoa(params.mc_addr),

--- a/lcm/lcm_mpudpm.c
+++ b/lcm/lcm_mpudpm.c
@@ -200,7 +200,7 @@ static void update_subscription_ports(lcm_mpudpm_t *lcm);
 static void add_channel_to_subscriber(lcm_mpudpm_t *lcm, mpudpm_subscriber_t *sub,
                                       const char *channel, uint16_t port);
 
-static GStaticPrivate CREATE_READ_THREAD_PKEY = G_STATIC_PRIVATE_INIT;
+static GPrivate CREATE_READ_THREAD_PKEY;
 
 static void mpudpm_subscriber_t_destroy(mpudpm_subscriber_t *sub)
 {
@@ -1523,7 +1523,7 @@ static int setup_recv_parts(lcm_mpudpm_t *lcm)
     if (lcm->creating_read_thread) {
         // check if this thread is the one creating the receive thread.
         // If so, just return.
-        if (g_static_private_get(&CREATE_READ_THREAD_PKEY)) {
+        if (g_private_get(&CREATE_READ_THREAD_PKEY)) {
             g_mutex_unlock(&lcm->receive_lock);
             return 0;
         }
@@ -1557,7 +1557,7 @@ static int setup_recv_parts(lcm_mpudpm_t *lcm)
     g_cond_init(&lcm->create_read_thread_cond);
 
     // mark this thread as the one creating the read thread
-    g_static_private_set(&CREATE_READ_THREAD_PKEY, GINT_TO_POINTER(1), NULL);
+    g_private_set(&CREATE_READ_THREAD_PKEY, GINT_TO_POINTER(1));
 
     dbg(DBG_LCM, "allocating resources for receiving messages\n");
 

--- a/lcm/lcm_tcpq.c
+++ b/lcm/lcm_tcpq.c
@@ -55,13 +55,6 @@ static int _close_socket(int fd)
 #endif
 }
 
-static int64_t timestamp_now(void)
-{
-    GTimeVal tv;
-    g_get_current_time(&tv);
-    return (int64_t) tv.tv_sec * 1000000 + tv.tv_usec;
-}
-
 static int _recv_fully(int fd, void *b, int len)
 {
     int cnt = 0;
@@ -358,7 +351,7 @@ static int lcm_tcpq_handle(lcm_tcpq_t *self)
     lcm_recv_buf_t rbuf;
     rbuf.data = self->data_buf;
     rbuf.data_size = data_len;
-    rbuf.recv_utime = timestamp_now();
+    rbuf.recv_utime = g_get_real_time();
     rbuf.lcm = self->lcm;
 
     if (lcm_try_enqueue_message(self->lcm, self->recv_channel_buf))

--- a/lcm/lcm_udpm.c
+++ b/lcm/lcm_udpm.c
@@ -114,7 +114,7 @@ struct _lcm_provider_t {
 
 static int _setup_recv_parts(lcm_udpm_t *lcm);
 
-static GStaticPrivate CREATE_READ_THREAD_PKEY = G_STATIC_PRIVATE_INIT;
+static GPrivate CREATE_READ_THREAD_PKEY;
 
 static void _destroy_recv_parts(lcm_udpm_t *lcm)
 {
@@ -851,7 +851,7 @@ static int _setup_recv_parts(lcm_udpm_t *lcm)
     if (lcm->creating_read_thread) {
         // check if this thread is the one creating the receive thread.
         // If so, just return.
-        if (g_static_private_get(&CREATE_READ_THREAD_PKEY)) {
+        if (g_private_get(&CREATE_READ_THREAD_PKEY)) {
             g_rec_mutex_unlock(&lcm->mutex);
             return 0;
         }
@@ -884,7 +884,7 @@ static int _setup_recv_parts(lcm_udpm_t *lcm)
     lcm->p_create_read_thread_mutex = &lcm->create_read_thread_mutex;
     g_cond_init(&lcm->create_read_thread_cond);
     // mark this thread as the one creating the read thread
-    g_static_private_set(&CREATE_READ_THREAD_PKEY, GINT_TO_POINTER(1), NULL);
+    g_private_set(&CREATE_READ_THREAD_PKEY, GINT_TO_POINTER(1));
 
     dbg(DBG_LCM, "allocating resources for receiving messages\n");
 

--- a/lcm/udpm_util.h
+++ b/lcm/udpm_util.h
@@ -93,42 +93,6 @@ static inline int lcm_close_socket(SOCKET fd)
 #endif
 }
 
-static inline int lcm_timeval_compare(const GTimeVal *a, const GTimeVal *b)
-{
-    if (a->tv_sec == b->tv_sec && a->tv_usec == b->tv_usec)
-        return 0;
-    if (a->tv_sec > b->tv_sec || (a->tv_sec == b->tv_sec && a->tv_usec > b->tv_usec))
-        return 1;
-    return -1;
-}
-
-static inline void lcm_timeval_add(const GTimeVal *a, const GTimeVal *b, GTimeVal *dest)
-{
-    dest->tv_sec = a->tv_sec + b->tv_sec;
-    dest->tv_usec = a->tv_usec + b->tv_usec;
-    if (dest->tv_usec > 999999) {
-        dest->tv_usec -= 1000000;
-        dest->tv_sec++;
-    }
-}
-
-static inline void lcm_timeval_subtract(const GTimeVal *a, const GTimeVal *b, GTimeVal *dest)
-{
-    dest->tv_sec = a->tv_sec - b->tv_sec;
-    dest->tv_usec = a->tv_usec - b->tv_usec;
-    if (dest->tv_usec < 0) {
-        dest->tv_usec += 1000000;
-        dest->tv_sec--;
-    }
-}
-
-static inline int64_t lcm_timestamp_now()
-{
-    GTimeVal tv;
-    g_get_current_time(&tv);
-    return (int64_t) tv.tv_sec * 1000000 + tv.tv_usec;
-}
-
 /******************** message buffer **********************/
 typedef struct _lcm_buf {
     char channel_name[LCM_MAX_CHANNEL_NAME_LENGTH + 1];

--- a/liblcm-test/lcm-tester.c
+++ b/liblcm-test/lcm-tester.c
@@ -14,13 +14,6 @@
 
 #include <lcm/lcm.h>
 
-static int64_t timestamp_now()
-{
-    GTimeVal tv;
-    g_get_current_time(&tv);
-    return (int64_t) tv.tv_sec * 1000000 + tv.tv_usec;
-}
-
 static int64_t timestamp_seconds(int64_t v)
 {
     return v / 1000000;
@@ -132,12 +125,12 @@ int main(int argc, char **argv)
     printf("LCM: transmitting %d messages to self-receive...\n", ntotransmit * 2);
 
     int64_t send_interval = 100000;
-    int64_t time_to_send = timestamp_now() + send_interval;
+    int64_t time_to_send = g_get_real_time() + send_interval;
     struct timeval timeout;
     fd_set readfds;
 
     while (ntransmitted < ntotransmit) {
-        int64_t now = timestamp_now();
+        int64_t now = g_get_real_time();
         if (time_to_send < now) {
             time_to_send = now;
         }
@@ -157,12 +150,12 @@ int main(int argc, char **argv)
             lcm_handle(lcm);
         }
 
-        if (timestamp_now() >= time_to_send) {
+        if (g_get_real_time() >= time_to_send) {
             lcm_publish(lcm, "TEST", data, datalen);
             lcm_publish(lcm, "12345", data, datalen);
             ntransmitted++;
 
-            time_to_send = timestamp_now() + send_interval;
+            time_to_send = g_get_real_time() + send_interval;
         }
     }
 


### PR DESCRIPTION
I tried to achieve some basic organization with each commit.  The first hits the Thread API, then GTimeVal, and the third GStaticPrivate.  The last commit is just updating the GLib version check to `2.32.0`.

Mainly, this is just find and replace stuff.  The only tricky part was taking an `int64_t` returned from `g_get_real_time()` and splitting it out into a `struct timeval` for the `select` function's timeout parameter.  You can see that in `lcm/lcm_udpm.c`.

I ran the tests with `make test` in fc37, ubuntu 22.04, and ubuntu 20.04 containers and all tests passed.  Also ran some log file playback and everything seemed unchanged.

Closes #65.