### PR TITLE
Fix compiler warnings and turn on werror on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on: [push, pull_request]
 
 env:
-  BUILD_TYPE: Release
+  CMAKE_FLAGS: -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS="-Werror"
 
 jobs:
 
@@ -18,14 +18,14 @@ jobs:
         sudo apt install liblua5.4-dev lua5.4
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build ${{env.CMAKE_FLAGS}}
 
     - name: Build
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cmake --build ${{github.workspace}}/build
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest -C ${{env.BUILD_TYPE}}
+      run: ctest
 
   macos:
     runs-on: macos-latest
@@ -38,14 +38,14 @@ jobs:
         brew install lua
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build ${{env.CMAKE_FLAGS}}
 
     - name: Build
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cmake --build ${{github.workspace}}/build
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest -C ${{env.BUILD_TYPE}}
+      run: ctest
 
   docs:
     runs-on: ubuntu-latest

--- a/lcm-logger/lcm_logger.c
+++ b/lcm-logger/lcm_logger.c
@@ -141,12 +141,20 @@ static int open_logfile(logger_t *logger)
         /* Loop through possible file names until we find one that doesn't
          * already exist.  This way, we never overwrite an existing file. */
         do {
-            snprintf(logger->fname, sizeof(logger->fname), "%s.%02d", logger->fname_prefix,
+            int ret = snprintf(logger->fname, sizeof(logger->fname), "%s.%02d", logger->fname_prefix,
                      logger->next_increment_num);
+            if (ret < 0) {
+                fprintf(stderr, "Error: failed to create filename string");
+                return 1;
+            }
             logger->next_increment_num++;
         } while (g_file_test(logger->fname, G_FILE_TEST_EXISTS));
     } else if (logger->rotate > 0) {
-        snprintf(logger->fname, sizeof(logger->fname), "%s.0", logger->fname_prefix);
+        int ret = snprintf(logger->fname, sizeof(logger->fname), "%s.0", logger->fname_prefix);
+        if (ret < 0) {
+            fprintf(stderr, "Error: failed to create filename string");
+            return 1;
+        }
     } else {
         strcpy(logger->fname, logger->fname_prefix);
         if (!(logger->force_overwrite || logger->append)) {

--- a/lcm-lua/lualcm_hash.c
+++ b/lcm-lua/lualcm_hash.c
@@ -212,7 +212,7 @@ static int impl_hash_rotate(lua_State *L)
     /* do a fancy modulo, because 64 is 2^8, result is always positive*/
     rotation &= 63;
 
-    hashu->hash = hashu->hash << rotation | hashu->hash >> 64 - rotation;
+    hashu->hash = hashu->hash << rotation | hashu->hash >> (64 - rotation);
 
     /* pop the rotation int from the stack, return the hash */
     lua_pop(L, 1);

--- a/lcm-lua/lualcm_pack.c
+++ b/lcm-lua/lualcm_pack.c
@@ -754,7 +754,7 @@ static void impl_unpack_byte(lua_State *L, const uint8_t *buf, size_t *offset, s
 {
     /* unpack as a Lua "byte string" which is really just a string */
     const uint8_t *bytes = (const uint8_t *) (buf + *offset);
-    lua_pushlstring(L, bytes, bytes_size);
+    lua_pushlstring(L, (const char*)bytes, bytes_size);
     *offset += bytes_size * sizeof(uint8_t);
 }
 
@@ -897,7 +897,7 @@ static void impl_pack_byte(lua_State *L, uint8_t *buf, size_t *offset, int *stac
                            size_t bytes_size, bool swap)
 {
     size_t other_bytes_size;
-    const uint8_t *other_bytes = luaL_checklstring(L, *stack_pos, &other_bytes_size);
+    const uint8_t *other_bytes = (const uint8_t *)luaL_checklstring(L, *stack_pos, &other_bytes_size);
     uint8_t *bytes = (uint8_t *) (buf + *offset);
 
     int i;

--- a/lcm-lua/lualcm_pack.c
+++ b/lcm-lua/lualcm_pack.c
@@ -413,6 +413,9 @@ static size_t impl_get_required_buffer_size(impl_pack_op_t *ops, size_t num_ops)
         case DATATYPE_HASH:
             buf_size += ops[i].repeat * sizeof(uint64_t);
             break;
+        case DATATYPE_UNKNOWN:
+            fprintf(stderr, "WARNING! Encountered unknown datatype.\n");
+            break;
         }
     }
 
@@ -459,6 +462,10 @@ static int impl_get_required_stack_size(impl_pack_op_t *ops, size_t num_ops)
         case DATATYPE_HASH:
             num_values += ops[i].repeat;
             break;
+        case DATATYPE_UNKNOWN:
+            fprintf(stderr, "WARNING! Encountered unknown datatype.\n");
+            num_values += 1;
+            break;;
         }
     }
 
