### PR TITLE
Clean up a few C compiler warnings

### DIFF
--- a/lcm/lcm_mpudpm.c
+++ b/lcm/lcm_mpudpm.c
@@ -398,7 +398,7 @@ static int recv_message_fragment(lcm_mpudpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz
 
     // any existing fragment buffer for this message source?
     lcm_frag_key_t key;
-    key.from = &(lcmb->from);
+    key.from = (struct sockaddr_in*)&(lcmb->from);
     key.msg_seqno = msg_seqno;
     lcm_frag_buf_t *fbuf = lcm_frag_buf_store_lookup(lcm->frag_bufs, &key);
 

--- a/lcm/lcm_udpm.c
+++ b/lcm/lcm_udpm.c
@@ -243,7 +243,7 @@ static int _recv_message_fragment(lcm_udpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz)
 
     // any existing fragment buffer for this message source?
     lcm_frag_key_t key;
-    key.from = &(lcmb->from);
+    key.from = (struct sockaddr_in*)&(lcmb->from);
     key.msg_seqno = msg_seqno;
     lcm_frag_buf_t *fbuf = lcm_frag_buf_store_lookup(lcm->frag_bufs, &key);
 

--- a/lcmgen/emit_go.c
+++ b/lcmgen/emit_go.c
@@ -44,23 +44,6 @@
 
 /*
  * Simple function that takes a string like this.is.a.string and turns it into
- * this_is_a_string.
- *
- * CAUTION: memory has to be freed manually.
- */
-static char *dots_to_underscores(const char *const s)
-{
-    char *p = strdup(s);
-
-    for (char *t = p; *t != 0; t++)
-        if (*t == '.')
-            *t = '_';
-
-    return p;
-}
-
-/*
- * Simple function that takes a string like this.is.a.string and turns it into
  * this/is/a/string.
  *
  * CAUTION: memory has to be freed manually.
@@ -91,19 +74,6 @@ static char *strip_dots(const char *const s)
             p = t + 1;
 
     return strdup(p);
-}
-
-/*
- * Simple function that takes a string like this_is_a_string and turns it into
- * This_is_a_string.
- *
- * CAUTION: memory has to be freed manually.
- */
-static char *first_to_upper(const char *const str)
-{
-    char *s = strdup(str);
-    s[0] = toupper(s[0]);
-    return s;
 }
 
 /*
@@ -1147,7 +1117,6 @@ static void emit_go_lcm_decode(FILE *f, lcmgen_t *lcm, lcm_struct_t *ls, const c
 static void emit_go_lcm_unmarshal_binary(FILE *f, lcmgen_t *lcm, lcm_struct_t *ls,
                                          const char *const gotype, const uint64_t fingerprint)
 {
-    int readVar = 0;
     emit(0, "// UnmarshalBinary implements the BinaryUnmarshaler interface");
     emit(0, "func (p *%s) UnmarshalBinary(data []byte) (err error) {", gotype);
     if (ls->members->len) {


### PR DESCRIPTION
Fixes the following warnings on `master`:

```
lcm/lcm_mpudpm.c:401:14: warning: assignment to ‘struct sockaddr_in *’ from incompatible pointer type ‘struct sockaddr *’ [-Wincompatible-pointer-types]
  401 |     key.from = &(lcmb->from);

lcm/lcm_udpm.c:246:14: warning: assignment to ‘struct sockaddr_in *’ from incompatible pointer type ‘struct sockaddr *’ [-Wincompatible-pointer-types]
  246 |     key.from = &(lcmb->from);

lcm/lcmgen/emit_go.c:1150:9: warning: unused variable ‘readVar’ [-Wunused-variable]
 1150 |     int readVar = 0;

lcm/lcmgen/emit_go.c:102:14: warning: ‘first_to_upper’ defined but not used [-Wunused-function]
  102 | static char *first_to_upper(const char *const str)

lcm/lcmgen/emit_go.c:51:14: warning: ‘dots_to_underscores’ defined but not used [-Wunused-function]
   51 | static char *dots_to_underscores(const char *const s)
```
