### PR TITLE
lcm-python: replace PyEval_CallObject with PyObject_CallObject

### DIFF
--- a/lcm-python/pylcm.c
+++ b/lcm-python/pylcm.c
@@ -106,7 +106,7 @@ static void pylcm_msg_handler(const lcm_recv_buf_t *rbuf, const char *channel, v
                                       rbuf->data, rbuf->data_size);
 #endif
 
-    PyObject *result = PyEval_CallObject(subs_obj->handler, arglist);
+    PyObject *result = PyObject_CallObject(subs_obj->handler, arglist);
     Py_DECREF(arglist);
 
     if (!result) {


### PR DESCRIPTION
`PyEval_CallObject` was deprecated in [`3.9`](https://docs.python.org/3/whatsnew/3.9.html#changes-in-the-c-api) and `PyObject_CallObject` has been available since at least [`2.7`](https://docs.python.org/2.7/c-api/object.html?highlight=pyobject_callobject#c.PyObject_CallObject) and [`3.5`](https://docs.python.org/3.5/c-api/object.html?highlight=pyobject_callobject#c.PyObject_CallObject).