### PR TITLE
Refactor Examples CI Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,21 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: ctest
 
+    - name: Install
+      run: sudo cmake --install ${{github.workspace}}/build
+
+    - name: Build C Example
+      working-directory: ${{github.workspace}}/examples/c
+      run: |
+        cmake -B build ${{env.CMAKE_FLAGS}}
+        cmake --build build
+
+    - name: Build C++ Example
+      working-directory: ${{github.workspace}}/examples/cpp
+      run: |
+        cmake -B build ${{env.CMAKE_FLAGS}}
+        cmake --build build
+
   macos:
     runs-on: macos-latest
 
@@ -46,6 +61,21 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build
       run: ctest
+
+    - name: Install
+      run: sudo cmake --install ${{github.workspace}}/build
+
+    - name: Build C Example
+      working-directory: ${{github.workspace}}/examples/c
+      run: |
+        cmake -B build ${{env.CMAKE_FLAGS}}
+        cmake --build build
+
+    - name: Build C++ Example
+      working-directory: ${{github.workspace}}/examples/cpp
+      run: |
+        cmake -B build ${{env.CMAKE_FLAGS}}
+        cmake --build build
 
   docs:
     runs-on: ubuntu-latest
@@ -69,26 +99,3 @@ jobs:
         with:
           name: archived-docs
           path: build/docs/_build
-
-  examples:
-    strategy:
-      matrix:
-        directory: [c, cpp]
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Install Dependencies
-      run: |
-        sudo apt install liblcm-dev
-
-    - name: Configure CMake
-      run: cmake -B build ${{env.CMAKE_FLAGS}}
-      working-directory: ${{github.workspace}}/examples/${{ matrix.directory }}
-
-    - name: Build
-      run: cmake --build build
-      working-directory: ${{github.workspace}}/examples/${{ matrix.directory }}
-

--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -13,26 +13,26 @@ add_custom_target(exlcm
   BYPRODUCTS exlcm_example_t.c)
 include_directories("${lcm_c_example_BINARY_DIR}")
 
+# Everything from here on needs these flags.
+include_directories(${LCM_INCLUDE_DIRS})
+link_libraries(${LCM_LDFLAGS})
+
 # Create executables for the example programs.
 
 add_executable(listener "listener.c" "exlcm_example_t.c")
 add_dependencies(listener exlcm)
-target_link_libraries(listener ${LCM_LIBRARIES})
 
 add_executable(listener-async "listener-async.c" "exlcm_example_t.c")
 add_dependencies(listener-async exlcm)
-target_link_libraries(listener-async ${LCM_LIBRARIES})
 
 add_executable(listener-glib "listener-glib.c" "exlcm_example_t.c")
 add_dependencies(listener-glib exlcm)
 pkg_check_modules(GLIB REQUIRED glib-2.0)
-target_link_libraries(listener-glib ${LCM_LIBRARIES} ${GLIB_LIBRARIES})
+target_link_libraries(listener-glib ${GLIB_LIBRARIES})
 target_include_directories(listener-glib PRIVATE ${GLIB_INCLUDE_DIRS})
 
 add_executable(send_message "send_message.c" "exlcm_example_t.c")
 add_dependencies(send_message exlcm)
-target_link_libraries(send_message ${LCM_LIBRARIES})
                                        
 add_executable(read_log "read_log.c" "exlcm_example_t.c")
 add_dependencies(read_log exlcm)
-target_link_libraries(read_log ${LCM_LIBRARIES})

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -12,16 +12,17 @@ add_custom_target(exlcm
   COMMAND ${LCM_GEN_EXECUTABLE} -x ../../types/*.lcm)
 include_directories("${lcm_cpp_example_BINARY_DIR}")
 
+# Everything from here on needs these flags.
+include_directories(${LCM_INCLUDE_DIRS})
+link_libraries(${LCM_LDFLAGS})
+
 # Create executables for the example programs.
 
 add_executable(listener "listener.cpp")
 add_dependencies(listener exlcm)
-target_link_libraries(listener ${LCM_LIBRARIES})
 
 add_executable(send_message "send_message.cpp")
 add_dependencies(send_message exlcm)
-target_link_libraries(send_message ${LCM_LIBRARIES})
                                        
 add_executable(read_log "read_log.cpp")
 add_dependencies(read_log exlcm)
-target_link_libraries(read_log ${LCM_LIBRARIES})


### PR DESCRIPTION
@ihilt pointed out that one significant downside of the current approach is that it tests building the examples using the latest package's version rather than the current revision, which may lead to headache down the road. 

This PR:
- fixes the above issue by moving the examples test into the `ubuntu` and `macos` jobs. 
- tests installing LCM from cmake on the CI 
- builds the examples on the macos target
    -  some small modifications to the `CMakeLists.txt`s was necessary to support this