### PR TITLE
Lcm-spy: Add cli params for the window title

### DIFF
--- a/lcm-java/lcm/lcm/LCM.java
+++ b/lcm-java/lcm/lcm/LCM.java
@@ -11,6 +11,18 @@ import lcm.util.*;
 /** Lightweight Communications and Marshalling Java implementation **/
 public class LCM
 {
+    /**
+     * 
+     * @return The value of the LCM_DEFAULT_URL environment variable if set
+     *         or "udpm://239.255.76.67:7667".
+     */
+    public static String getDefaultURL() {
+        String env = System.getenv("LCM_DEFAULT_URL");
+        if (null == env || env.isEmpty())
+            return "udpm://239.255.76.67:7667";
+        return env;
+    }
+
     static class SubscriptionRecord
     {
         String  regex;
@@ -37,20 +49,14 @@ public class LCM
     public LCM(String... urls) throws IOException
     {
         if (urls.length==0) {
-            String env = System.getenv("LCM_DEFAULT_URL");
-            if (env == null)
-                urls = new String[] {"udpm://239.255.76.67:7667"};
-            else
-                urls = new String[] { env };
+            urls = new String[] { getDefaultURL() };
         }
 
         for (String url : urls) {
             // Allow passing in NULL or the empty string to explicitly indicate
             // the default LCM URL.
             if(null == url || url.equals("")) {
-                url = System.getenv("LCM_DEFAULT_URL");
-                if (url == null)
-                    url = "udpm://239.255.76.67:7667";
+                url = getDefaultURL();
             }
         	
             URLParser up = new URLParser(url);

--- a/lcm-java/lcm/spy/Spy.java
+++ b/lcm-java/lcm/spy/Spy.java
@@ -515,7 +515,6 @@ public class Spy
         System.err.println("  -l, --lcm-url=URL      Use the specified LCM URL");
         System.err.println("  -t, --title [LABEL]    Display LABEL in the window title");
         System.err.println("  --title-url            Display the LCM URL in the title");
-        // System.err.println("  -, --            ");
         System.err.println("");
         System.exit(1);
     }


### PR DESCRIPTION
I use LCM with multiple multicast addresses at the same time. It'd be useful for my team if there were option to have more detailed window titles than just "LCM Spy" when using multiple windows. 

```
  -t, --title [LABEL]    Display LABEL in the window title
  --title-url            Display the LCM URL in the title
```
Example usages:
```
./lcm-java/lcm-spy --title 'Alice' --title-url
./lcm-java/lcm-spy -l 'udpm://239.255.76.67:8888' --title-url
./lcm-java/lcm-spy -t Bob
```


Added public static `LCM.getDefaultURL`.

I made and used `WindowTitleOptions` as I would in C. I find this *clean* enough, but if desired I can add java style boilerplate and maybe follow a builder pattern or something. 

After feedback, I'd like to add these options [and maybe  also `--title-filename`] to `lcm-logplayer-gui`.