### PR TITLE
lcm-java: use factory method on boxed types

### DIFF
--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/Chart2D.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/Chart2D.java
@@ -4088,7 +4088,7 @@ public class Chart2D extends JPanel implements PropertyChangeListener, Iterable<
     final boolean change = this.m_paintLabels != paintLabels;
     this.m_paintLabels = paintLabels;
     if (change) {
-      this.firePropertyChange(Chart2D.PROPERTY_PAINTLABELS, new Boolean(!paintLabels), new Boolean(
+      this.firePropertyChange(Chart2D.PROPERTY_PAINTLABELS, Boolean.valueOf(!paintLabels), Boolean.valueOf(
           paintLabels));
       this.setRequestedRepaint(true);
     }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/axis/AAxis.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/axis/AAxis.java
@@ -2633,7 +2633,7 @@ public abstract class AAxis<T extends IAxisScalePolicy> implements IAxis<T>, Pro
     this.m_paintGrid = grid;
     if (oldValue != grid) {
       this.m_propertyChangeSupport.firePropertyChange(new PropertyChangeEvent(this,
-          IAxis.PROPERTY_PAINTGRID, new Boolean(oldValue), Boolean.valueOf(this.m_paintGrid)));
+          IAxis.PROPERTY_PAINTGRID, Boolean.valueOf(oldValue), Boolean.valueOf(this.m_paintGrid)));
     }
   }
 
@@ -2649,7 +2649,7 @@ public abstract class AAxis<T extends IAxisScalePolicy> implements IAxis<T>, Pro
     this.m_paintScale = show;
     if (oldValue != this.m_paintScale) {
       this.m_propertyChangeSupport.firePropertyChange(new PropertyChangeEvent(this,
-          IAxis.PROPERTY_PAINTSCALE, new Boolean(oldValue), Boolean.valueOf(this.m_paintGrid)));
+          IAxis.PROPERTY_PAINTSCALE, Boolean.valueOf(oldValue), Boolean.valueOf(this.m_paintGrid)));
     }
   }
 

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/controls/RangeChooserPanel.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/controls/RangeChooserPanel.java
@@ -154,7 +154,7 @@ public class RangeChooserPanel extends JPanel {
     // text field views to show the range values;
     // minimum value view:
     final JTextField rangeMinView = new JTextField();
-    rangeMinView.setText(this.m_nf.format(new Double(this.m_rangeSlider.getLowValue())));
+    rangeMinView.setText(this.m_nf.format(Double.valueOf(this.m_rangeSlider.getLowValue())));
     rangeMinView.setEditable(true);
     rangeMinView.setPreferredSize(new Dimension(120, 20));
     rangeMinView.addActionListener(new ActionListener() {
@@ -180,7 +180,7 @@ public class RangeChooserPanel extends JPanel {
 
     // maximum value view:
     final JTextField rangeMaxView = new JTextField();
-    rangeMaxView.setText(new Double(this.m_rangeSlider.getHighValue()).toString());
+    rangeMaxView.setText(Double.valueOf(this.m_rangeSlider.getHighValue()).toString());
     rangeMaxView.setEditable(true);
 
     rangeMaxView.setPreferredSize(new Dimension(120, 20));

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/AxisActionSetRangePolicy.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/AxisActionSetRangePolicy.java
@@ -118,11 +118,11 @@ public class AxisActionSetRangePolicy
       Boolean oldValue;
       Boolean newValue;
       if (rangepolicyClass == this.m_rangePolicy.getClass()) {
-        oldValue = new Boolean(false);
-        newValue = new Boolean(true);
+        oldValue = Boolean.valueOf(false);
+        newValue = Boolean.valueOf(true);
       } else {
-        oldValue = new Boolean(true);
-        newValue = new Boolean(false);
+        oldValue = Boolean.valueOf(true);
+        newValue = Boolean.valueOf(false);
       }
       this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED, oldValue, newValue);
     }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/AxisActionSetTitleFont.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/AxisActionSetTitleFont.java
@@ -98,11 +98,11 @@ public class AxisActionSetTitleFont
       Font newFont = (Font) evt.getNewValue();
       if (newFont.equals(this.m_titleFont)) {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(false), new Boolean(true));
+            Boolean.valueOf(false), Boolean.valueOf(true));
 
       } else {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(true), new Boolean(false));
+            Boolean.valueOf(true), Boolean.valueOf(false));
       }
     }
   }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Chart2DActionSetAxis.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Chart2DActionSetAxis.java
