### PR TITLE
logplayer-gui: Window title options

### DIFF
--- a/lcm-java/lcm/logging/LogPlayer.java
+++ b/lcm-java/lcm/logging/LogPlayer.java
@@ -978,9 +978,17 @@ public class LogPlayer extends JComponent
         System.err.println("                         (default: \"\")");
         System.err.println("  -v, --invert-filter    Invert the filtering regex. Only enable channels");
         System.err.println("                         matching CHAN.");
+        System.err.println("  -t, --title [LABEL]    Display LABEL in the window title.");
+        System.err.println("                         Defaults to the log filename.");
+        System.err.println("  --title-url            Display the LCM URL in the window title.");
         System.err.println("  -h, --help             Shows this help text and exits");
         System.err.println("");
         System.exit(1);
+    }
+
+    static class WindowTitleOptions {
+        String label = null;
+        boolean showURL = false;
     }
 
     public static void main(String args[])
@@ -1000,6 +1008,7 @@ public class LogPlayer extends JComponent
         String channelFilterRegex = null;
         boolean invertChannelFilter = false;
 
+        WindowTitleOptions titleOptions = new WindowTitleOptions();
 
         for (optind = 0; optind < args.length; optind++) {
             boolean hasParam = optind + 1 < args.length;
@@ -1024,6 +1033,7 @@ public class LogPlayer extends JComponent
                 } else {
                     lcmurl = optarg;
                 }
+
             } else if (c.equals("-p") || c.equals("--paused")) {
                 startPaused = true;
 
@@ -1042,8 +1052,24 @@ public class LogPlayer extends JComponent
                 } else {
                     channelFilterRegex = optarg;
                 }
+
             } else if (c.equals("-v") || c.equals("--invert-filter")) {
                 invertChannelFilter = true;
+
+            } else if (c.equals("-t") || c.equals("--title")) {
+                String optarg = null;
+                if (hasParam) {
+                    optind++;
+                    optarg = args[optind];
+                }
+                if (null == optarg) {
+                    usage();
+                } else {
+                    titleOptions.label = optarg;
+                }
+
+            } else if (c.equals("--title-url")) {
+                titleOptions.showURL = true;
 
             } else if (c.startsWith("-")) {
                 // !! This does not allow the common unix pattern of passing
@@ -1098,7 +1124,17 @@ public class LogPlayer extends JComponent
                 String filename = p.logName.getText();
 
                 String title = "LogPlayer";
-                title += spacer + filename;
+
+                if (null != titleOptions.label) {
+                    title += spacer + titleOptions.label;
+                } else {
+                    title += spacer + filename;
+                }
+
+                if (titleOptions.showURL){
+                    String url = null == lcmurl ? LCM.getDefaultURL() : lcmurl;
+                    title += spacer + url;
+                }
 
                 f.setTitle(title);
             }  

--- a/lcm-java/lcm/logging/LogPlayer.java
+++ b/lcm-java/lcm/logging/LogPlayer.java
@@ -469,18 +469,21 @@ public class LogPlayer extends JComponent
         return chooser.getSelectedFile().getPath();
     }
 
-    void openDialog()
+    boolean openDialog()
     {
         doStop();
         int res = jfc.showOpenDialog(this);
-        if (res != JFileChooser.APPROVE_OPTION)
-            return;
+        if (res != JFileChooser.APPROVE_OPTION) {
+            return false;
+        }
 
         try {
             setLog(jfc.getSelectedFile().getPath(), true);
         } catch (IOException ex) {
-            System.out.println("Exception: "+ex);
+            System.out.println("Exception: " + ex);
+            return false;
         }
+        return true;
     }
 
     void savePreferences() throws IOException
@@ -1078,10 +1081,27 @@ public class LogPlayer extends JComponent
             if (invertChannelFilter)
             	p.invertChannelFilter();
 
-            if (logFile !=null)
+            if (logFile != null) {
                 p.setLog(logFile, !startPaused);
-            else
-                p.openDialog();
+            } else {
+                // `openDialog` blocks execution flow until the window closes
+                boolean pathGiven = p.openDialog();
+                if (!pathGiven) {
+                    f.dispose();
+                    System.err.println("No log chosen. Exiting.");
+                    System.exit(1);
+                }
+            }
+
+            {
+                String spacer = "  •  ";
+                String filename = p.logName.getText();
+
+                String title = "LogPlayer";
+                title += spacer + filename;
+
+                f.setTitle(title);
+            }  
 
         } catch (IOException ex) {
             System.out.println("Exception: "+ex);


### PR DESCRIPTION
Matching the new args added to lcm-spy by #389 :

```
  -t, --title [LABEL]    Display LABEL in the window title.
                         Defaults to the log filename.
  --title-url            Display the LCM URL in the window title.
```

The log filename is now displayed in the title if a different title isn't given.

If the file chooser gui is canceled, the app now closes. [I don't see a reason to remain running if there is no other way to select a log].

Example usages:
```
./lcm-java/lcm-logplayer-gui # Will exit if you hit cancel
./lcm-java/lcm-logplayer-gui loggylog.log 
./lcm-java/lcm-logplayer-gui loggylog.log --title "Alice"
./lcm-java/lcm-logplayer-gui loggylog.log -l 'udpm://239.255.76.67:8888?ttl=1' --title-url

```