### PR TITLE
Docs: update links to pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The LCM project is active again. The current near-term plan is to:
 # Quick Links
 
 * [LCM downloads](https://github.com/lcm-proj/lcm/releases)
-* [Website and documentation](https://lcm-proj.github.io)
+* [Website and documentation](https://lcm-proj.github.io/lcm)
 
 # Features
 

--- a/docs/release_checklist
+++ b/docs/release_checklist
@@ -41,21 +41,6 @@
   b. Name the release title "vX.Y.Z"
   c. Add release notes from the NEWS file
 
-# Update documentation
-
-1. Build docs
-  $ make doc
-2. Clone the documentation repository
-  $ git clone https://github.com/lcm-proj/lcm-proj.github.io
-  $ cd lcm-proj.github.io
-3. Copy the built docs to the lcm.www repository
-  $ cp -r ../docs/html/* .
-4. Commit the changes, tag the release, and push to origin
-  $ git commit -a -m "Release X.Y.Z"
-  $ git tag vX.Y.Z
-  $ git push origin master
-  $ git push origin vX.Y.Z
-
 # Notify the mailing list
 
 1. Send e-mail to lcm-users@googlegroups.com

--- a/lcm-lua/rock/lcm-1.4.0-0.rockspec
+++ b/lcm-lua/rock/lcm-1.4.0-0.rockspec
@@ -13,7 +13,7 @@ emphasizes simplicity in usage, exhibits high performance under heavy load, and
 runs on a variety of programming languages and operating systems.
 
 The LCM project is located here:
-http://lcm-proj.github.io/
+http://lcm-proj.github.io/lcm/
   ]],
   homepage = "http://github.com/lcm-proj/lcm",
   license = "LGPL v2.1"

--- a/lcm/lcm_mpudpm.c
+++ b/lcm/lcm_mpudpm.c
@@ -449,7 +449,7 @@ static int recv_message_fragment(lcm_mpudpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz
                 "insufficient buffer space is very high.\n"
                 "\n"
                 "For more information, visit:\n"
-                "   http://lcm-proj.github.io/multicast_setup.html\n\n");
+                "   http://lcm-proj.github.io/lcm/multicast_setup.html\n\n");
         lcm->warned_about_small_kernel_buf = 1;
     }
 #endif
@@ -1454,7 +1454,7 @@ static mpudpm_socket_t *add_recv_socket(lcm_mpudpm_t *lcm, uint16_t port)
                 "LCM UDP receive buffer size (%d) \n"
                 "       is smaller than reqested (%d). "
                 "For more info:\n"
-                "       http://lcm-proj.github.io/multicast_setup.html\n",
+                "       http://lcm-proj.github.io/lcm/multicast_setup.html\n",
                 lcm->kernel_rbuf_sz, lcm->params.recv_buf_size);
         }
     }

--- a/lcm/lcm_udpm.c
+++ b/lcm/lcm_udpm.c
@@ -298,7 +298,7 @@ static int _recv_message_fragment(lcm_udpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz)
                 "insufficient buffer space is very high.\n"
                 "\n"
                 "For more information, visit:\n"
-                "   http://lcm-proj.github.io/multicast_setup.html\n\n");
+                "   http://lcm-proj.github.io/lcm/multicast_setup.html\n\n");
         lcm->warned_about_small_kernel_buf = 1;
     }
 #endif
@@ -970,7 +970,7 @@ static int _setup_recv_parts(lcm_udpm_t *lcm)
                 "LCM UDP receive buffer size (%d) \n"
                 "       is smaller than reqested (%d). "
                 "For more info:\n"
-                "       http://lcm-proj.github.io/multicast_setup.html\n",
+                "       http://lcm-proj.github.io/lcm/multicast_setup.html\n",
                 lcm->kernel_rbuf_sz, lcm->params.recv_buf_size);
         }
     }

--- a/lcm/udpm_util.c
+++ b/lcm/udpm_util.c
@@ -311,7 +311,7 @@ show_route_cmds:
             "   sudo route add -net 224.0.0.0 netmask 240.0.0.0 dev lo\n"
             "\n"
             "For more information, visit:\n"
-            "   http://lcm-proj.github.io/multicast_setup.html\n\n",
+            "   http://lcm-proj.github.io/lcm/multicast_setup.html\n\n",
             inet_ntoa(lcm_mcaddr));
 }
 #endif

--- a/lcmgen/emit_go.c
+++ b/lcmgen/emit_go.c
@@ -244,7 +244,7 @@ lcm_struct_t *lcm_find_struct(lcmgen_t *lcm, lcm_member_t *lm)
  * Calculates the fingerprint during code generation.
  *
  * Algorithm as described in:
- *     https://lcm-proj.github.io/type_specification.html
+ *     https://lcm-proj.github.io/lcm/type_specification.html
  *
  * Returns calculated fingerprint or 0 on error
  */
@@ -1214,7 +1214,7 @@ static void emit_go_lcm_unmarshal_binary(FILE *f, lcmgen_t *lcm, lcm_struct_t *l
  * Emits code to calculate the fingerprint in runtime.
  *
  * Algorithm as described in:
- *     https://lcm-proj.github.io/type_specification.html
+ *     https://lcm-proj.github.io/lcm/type_specification.html
  */
 static void emit_go_lcm_fingerprint(FILE *f, lcmgen_t *lcm, lcm_struct_t *ls,
                                     const char *const typename, const char *const gotype,


### PR DESCRIPTION
This PR:

- Updates links to point at the automatically-updating pages (http://lcm-proj.github.io/lcm) rather than the manually-updated pages (http://lcm-proj.github.io)
- Removes manually updating the docs from the release checklist, since this is now automated 