### PR TITLE
remove environment specification from docs test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,6 @@ jobs:
       run: ctest -C ${{env.BUILD_TYPE}}
 
   docs:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
GH-381 introduced a bug where some junk was copy-pasted from the docs deploy job into the docs test job, causing all non-master pushes and PRs to fail. This PR removes that junk.