### PR TITLE
Pass NAME_MISMATCHED to avoid warning

### DIFF
--- a/cmake/FindGLib2.cmake
+++ b/cmake/FindGLib2.cmake
@@ -45,6 +45,7 @@ function(_glib2_add_target TARGET LIBRARY)
   endforeach()
 
   find_package_handle_standard_args(GLib2_${TARGET}
+    NAME_MISMATCHED
     FOUND_VAR GLib2_${TARGET}_FOUND
     REQUIRED_VARS ${_deps}
   )


### PR DESCRIPTION
It appears that all that is needed here is to pass `NAME_MISMATCHED` to avoid the following warning when running `cmake`.  Took this path since the [docs](https://cmake.org/cmake/help/latest/module/FindPackageHandleStandardArgs.html#command:find_package_handle_standard_args) indicate this is the intended way to handle mismatched names for packages.  They do note that this is usually a mistake but since LCM has been working this way for quite a while I tend to think this is an exception.

```
CMake Warning (dev) at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (GLib2_glib)
  does not match the name of the calling package (GLib2).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake/FindGLib2.cmake:47 (find_package_handle_standard_args)
  cmake/FindGLib2.cmake:74 (_glib2_add_target)
  CMakeLists.txt:10 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```