@@ -519,6 +526,9 @@ static bool impl_unpack_buffer(lua_State *L, impl_pack_op_t *ops, size_t num_ops
             break;
         case DATATYPE_HASH:
             impl_unpack_hash(L, buf, &offset, ops[i].repeat, swap);
+            break;
+        case DATATYPE_UNKNOWN:
+            fprintf(stderr, "WARNING! Encountered unknown datatype.\n");
             break;
         }
     }
@@ -588,6 +598,9 @@ static bool impl_pack_buffer(lua_State *L, impl_pack_op_t *ops, size_t num_ops,
             break;
         case DATATYPE_HASH:
             impl_pack_hash(L, buf, &offset, &stack_pos, ops[i].repeat, swap);
+            break;
+        case DATATYPE_UNKNOWN:
+            fprintf(stderr, "WARNING! Encountered unknown datatype.\n");
             break;
         }
     }

--- a/lcm-lua/utf8_check.c
+++ b/lcm-lua/utf8_check.c
@@ -30,8 +30,10 @@
 
 #include <stdlib.h>
 
-int utf8_check(const char *s, size_t length)
+int utf8_check(const char *p, size_t length)
 {
+    const unsigned char* s = (const unsigned char*)p;
+
     size_t i = 0;
     while (i < length) {
         if (s[i] < 0x80) /* 0xxxxxxx */

--- a/lcmgen/emit_go.c
+++ b/lcmgen/emit_go.c
@@ -340,7 +340,7 @@ static char *go_typename(const char *const package, const char *const typepackag
 
     // Add fingerprint suffix
     if (fingerprint != 0) {
-        g_string_append_printf(name, "_%lx", (uint64_t) fingerprint);
+        g_string_append_printf(name, "_%" PRIu64, (uint64_t) fingerprint);
     }
 
     char *ret = name->str;
@@ -357,7 +357,7 @@ char *go_filename(lcmgen_t *lcm, const char *const dir, const char *const name,
                   uint64_t fingerprint, const char *const suffix)
 {
     if (fingerprint != 0)
-        return g_strdup_printf("%s/%s_%lx%s.go", dir, name, fingerprint, suffix);
+        return g_strdup_printf("%s/%s_%" PRIu64 "%s.go", dir, name, (uint64_t) fingerprint, suffix);
     else
         return g_strdup_printf("%s/%s%s.go", dir, name, suffix);
 }

--- a/lcmgen/emit_lua.c
+++ b/lcmgen/emit_lua.c
@@ -993,7 +993,11 @@ static int emit_package(lcmgen_t *lcm, _package_contents_t *pc)
         lcm_struct_t *ls = (lcm_struct_t *) g_ptr_array_index(pc->structs, i);
 
         char path[PATH_MAX];
-        sprintf(path, "%s%s.lua", package_dir, ls->structname->shortname);
+        int ret = snprintf(path, sizeof(path), "%s%s.lua", package_dir, ls->structname->shortname);
+        if (ret < 0) {
+            fprintf(stderr, "Error: failed to create path string");
+            return -1;
+        }
 
         if (init_lua_fp) {
             // XXX add the 'require' to the appropriate init.lua

--- a/lcmgen/emit_lua.c
+++ b/lcmgen/emit_lua.c
@@ -686,7 +686,8 @@ static void emit_lua_dependencies(const lcmgen_t *lcm, FILE *f, lcm_struct_t *ls
         emit(0, "");
 
     g_ptr_array_free(deps, TRUE);
-    g_hash_table_destroy(dependencies);
+    if (dependencies)
+        g_hash_table_destroy(dependencies);
 }
 
 static void emit_lua_locals(const lcmgen_t *lcm, FILE *f, lcm_struct_t *ls)
@@ -1109,7 +1110,8 @@ static int emit_package(lcmgen_t *lcm, _package_contents_t *pc)
         fclose(init_lua_fp);
     }
 
-    g_hash_table_destroy(initlua_requires);
+    if (initlua_requires)
+        g_hash_table_destroy(initlua_requires);
     return 0;
 }
 
@@ -1153,6 +1155,7 @@ int emit_lua(lcmgen_t *lcm)
 
     g_ptr_array_free(vals, TRUE);
 
-    g_hash_table_destroy(packages);
+    if (packages)
+        g_hash_table_destroy(packages);
     return 0;
 }

--- a/lcmgen/emit_python.c
+++ b/lcmgen/emit_python.c
@@ -812,7 +812,11 @@ emit_package (lcmgen_t *lcm, _package_contents_t *pc)
         lcm_enum_t *le = (lcm_enum_t *) g_ptr_array_index (pc->enums, i);
 
         char path[PATH_MAX];
-        sprintf (path, "%s%s.py", package_dir, le->enumname->shortname);
+        int ret = snprintf(path, sizeof(path), "%s%s.py", package_dir, le->enumname->shortname);
+        if (ret < 0) {
+            fprintf(stderr, "Error: failed to create path string");
+            return -1;
+        }
 
         if(init_py_fp && 
            !g_hash_table_lookup(init_py_imports, le->enumname->shortname))
@@ -893,7 +897,11 @@ emit_package (lcmgen_t *lcm, _package_contents_t *pc)
         lcm_struct_t *ls = (lcm_struct_t *) g_ptr_array_index(pc->structs, i);
 
         char path[PATH_MAX];
-        sprintf(path, "%s%s.py", package_dir, ls->structname->shortname);
+        int ret = snprintf(path, sizeof(path), "%s%s.py", package_dir, ls->structname->shortname);
+        if (ret < 0) {
+            fprintf(stderr, "Error: failed to create path string");
+            return -1;
+        } 
 
         if (init_py_fp && !g_hash_table_lookup(init_py_imports, ls->structname->shortname))
             fprintf(init_py_fp, "from .%s import %s\n", ls->structname->shortname,

--- a/test/cpp/common.cpp
+++ b/test/cpp/common.cpp
@@ -195,7 +195,7 @@ int CheckLcmType(const lcmtest::primitives_list_t *msg, int expected)
         for (i = 0; i < n; i++)
             CHECK_FIELD(ex->ranges[i], -i, "%d");
         char expected_name[100];
-        sprintf(expected_name, "%d", -n);
+        snprintf(expected_name, sizeof(expected_name), "%d", -n);
         if (strcmp(expected_name, ex->name.c_str())) {
             info("Expected msg->items[%d].name to be %s, got %s instead", n, expected_name,
                  ex->name.c_str());
@@ -259,7 +259,7 @@ int CheckLcmType(const lcmtest::primitives_t *msg, int expected)
     for (i = 0; i < n; i++)
         CHECK_FIELD(msg->ranges[i], i, "%d");
     char expected_name[100];
-    sprintf(expected_name, "%d", n);
+    snprintf(expected_name, sizeof(expected_name), "%d", n);
     if (strcmp(expected_name, msg->name.c_str())) {
         info("Expected msg->expected_name to be %s, got %s instead", expected_name,
              msg->name.c_str());

--- a/test/cpp/common.cpp
+++ b/test/cpp/common.cpp
@@ -182,7 +182,7 @@ int CheckLcmType(const lcmtest::primitives_list_t *msg, int expected)
         const lcmtest::primitives_t *ex = &msg->items[n];
         CHECK_FIELD(ex->i8, -(n % 100), "%d");
         CHECK_FIELD(ex->i16, -n * 10, "%d");
-        CHECK_FIELD(ex->i64, (int64_t)(-n * 10000), "%jd");
+        CHECK_FIELD(ex->i64, (int64_t)(-n * 10000), "%" PRId64);
         CHECK_FIELD(ex->position[0], (double) -n, "%f");
         CHECK_FIELD(ex->position[1], (double) -n, "%f");
         CHECK_FIELD(ex->position[2], (double) -n, "%f");
@@ -246,7 +246,7 @@ int CheckLcmType(const lcmtest::primitives_t *msg, int expected)
     int n = expected;
     CHECK_FIELD(msg->i8, n % 100, "%d");
     CHECK_FIELD(msg->i16, n * 10, "%d");
-    CHECK_FIELD(msg->i64, (int64_t)(n * 10000), "%jd");
+    CHECK_FIELD(msg->i64, (int64_t)(n * 10000), "%" PRId64);
     CHECK_FIELD(msg->position[0], (double) n, "%f");
     CHECK_FIELD(msg->position[1], (double) n, "%f");
     CHECK_FIELD(msg->position[2], (double) n, "%f");


### PR DESCRIPTION
This PR:
- Adds `-Werror` as a compiler argument for both C and C++
- Fixes warnings so it compiles warning-free on the Ubuntu and macOS CI targets

Warnings fixed:
- `format-overflow`:  9c7a4a47d14dbce11e9fea01217c969c2539b9ea
- `GLib-CRITICAL **: 10:09:34.795: g_hash_table_destroy: assertion 'hash_table != NULL' failed` warnings while running lcm-gen: af37954152982da00ef1892cfd75ce97a7b56ccb
- `Wshift-op-parentheses`: 1927a43dc167425bedfb2345c7897c5eb7e3e134
- `Wswitch`: a4d7fac403c2cff17a07f1dabc2950b4e367a22c
- `Wpointer-sign`: e520e621feb3158721d079ae64ffb959d2e2325b
- `Wtautological-constant-out-of-range-compare`: 52073cf738f34a95e57e4592e302f23993d79234
- `Wdeprecated-declarations`: 405c5c6500162be10a5b6056bcf0aab45149e7d5
- `Wformat`:  42a5b611cd5d59ced9c76e935328da7ea4597915

I started going down the path of trying to fix warnings from `-Wall` and `-Wextra` but stopped. [These commits](https://github.com/nosracd/lcm/pull/2/commits) are *not* included in the PR, but I'd appreciate if you could take a look at them and determine if any are actually helpful: