### PR TITLE
Raise cmake required version to a non-deprecated version

### DIFF
--- a/lcm-cmake/lcmUtilities.cmake
+++ b/lcm-cmake/lcmUtilities.cmake
@@ -31,7 +31,7 @@ if(WIN32)
   # Need 'cmake -E env'
   cmake_minimum_required(VERSION 3.1.0)
 else()
-  cmake_minimum_required(VERSION 2.8.3)
+  cmake_minimum_required(VERSION 2.8.12)
 endif()
 include(CMakeParseArguments)
 


### PR DESCRIPTION
This PR fixes the following warning:

```
CMake Deprecation Warning at lcm-cmake/lcmUtilities.cmake:34 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
Call Stack (most recent call first):
  test/types/CMakeLists.txt:1 (include)

```