@@ -120,11 +120,11 @@ public final class Chart2DActionSetAxis
       if (evt.getNewValue() != null) {
         Class< ? > axisClass = evt.getNewValue().getClass();
         if (this.m_axis.getClass() == axisClass) {
-          this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED, new Boolean(
-              false), new Boolean(true));
+          this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED, Boolean.valueOf(
+              false), Boolean.valueOf(true));
         } else {
-          this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED, new Boolean(
-              true), new Boolean(false));
+          this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED, Boolean.valueOf(
+              true), Boolean.valueOf(false));
         }
       }
     } else if (evt.getPropertyName().equals(Chart2D.PROPERTY_AXIS_Y)
@@ -134,11 +134,11 @@ public final class Chart2DActionSetAxis
 
         Class< ? > axisClass = evt.getNewValue().getClass();
         if (this.m_axis.getClass() == axisClass) {
-          this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED, new Boolean(
-              false), new Boolean(true));
+          this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED, Boolean.valueOf(
+              false), Boolean.valueOf(true));
         } else {
-          this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED, new Boolean(
-              true), new Boolean(false));
+          this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED, Boolean.valueOf(
+              true), Boolean.valueOf(false));
         }
       }
     }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Chart2DActionSetCustomGridColor.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Chart2DActionSetCustomGridColor.java
@@ -90,11 +90,11 @@ public final class Chart2DActionSetCustomGridColor extends AChart2DAction {
       Color newColor = (Color) evt.getNewValue();
       if (newColor.equals(this.m_lastChosenColor)) {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(false), new Boolean(true));
+            Boolean.valueOf(false), Boolean.valueOf(true));
 
       } else {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(true), new Boolean(false));
+            Boolean.valueOf(true), Boolean.valueOf(false));
       }
     }
   }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Chart2DActionSetCustomGridColorSingleton.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Chart2DActionSetCustomGridColorSingleton.java
@@ -149,11 +149,11 @@ public final class Chart2DActionSetCustomGridColorSingleton extends AChart2DActi
       Color newColor = (Color) evt.getNewValue();
       if (newColor.equals(this.m_lastChosenColor)) {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(false), new Boolean(true));
+            Boolean.valueOf(false), Boolean.valueOf(true));
 
       } else {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(true), new Boolean(false));
+            Boolean.valueOf(true), Boolean.valueOf(false));
       }
     }
   }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Chart2DActionSetGridColor.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Chart2DActionSetGridColor.java
@@ -87,11 +87,11 @@ public class Chart2DActionSetGridColor extends AChart2DAction {
       Color newColor = (Color) evt.getNewValue();
       if (newColor.equals(this.m_color)) {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(false), new Boolean(true));
+            Boolean.valueOf(false), Boolean.valueOf(true));
 
       } else {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(true), new Boolean(false));
+            Boolean.valueOf(true), Boolean.valueOf(false));
       }
     }
   }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/JComponentActionSetBackground.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/JComponentActionSetBackground.java
@@ -91,11 +91,11 @@ public final class JComponentActionSetBackground extends AJComponentAction {
       Color newColor = (Color) evt.getNewValue();
       if (newColor.equals(this.m_color)) {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(false), new Boolean(true));
+            Boolean.valueOf(false), Boolean.valueOf(true));
 
       } else {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(true), new Boolean(false));
+            Boolean.valueOf(true), Boolean.valueOf(false));
       }
     }
   }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/JComponentActionSetCustomBackground.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/JComponentActionSetCustomBackground.java
@@ -93,11 +93,11 @@ public final class JComponentActionSetCustomBackground extends AJComponentAction
       Color newColor = (Color) evt.getNewValue();
       if (newColor.equals(this.m_lastChosenColor)) {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(false), new Boolean(true));
+            Boolean.valueOf(false), Boolean.valueOf(true));
 
       } else {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(true), new Boolean(false));
+            Boolean.valueOf(true), Boolean.valueOf(false));
       }
     }
   }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/JComponentActionSetCustomBackgroundSingleton.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/JComponentActionSetCustomBackgroundSingleton.java
@@ -153,11 +153,11 @@ public final class JComponentActionSetCustomBackgroundSingleton extends AJCompon
       Color newColor = (Color) evt.getNewValue();
       if (newColor.equals(this.m_lastChosenColor)) {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(false), new Boolean(true));
+            Boolean.valueOf(false), Boolean.valueOf(true));
 
       } else {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(true), new Boolean(false));
+            Boolean.valueOf(true), Boolean.valueOf(false));
       }
     }
   }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/JComponentActionSetCustomForegroundSingleton.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/JComponentActionSetCustomForegroundSingleton.java
@@ -153,11 +153,11 @@ public final class JComponentActionSetCustomForegroundSingleton extends AJCompon
       Color newColor = (Color) evt.getNewValue();
       if (newColor.equals(this.m_lastChosenColor)) {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(false), new Boolean(true));
+            Boolean.valueOf(false), Boolean.valueOf(true));
 
       } else {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(true), new Boolean(false));
+            Boolean.valueOf(true), Boolean.valueOf(false));
       }
     }
   }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/JComponentActionSetForeground.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/JComponentActionSetForeground.java
@@ -92,11 +92,11 @@ public final class JComponentActionSetForeground extends AJComponentAction {
       Color newColor = (Color) evt.getNewValue();
       if (newColor.equals(this.m_color)) {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(false), new Boolean(true));
+            Boolean.valueOf(false), Boolean.valueOf(true));
 
       } else {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(true), new Boolean(false));
+            Boolean.valueOf(true), Boolean.valueOf(false));
       }
     }
   }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Trace2DActionAddRemoveHighlighter.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Trace2DActionAddRemoveHighlighter.java
@@ -117,14 +117,14 @@ public final class Trace2DActionAddRemoveHighlighter extends ATrace2DAction {
       if (oldValue == null) {
         // added
         if (newValue.equals(this.m_pointHighlighter)) {
-          this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED, new Boolean(
-              false), new Boolean(true));
+          this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED, Boolean.valueOf(
+              false), Boolean.valueOf(true));
         }
       } else {
         // removed
         if (oldValue.equals(this.m_pointHighlighter)) {
-          this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED, new Boolean(
-              true), new Boolean(false));
+          this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED, Boolean.valueOf(
+              true), Boolean.valueOf(false));
         }
       }
     }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Trace2DActionAddRemoveTracePainter.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Trace2DActionAddRemoveTracePainter.java
@@ -117,14 +117,14 @@ public final class Trace2DActionAddRemoveTracePainter extends ATrace2DAction {
       if (oldValue == null) {
         // added
         if (newValue.getClass() == this.m_tracePainter.getClass()) {
-          this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED, new Boolean(
-              false), new Boolean(true));
+          this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED, Boolean.valueOf(
+              false), Boolean.valueOf(true));
         }
       } else {
         // removed
         if (oldValue.getClass() == this.m_tracePainter.getClass()) {
-          this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED, new Boolean(
-              true), new Boolean(false));
+          this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED, Boolean.valueOf(
+              true), Boolean.valueOf(false));
         }
       }
     }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Trace2DActionSetColor.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Trace2DActionSetColor.java
@@ -87,10 +87,10 @@ public final class Trace2DActionSetColor extends ATrace2DAction {
       Color newValue = (Color) evt.getNewValue();
       if (newValue.equals(this.m_color)) {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(false), new Boolean(true));
+            Boolean.valueOf(false), Boolean.valueOf(true));
       } else {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(true), new Boolean(false));
+            Boolean.valueOf(true), Boolean.valueOf(false));
       }
     }
   }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Trace2DActionSetCustomColor.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Trace2DActionSetCustomColor.java
@@ -109,10 +109,10 @@ public final class Trace2DActionSetCustomColor extends ATrace2DAction {
       Color newValue = (Color) evt.getNewValue();
       if (newValue.equals(this.m_lastChosen)) {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(false), new Boolean(true));
+            Boolean.valueOf(false), Boolean.valueOf(true));
       } else {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(true), new Boolean(false));
+            Boolean.valueOf(true), Boolean.valueOf(false));
       }
     }
   }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Trace2DActionSetStroke.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Trace2DActionSetStroke.java
@@ -92,10 +92,10 @@ public final class Trace2DActionSetStroke extends ATrace2DAction {
       // added
       if (newValue.equals(this.m_stroke)) {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(false), new Boolean(true));
+            Boolean.valueOf(false), Boolean.valueOf(true));
       } else {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(true), new Boolean(false));
+            Boolean.valueOf(true), Boolean.valueOf(false));
       }
     }
   }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Trace2DActionSetZindex.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Trace2DActionSetZindex.java
@@ -68,7 +68,7 @@ public final class Trace2DActionSetZindex extends ATrace2DAction {
    */
   public Trace2DActionSetZindex(final ITrace2D trace, final String description, final int zIndex) {
     super(trace, description);
-    this.m_zIndex = new Integer(zIndex);
+    this.m_zIndex = Integer.valueOf(zIndex);
     trace.addPropertyChangeListener(ITrace2D.PROPERTY_ZINDEX, this);
   }
 
@@ -88,10 +88,10 @@ public final class Trace2DActionSetZindex extends ATrace2DAction {
       Number newValue = (Number) evt.getNewValue();
       if (newValue.equals(this.m_zIndex)) {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(false), new Boolean(true));
+            Boolean.valueOf(false), Boolean.valueOf(true));
       } else {
         this.firePropertyChange(PropertyChangeCheckBoxMenuItem.PROPERTY_SELECTED,
-            new Boolean(true), new Boolean(false));
+            Boolean.valueOf(true), Boolean.valueOf(false));
       }
     }
   }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Trace2DActionZindexDecrease.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Trace2DActionZindexDecrease.java
