### PR TITLE
Replace tmpnam with mkstemp

### DIFF
--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(test-c-memq_test memq_test.cpp common.c)
 target_link_libraries(test-c-memq_test ${test_c_libs})
 
 add_executable(test-c-eventlog_test eventlog_test.cpp common.c)
-target_link_libraries(test-c-eventlog_test ${test_c_libs})
+target_link_libraries(test-c-eventlog_test GLib2::glib ${test_c_libs})
 
 add_executable(test-c-udpm_test udpm_test.cpp common.c)
 target_link_libraries(test-c-udpm_test ${test_c_libs})

--- a/test/c/common.c
+++ b/test/c/common.c
@@ -354,19 +354,3 @@ void clear_lcmtest2_another_type_t(lcmtest2_another_type_t *msg)
 {
     return;
 }
-
-char *make_tmpnam()
-{
-#ifndef WIN32
-    return tmpnam(NULL);
-#else
-    return _tempnam(NULL, NULL);
-#endif
-}
-
-void free_tmpnam(char *tmpnam)
-{
-#ifdef WIN32
-    free(tmpnam);
-#endif
-}

--- a/test/c/common.h
+++ b/test/c/common.h
@@ -39,9 +39,6 @@ int check_lcmtest2_another_type_t(const lcmtest2_another_type_t *msg, int expect
 void fill_lcmtest2_another_type_t(int n, lcmtest2_another_type_t *msg);
 void clear_lcmtest2_another_type_t(lcmtest2_another_type_t *msg);
 
-char *make_tmpnam();
-void free_tmpnam(char *tmpnam);
-
 #ifdef __cplusplus
 }
 #endif

--- a/test/c/eventlog_test.cpp
+++ b/test/c/eventlog_test.cpp
@@ -1,3 +1,4 @@
+#include <glib.h>
 #include <gtest/gtest.h>
 #include <stdlib.h>
 #include <string.h>
@@ -8,20 +9,21 @@
 TEST(LCM_C, EventLogBasic)
 {
     // Open and close a log file.
-    char *fname = make_tmpnam();
+    char fname[] = "XXXXXX";
+    int fd = g_mkstemp(fname);
 
     lcm_eventlog_t *wlog = lcm_eventlog_create(fname, "w");
     EXPECT_NE((void *) NULL, wlog);
     lcm_eventlog_destroy(wlog);
-
-    free_tmpnam(fname);
+    close(fd);
 }
 
 TEST(LCM_C, EventLogWriteRead)
 {
     // Write some events to a log, then read them back in and check what was
     // read is the same as what was written.
-    char *fname = make_tmpnam();
+    char fname[] = "XXXXXX";
+    int fd = g_mkstemp(fname);
 
     lcm_eventlog_t *wlog = lcm_eventlog_create(fname, "w");
     EXPECT_NE((void *) NULL, wlog);
@@ -79,13 +81,14 @@ TEST(LCM_C, EventLogWriteRead)
     }
 
     lcm_eventlog_destroy(rlog);
-    free_tmpnam(fname);
+    close(fd);
 }
 
 TEST(LCM_C, EventLogCorrupt)
 {
     // Tests detection of corrupt data.
-    char *fname = make_tmpnam();
+    char fname[] = "XXXXXX";
+    int fd = g_mkstemp(fname);
 
     lcm_eventlog_t *wlog = lcm_eventlog_create(fname, "w");
     ASSERT_NE((void *) NULL, wlog);
@@ -128,5 +131,5 @@ TEST(LCM_C, EventLogCorrupt)
     EXPECT_EQ((void *) NULL, revent);
 
     lcm_eventlog_destroy(rlog);
-    free_tmpnam(fname);
+    close(fd);
 }


### PR DESCRIPTION
This addresses the linker warning:

```
CMakeFiles/test-c-client.dir/common.c.o:common.c:function make_tmpnam: warning: the use of `tmpnam' is dangerous, better use `mkstemp'
```

I'm assuming that `g_mkstemp` is a suitable replacement on the Windows platform but I'm not currently setup to test.  Since this only impacts the eventlog tests, I thought this was a low risk change.