### PR TITLE
Update Python paths

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -45,15 +45,8 @@ if(NOT SPHINX_EXECUTABLE)
   return()
 endif()
 
-execute_process(
-  COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
-    from distutils import sysconfig as sc
-    print(sc.get_python_lib(prefix='', plat_specific=True))"
-  OUTPUT_VARIABLE PYTHON_SITE
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
-
 add_custom_target(doc-sphinx
-  COMMAND "PYTHONPATH=${CMAKE_BINARY_DIR}/${PYTHON_SITE}" ${SPHINX_EXECUTABLE} ${lcm_SOURCE_DIR}/docs ${lcm_BINARY_DIR}/docs/_build
+  COMMAND "PYTHONPATH=${CMAKE_BINARY_DIR}/python" ${SPHINX_EXECUTABLE} ${lcm_SOURCE_DIR}/docs ${lcm_BINARY_DIR}/docs/_build
   WORKING_DIRECTORY ${lcm_SOURCE_DIR}/docs
   DEPENDS doc-setup doc-dotnet doc-doxygen doc-java lcm-python lcm-python-init)
 

--- a/lcm-python/CMakeLists.txt
+++ b/lcm-python/CMakeLists.txt
@@ -1,7 +1,7 @@
 execute_process(
   COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
-    from distutils import sysconfig as sc
-    print(sc.get_python_lib(prefix='', plat_specific=True))"
+    import sysconfig as sc
+    print(sc.get_path('platlib'))"
   OUTPUT_VARIABLE PYTHON_SITE
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 
@@ -15,7 +15,7 @@ set(lcm_python_sources
 add_library(lcm-python MODULE ${lcm_python_sources})
 
 set_target_properties(lcm-python PROPERTIES
-  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${PYTHON_SITE}/lcm
+  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/python/lcm
   LIBRARY_OUTPUT_NAME _lcm
   PREFIX ""
 )
@@ -47,7 +47,7 @@ install(TARGETS lcm-python
 
 lcm_copy_file_target(lcm-python-init
   ${CMAKE_CURRENT_SOURCE_DIR}/lcm/__init__.py
-  ${CMAKE_BINARY_DIR}/${PYTHON_SITE}/lcm/__init__.py
+  ${CMAKE_BINARY_DIR}/python/lcm/__init__.py
 )
 
 install(FILES lcm/__init__.py DESTINATION ${PYTHON_SITE}/lcm)

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -1,13 +1,6 @@
-execute_process(
-  COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
-    from distutils import sysconfig as sc
-    print(sc.get_python_lib(prefix='', plat_specific=True))"
-  OUTPUT_VARIABLE PYTHON_SITE
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
-
 set(PYTHON_PATH
   ${lcm_BINARY_DIR}/test/types
-  ${CMAKE_BINARY_DIR}/${PYTHON_SITE})
+  ${CMAKE_BINARY_DIR}/python)
 if(NOT WIN32)
   string(REPLACE ";" ":" PYTHON_PATH "${PYTHON_PATH}")
 endif()


### PR DESCRIPTION
This PR fixes the following warnings, which occur while configuring a build directory:

```
<string>:2: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
<string>:2: DeprecationWarning: The distutils.sysconfig module is deprecated, use sysconfig instead
```

These happen because of a this code block which occurs in three places in the current revision:

```
execute_process(
  COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
    from distutils import sysconfig as sc
    print(sc.get_python_lib(prefix='', plat_specific=True))"
  OUTPUT_VARIABLE PYTHON_SITE
  OUTPUT_STRIP_TRAILING_WHITESPACE)
```

On my system, `PYTHON_SITE` ends up being `lib/python3/dist-packages`. This variable is used to set the output of Python build artifacts to `build/lib/python3/dist-packages` and to install Python artifacts to `/usr/local/lib/python3/dist-packages/lcm/`.

This PR refactors the above Python call to instead be:

```
execute_process(
  COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
    import sysconfig as sc
    print(sc.get_path('platlib'))"
  OUTPUT_VARIABLE PYTHON_SITE
  OUTPUT_STRIP_TRAILING_WHITESPACE)
```

Now, on my system, `PYTHON_SITE` ends up being `/usr/local/lib/python3.10/dist-packages`. This is still used to set the install path, but is probably not ideal for local build artifacts in the build directory. Instead, I've refactored these to be hard-coded to go to `build/python`.