@@ -77,7 +77,7 @@ public final class Trace2DActionZindexDecrease extends ATrace2DAction {
    */
   public void actionPerformed(final ActionEvent e) {
     int value = this.m_trace.getZIndex().intValue();
-    this.m_trace.setZIndex(new Integer(value - this.m_decrease));
+    this.m_trace.setZIndex(Integer.valueOf(value - this.m_decrease));
   }
 
   /**

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Trace2DActionZindexIncrease.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/events/Trace2DActionZindexIncrease.java
@@ -78,7 +78,7 @@ public final class Trace2DActionZindexIncrease extends ATrace2DAction {
    */
   public void actionPerformed(final ActionEvent e) {
     int value = this.m_trace.getZIndex().intValue();
-    this.m_trace.setZIndex(new Integer(value + this.m_increase));
+    this.m_trace.setZIndex(Integer.valueOf(value + this.m_increase));
   }
 
   /**

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/labelformatters/LabelFormatterAutoUnits.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/labelformatters/LabelFormatterAutoUnits.java
@@ -84,7 +84,7 @@ public class LabelFormatterAutoUnits extends ALabelFormatter {
           power--;
         }
       }
-      LabelFormatterAutoUnits.UNITS_2_POWER.put(unit, new Integer(power));
+      LabelFormatterAutoUnits.UNITS_2_POWER.put(unit, Integer.valueOf(power));
     }
   }
 
@@ -291,7 +291,7 @@ public class LabelFormatterAutoUnits extends ALabelFormatter {
   public Number parse(final String formatted) throws NumberFormatException {
     double parsed = this.m_delegate.parse(formatted).doubleValue();
     parsed *= this.m_unit.getFactor();
-    return new Double(parsed);
+    return Double.valueOf(parsed);
   }
 
   /**

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/labelformatters/LabelFormatterDate.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/labelformatters/LabelFormatterDate.java
@@ -269,7 +269,7 @@ public class LabelFormatterDate extends ALabelFormatter implements IAxisLabelFor
    * @see info.monitorenter.gui.chart.IAxisLabelFormatter#parse(java.lang.String)
    */
   public Number parse(final String formatted) throws NumberFormatException {
-    return new Double(this.m_lastFormatted);
+    return Double.valueOf(this.m_lastFormatted);
   }
 
   /**

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/labelformatters/LabelFormatterUnit.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/labelformatters/LabelFormatterUnit.java
@@ -252,7 +252,7 @@ public class LabelFormatterUnit
   public Number parse(final String formatted) throws NumberFormatException {
     double parsed = this.m_delegate.parse(formatted).doubleValue();
     parsed *= this.m_unit.getFactor();
-    return new Double(parsed);
+    return Double.valueOf(parsed);
   }
 
   /**

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/rangepolicies/ARangePolicy.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/rangepolicies/ARangePolicy.java
@@ -227,10 +227,10 @@ public abstract class ARangePolicy implements IRangePolicy {
     if (minchanged && maxchanged) {
       this.firePropertyChange(IRangePolicy.PROPERTY_RANGE, oldRange, this.m_range);
     } else if (minchanged) {
-      this.firePropertyChange(IRangePolicy.PROPERTY_RANGE_MIN, new Double(oldMin), new Double(range
+      this.firePropertyChange(IRangePolicy.PROPERTY_RANGE_MIN, Double.valueOf(oldMin), Double.valueOf(range
           .getMin()));
     } else if (maxchanged) {
-      this.firePropertyChange(IRangePolicy.PROPERTY_RANGE_MAX, new Double(oldMax), new Double(range
+      this.firePropertyChange(IRangePolicy.PROPERTY_RANGE_MAX, Double.valueOf(oldMax), Double.valueOf(range
           .getMax()));
     }
 

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/traces/ATrace2D.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/traces/ATrace2D.java
@@ -358,9 +358,9 @@ public abstract class ATrace2D implements ITrace2D, Comparable<ITrace2D> {
           this.m_minY = p.getY();
           this.m_maxX = p.getX();
           this.m_maxY = p.getY();
-          final Double zero = new Double(0);
-          this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, zero, new Double(this.m_minX));
-          this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, zero, new Double(this.m_minY));
+          final Double zero = Double.valueOf(0);
+          this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, zero, Double.valueOf(this.m_minX));
+          this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, zero, Double.valueOf(this.m_minY));
 
           this.m_firsttime = false;
         }
@@ -489,45 +489,45 @@ public abstract class ATrace2D implements ITrace2D, Comparable<ITrace2D> {
           if (this.showsPositiveXErrorBars()) {
             change = this.expandMaxXErrorBarBounds();
             if (change) {
-              this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, this, new Double(this.getMaxX()));
+              this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, this, Double.valueOf(this.getMaxX()));
             }
           } else {
             if (this.m_maxXErrorBar != -Double.MAX_VALUE) {
               this.m_maxXErrorBar = -Double.MAX_VALUE;
-              this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, this, new Double(this.getMaxX()));
+              this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, this, Double.valueOf(this.getMaxX()));
             }
           }
           if (this.showsPositiveYErrorBars()) {
             change = this.expandMaxYErrorBarBounds();
             if (change) {
-              this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, this, new Double(this.getMaxY()));
+              this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, this, Double.valueOf(this.getMaxY()));
             }
           } else {
             if (this.m_maxYErrorBar != -Double.MAX_VALUE) {
               this.m_maxYErrorBar = -Double.MAX_VALUE;
-              this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, this, new Double(this.getMaxY()));
+              this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, this, Double.valueOf(this.getMaxY()));
             }
           }
           if (this.showsNegativeXErrorBars()) {
             change = this.expandMinXErrorBarBounds();
             if (change) {
-              this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, this, new Double(this.getMinX()));
+              this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, this, Double.valueOf(this.getMinX()));
             }
           } else {
             if (this.m_minXErrorBar != Double.MAX_VALUE) {
               this.m_minXErrorBar = Double.MAX_VALUE;
-              this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, this, new Double(this.getMinX()));
+              this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, this, Double.valueOf(this.getMinX()));
             }
           }
           if (this.showsNegativeYErrorBars()) {
             change = this.expandMinYErrorBarBounds();
             if (change) {
-              this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, this, new Double(this.getMinY()));
+              this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, this, Double.valueOf(this.getMinY()));
             }
           } else {
             if (this.m_minYErrorBar != Double.MAX_VALUE) {
               this.m_minYErrorBar = Double.MAX_VALUE;
-              this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, this, new Double(this.getMinY()));
+              this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, this, Double.valueOf(this.getMinY()));
             }
           }
         }
@@ -744,20 +744,20 @@ public abstract class ATrace2D implements ITrace2D, Comparable<ITrace2D> {
           if (tmpx > this.m_maxX) {
             this.m_maxX = tmpx;
             this.expandMaxXErrorBarBounds();
-            this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, null, new Double(this.m_maxX));
+            this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, null, Double.valueOf(this.m_maxX));
           } else if (tmpx < this.m_minX) {
             this.m_minX = tmpx;
             this.expandMinXErrorBarBounds();
-            this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, null, new Double(this.m_minX));
+            this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, null, Double.valueOf(this.m_minX));
           }
           if (tmpy > this.m_maxY) {
             this.m_maxY = tmpy;
             this.expandMaxYErrorBarBounds();
-            this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, null, new Double(this.m_maxY));
+            this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, null, Double.valueOf(this.m_maxY));
           } else if (tmpy < this.m_minY) {
             this.m_minY = tmpy;
             this.expandMinYErrorBarBounds();
-            this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, null, new Double(this.m_minY));
+            this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, null, Double.valueOf(this.m_minY));
           }
         }
         if (ITracePoint2D.STATE_REMOVED == state) {
@@ -765,23 +765,23 @@ public abstract class ATrace2D implements ITrace2D, Comparable<ITrace2D> {
           if (tmpx >= this.m_maxX) {
             tmpx = this.m_maxX;
             this.maxXSearch();
-            this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, new Double(tmpx), new Double(
+            this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, Double.valueOf(tmpx), Double.valueOf(
                 this.m_maxX));
           } else if (tmpx <= this.m_minX) {
             tmpx = this.m_minX;
             this.minXSearch();
-            this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, new Double(tmpx), new Double(
+            this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, Double.valueOf(tmpx), Double.valueOf(
                 this.m_minX));
           }
           if (tmpy >= this.m_maxY) {
             tmpy = this.m_maxY;
             this.maxYSearch();
-            this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, new Double(tmpy), new Double(
+            this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, Double.valueOf(tmpy), Double.valueOf(
                 this.m_maxY));
           } else if (tmpy <= this.m_minY) {
             tmpy = this.m_minY;
             this.minYSearch();
-            this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, new Double(tmpy), new Double(
+            this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, Double.valueOf(tmpy), Double.valueOf(
                 this.m_minY));
           }
           if (this.getSize() == 0) {
@@ -792,49 +792,49 @@ public abstract class ATrace2D implements ITrace2D, Comparable<ITrace2D> {
           if (tmpx < this.m_maxX) {
             final double oldMaxX = this.m_maxX;
             this.maxXSearch();
-            this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, new Double(oldMaxX), new Double(
+            this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, Double.valueOf(oldMaxX), Double.valueOf(
                 this.m_maxX));
           } else if (tmpx > this.m_maxX) {
             final double oldMaxX = this.m_maxX;
             this.m_maxX = tmpx;
             this.expandMaxXErrorBarBounds();
-            this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, new Double(oldMaxX), new Double(
+            this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, Double.valueOf(oldMaxX), Double.valueOf(
                 this.m_maxX));
           }
           if (tmpx > this.m_minX) {
             final double oldMinX = this.m_minX;
             this.minXSearch();
-            this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, new Double(oldMinX), new Double(
+            this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, Double.valueOf(oldMinX), Double.valueOf(
                 this.m_minX));
           } else if (tmpx < this.m_minX) {
             final double oldMinX = this.m_minX;
             this.m_minX = tmpx;
             this.expandMinXErrorBarBounds();
-            this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, new Double(oldMinX), new Double(
+            this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, Double.valueOf(oldMinX), Double.valueOf(
                 this.m_minX));
           }
           if (tmpy < this.m_maxY) {
             final double oldMaxY = this.m_maxY;
             this.maxYSearch();
-            this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, new Double(oldMaxY), new Double(
+            this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, Double.valueOf(oldMaxY), Double.valueOf(
                 this.m_maxY));
           } else if (tmpy > this.m_maxY) {
             final double oldMaxY = this.m_maxY;
             this.m_maxY = tmpy;
             this.expandMaxYErrorBarBounds();
-            this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, new Double(oldMaxY), new Double(
+            this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, Double.valueOf(oldMaxY), Double.valueOf(
                 this.m_maxY));
           }
           if (tmpy > this.m_minY) {
             final double oldMinY = this.m_minY;
             this.minYSearch();
-            this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, new Double(oldMinY), new Double(
+            this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, Double.valueOf(oldMinY), Double.valueOf(
                 this.m_minY));
           } else if (tmpy < this.m_minY) {
             final double oldMinY = this.m_minY;
             this.m_minY = tmpy;
             this.expandMinYErrorBarBounds();
-            this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, new Double(oldMinY), new Double(
+            this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, Double.valueOf(oldMinY), Double.valueOf(
                 this.m_minY));
           }
           this.firePropertyChange(ITrace2D.PROPERTY_POINT_CHANGED, null, changed);
@@ -1459,19 +1459,19 @@ public abstract class ATrace2D implements ITrace2D, Comparable<ITrace2D> {
         // property changes:
         double oldValue = this.m_maxX;
         this.m_maxX = 0;
-        this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, new Double(oldValue), new Double(
+        this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, Double.valueOf(oldValue), Double.valueOf(
             this.m_maxX));
         oldValue = this.m_maxY;
         this.m_maxY = 0;
-        this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, new Double(oldValue), new Double(
+        this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, Double.valueOf(oldValue), Double.valueOf(
             this.m_maxY));
         oldValue = this.m_minX;
         this.m_minX = 0;
-        this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, new Double(oldValue), new Double(
+        this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, Double.valueOf(oldValue), Double.valueOf(
             this.m_minX));
         oldValue = this.m_minY;
         this.m_minY = 0;
-        this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, new Double(oldValue), new Double(
+        this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, Double.valueOf(oldValue), Double.valueOf(
             this.m_minY));
 
         // inform computing traces:
@@ -1566,23 +1566,23 @@ public abstract class ATrace2D implements ITrace2D, Comparable<ITrace2D> {
           if (tmpx >= this.m_maxX) {
             tmpx = this.m_maxX;
             this.maxXSearch();
-            this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, new Double(tmpx), new Double(
+            this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, Double.valueOf(tmpx), Double.valueOf(
                 this.m_maxX));
           } else if (tmpx <= this.m_minX) {
             tmpx = this.m_minX;
             this.minXSearch();
-            this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, new Double(tmpx), new Double(
+            this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, Double.valueOf(tmpx), Double.valueOf(
                 this.m_minX));
           }
           if (tmpy >= this.m_maxY) {
             tmpy = this.m_maxY;
             this.maxYSearch();
-            this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, new Double(tmpy), new Double(
+            this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, Double.valueOf(tmpy), Double.valueOf(
                 this.m_maxY));
           } else if (tmpy <= this.m_minY) {
             tmpy = this.m_minY;
             this.minYSearch();
-            this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, new Double(tmpy), new Double(
+            this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, Double.valueOf(tmpy), Double.valueOf(
                 this.m_minY));
           }
 

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/traces/Trace2DLtd.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/traces/Trace2DLtd.java
@@ -122,20 +122,20 @@ public class Trace2DLtd extends ATrace2D implements ITrace2D {
       if (tmpx >= this.m_maxX) {
         tmpx = this.m_maxX;
         this.maxXSearch();
-        this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, new Double(tmpx), new Double(this.m_maxX));
+        this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, Double.valueOf(tmpx), Double.valueOf(this.m_maxX));
       } else if (tmpx <= this.m_minX) {
         tmpx = this.m_minX;
         this.minXSearch();
-        this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, new Double(tmpx), new Double(this.m_minX));
+        this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, Double.valueOf(tmpx), Double.valueOf(this.m_minX));
       }
       if (tmpy >= this.m_maxY) {
         tmpy = this.m_maxY;
         this.maxYSearch();
-        this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, new Double(tmpy), new Double(this.m_maxY));
+        this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, Double.valueOf(tmpy), Double.valueOf(this.m_maxY));
       } else if (tmpy <= this.m_minY) {
         tmpy = this.m_minY;
         this.minYSearch();
-        this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, new Double(tmpy), new Double(this.m_minY));
+        this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, Double.valueOf(tmpy), Double.valueOf(this.m_minY));
       }
       // scale the new point, check for new bounds!
       this.firePointAdded(p);
@@ -292,29 +292,29 @@ public class Trace2DLtd extends ATrace2D implements ITrace2D {
         final double xmin = this.m_minX;
         this.minXSearch();
         if (this.m_minX != xmin) {
-          this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, new Double(xmin),
-              new Double(this.m_minX));
+          this.firePropertyChange(ITrace2D.PROPERTY_MIN_X, Double.valueOf(xmin),
+              Double.valueOf(this.m_minX));
         }
 
         final double xmax = this.m_maxX;
         this.maxXSearch();
         if (this.m_maxX != xmax) {
-          this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, new Double(xmax),
-              new Double(this.m_maxX));
+          this.firePropertyChange(ITrace2D.PROPERTY_MAX_X, Double.valueOf(xmax),
+              Double.valueOf(this.m_maxX));
         }
 
         final double ymax = this.m_maxY;
         this.maxYSearch();
         if (this.m_maxY != ymax) {
-          this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, new Double(ymax),
-              new Double(this.m_maxY));
+          this.firePropertyChange(ITrace2D.PROPERTY_MAX_Y, Double.valueOf(ymax),
+              Double.valueOf(this.m_maxY));
         }
 
         final double ymin = this.m_minY;
         this.minYSearch();
         if (this.m_minY != ymin) {
-          this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, new Double(ymin),
-              new Double(this.m_minY));
+          this.firePropertyChange(ITrace2D.PROPERTY_MIN_Y, Double.valueOf(ymin),
+              Double.valueOf(this.m_minY));
         }
       }
     }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/traces/painters/TracePainterPolyline.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/gui/chart/traces/painters/TracePainterPolyline.java
@@ -139,8 +139,8 @@ public class TracePainterPolyline extends ATracePainter {
   public void paintPoint(final int absoluteX, final int absoluteY, final int nextX,
       final int nextY, final Graphics g, final ITracePoint2D original) {
     super.paintPoint(absoluteX, absoluteY, nextX, nextY, g, original);
-    this.m_xPoints.add(new Integer(absoluteX));
-    this.m_yPoints.add(new Integer(absoluteY));
+    this.m_xPoints.add(Integer.valueOf(absoluteX));
+    this.m_yPoints.add(Integer.valueOf(absoluteY));
 
   }
 

--- a/lcm-java/jchart2d-code/src/info/monitorenter/util/FileUtil.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/util/FileUtil.java
@@ -584,18 +584,18 @@ public final class FileUtil extends Object {
 
     if (Math.abs(filesize) < 1024) {
       result = MessageFormat.format(m_bundle.getString("GUI_FILEUTIL_FILESIZE_BYTES_1"),
-          new Object[] {new Long(filesizeNormal) });
+          new Object[] {Long.valueOf(filesizeNormal) });
     } else if (filesizeNormal < 1048576) {
       // 1048576 = 1024.0 * 1024.0
       result = MessageFormat.format(m_bundle.getString("GUI_FILEUTIL_FILESIZE_KBYTES_1"),
-          new Object[] {new Double(filesizeNormal / 1024.0) });
+          new Object[] {Double.valueOf(filesizeNormal / 1024.0) });
     } else if (filesizeNormal < 1073741824) {
       // 1024.0^3 = 1073741824
       result = MessageFormat.format(m_bundle.getString("GUI_FILEUTIL_FILESIZE_MBYTES_1"),
-          new Object[] {new Double(filesize / 1048576.0) });
+          new Object[] {Double.valueOf(filesize / 1048576.0) });
     } else {
       result = MessageFormat.format(m_bundle.getString("GUI_FILEUTIL_FILESIZE_GBYTES_1"),
-          new Object[] {new Double(filesizeNormal / 1073741824.0) });
+          new Object[] {Double.valueOf(filesizeNormal / 1073741824.0) });
     }
     return result;
   }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/util/TimeStampedValue.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/util/TimeStampedValue.java
@@ -141,7 +141,7 @@ public final class TimeStampedValue implements Map.Entry<Long, Object>,
    * @see java.util.Map.Entry#getKey()
    */
   public Long getKey() {
-    return new Long(this.m_key);
+    return Long.valueOf(this.m_key);
   }
 
   /**

--- a/lcm-java/jchart2d-code/src/info/monitorenter/util/collections/TreeSetGreedy.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/util/collections/TreeSetGreedy.java
@@ -160,17 +160,17 @@ public class TreeSetGreedy<T extends IComparableProperty> extends TreeSet<T> imp
     Number result;
     Class< ? > c = n.getClass();
     if (c == Integer.class) {
-      result = new Integer(n.intValue() - 1);
+      result = Integer.valueOf(n.intValue() - 1);
     } else if (c == Double.class) {
-      result = new Double(n.doubleValue() - 1);
+      result = Double.valueOf(n.doubleValue() - 1);
     } else if (c == Float.class) {
-      result = new Float(n.floatValue() - 1);
+      result = Float.valueOf(n.floatValue() - 1);
     } else if (c == Short.class) {
-      result = new Short((short) (n.shortValue() - 1));
+      result = Short.valueOf((short) (n.shortValue() - 1));
     } else if (c == Byte.class) {
-      result = new Byte((byte) (n.byteValue() - 1));
+      result = Byte.valueOf((byte) (n.byteValue() - 1));
     } else if (c == Long.class) {
-      result = new Long(n.longValue() - 1);
+      result = Long.valueOf(n.longValue() - 1);
     } else if (c == BigDecimal.class) {
       BigDecimal bd = new BigDecimal(n.toString());
       bd = bd.subtract(new BigDecimal(1));
@@ -268,7 +268,7 @@ public class TreeSetGreedy<T extends IComparableProperty> extends TreeSet<T> imp
   // private void packComparableProperties() {
   // int i = ITrace2D.ZINDEX_MAX;
   // for (IComparableProperty prop : this) {
-  // prop.setComparableProperty(new Integer(i));
+  // prop.setComparableProperty(Integer.valueOf(i));
   // i++;
   // }
   // }

--- a/lcm-java/jchart2d-code/src/info/monitorenter/util/math/MathUtil.java
+++ b/lcm-java/jchart2d-code/src/info/monitorenter/util/math/MathUtil.java
@@ -129,12 +129,12 @@ public final class MathUtil {
 	 * <p>
 	 * 
 	 * <b>Warning</b>: Never do the following: <code>
-	 *  Integer count = new Integer(6);
+	 *  Integer count = Integer.valueOf(6);
 	 * 	MathUtil.increment(count);
 	 *  // don't expect count now carries 6.
  * </code> Integers are immutable.
 	 * Write: <code>
-	 *  Integer count = new Integer(6);
+	 *  Integer count = Integer.valueOf(6);
 	 * 	count = MathUtil.increment(count);
  * </code>
 	 * 

--- a/lcm-java/jchart2d-code/test/info/monitorenter/gui/chart/TestChart2DHeadless.java
+++ b/lcm-java/jchart2d-code/test/info/monitorenter/gui/chart/TestChart2DHeadless.java
@@ -218,7 +218,7 @@ public class TestChart2DHeadless extends TestCase {
     for (int i = 0; i < 100; i++) {
       chart.addTrace(new Trace2DSimple());
     }
-    trace.setZIndex(new Integer(33));
+    trace.setZIndex(Integer.valueOf(33));
     boolean removed = chart.removeTrace(trace);
     assertTrue("The trace was not removed after changing z-index!", removed);
 

--- a/lcm-java/jchart2d-code/test/info/monitorenter/gui/chart/TestChartOperationsVisual.java
+++ b/lcm-java/jchart2d-code/test/info/monitorenter/gui/chart/TestChartOperationsVisual.java
@@ -668,7 +668,7 @@ public class TestChartOperationsVisual extends ATestChartOperations {
 				for (ITrace2D trace : chart.getTraces()) {
 					trace.setColor(colors[count % 2]);
 					trace.setStroke(new BasicStroke(8));
-					trace.setZIndex(new Integer(count));
+					trace.setZIndex(Integer.valueOf(count));
 					count++;
 				}
 			}

--- a/lcm-java/jchart2d-code/test/info/monitorenter/util/collections/TestRingBufferArrayFast.java
+++ b/lcm-java/jchart2d-code/test/info/monitorenter/util/collections/TestRingBufferArrayFast.java
@@ -78,7 +78,7 @@ public class TestRingBufferArrayFast
   public void testAdd() {
     RingBufferArrayFast<Integer> ringBuffer = new RingBufferArrayFast<Integer>(1);
     System.out.println("Adding 1 element to a buffer of size 1.");
-    ringBuffer.add(new Integer(0));
+    ringBuffer.add(Integer.valueOf(0));
     Assert.assertEquals(1, ringBuffer.size());
 
   }

--- a/lcm-java/jchart2d-code/test/info/monitorenter/util/collections/TestTreeSetGreedy.java
+++ b/lcm-java/jchart2d-code/test/info/monitorenter/util/collections/TestTreeSetGreedy.java
@@ -59,7 +59,7 @@ public class TestTreeSetGreedy
     private static final long serialVersionUID = -615304987571740852L;
     
     /** The internal comparable. */
-    private Number m_compare = new Integer(ITrace2D.ZINDEX_MAX);
+    private Number m_compare = Integer.valueOf(ITrace2D.ZINDEX_MAX);
 
     /**
      * Defcon.


### PR DESCRIPTION
Doesn't deal with the `JApplet` deprecation warning.  Example of warnings it resolves:

```
src/info/monitorenter/gui/chart/events/Trace2DActionSetStroke.java:98: warning: [removal] Boolean(boolean) in Boolean has been deprecated and marked for removal
            new Boolean(true), new Boolean(false));
```