### PR TITLE
Check formatting with script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,3 +152,17 @@ jobs:
         with:
           name: archived-docs
           path: build/docs/_build
+
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Dependencies
+        run: |
+          sudo apt install clang-format-12
+
+      - name: Check formatting
+        run: |
+          ./format_code.sh --check

--- a/examples/c/listener-async.c
+++ b/examples/c/listener-async.c
@@ -18,6 +18,7 @@
 #include <lcm/lcm.h>
 #include <stdio.h>
 #include <sys/select.h>
+
 #include "exlcm_example_t.h"
 
 static void my_handler(const lcm_recv_buf_t *rbuf, const char *channel, const exlcm_example_t *msg,

--- a/examples/c/listener-glib.c
+++ b/examples/c/listener-glib.c
@@ -11,6 +11,7 @@
 #include <lcm/lcm.h>
 #include <stdio.h>
 #include <sys/select.h>
+
 #include "exlcm_example_t.h"
 
 typedef struct _state_t {

--- a/examples/c/listener.c
+++ b/examples/c/listener.c
@@ -11,6 +11,7 @@
 #include <inttypes.h>
 #include <lcm/lcm.h>
 #include <stdio.h>
+
 #include "exlcm_example_t.h"
 
 static void my_handler(const lcm_recv_buf_t *rbuf, const char *channel, const exlcm_example_t *msg,

--- a/examples/c/send_message.c
+++ b/examples/c/send_message.c
@@ -20,7 +20,9 @@ int main(int argc, char **argv)
         return 1;
 
     exlcm_example_t my_data = {
-        .timestamp = 0, .position = {1, 2, 3}, .orientation = {1, 0, 0, 0},
+        .timestamp = 0,
+        .position = {1, 2, 3},
+        .orientation = {1, 0, 0, 0},
     };
     int16_t ranges[15];
     int i;

--- a/examples/cpp/lcm_log_writer/include/joint_state_t.hpp
+++ b/examples/cpp/lcm_log_writer/include/joint_state_t.hpp
@@ -9,88 +9,92 @@
 #ifndef __pronto_joint_state_t_hpp__
 #define __pronto_joint_state_t_hpp__
 
-#include <vector>
 #include <string>
+#include <vector>
 
-namespace pronto
-{
+namespace pronto {
 
 /**
- * Generic State Message 
+ * Generic State Message
  * equivalent to ROS joint states message
  */
-class joint_state_t
-{
-    public:
-        int64_t    utime;
+class joint_state_t {
+  public:
+    int64_t utime;
 
-        int16_t    num_joints;
+    int16_t num_joints;
 
-        std::vector< std::string > joint_name;
+    std::vector<std::string> joint_name;
 
-        std::vector< float > joint_position;
+    std::vector<float> joint_position;
 
-        std::vector< float > joint_velocity;
+    std::vector<float> joint_velocity;
 
-        std::vector< float > joint_effort;
+    std::vector<float> joint_effort;
 
-    public:
-        /**
-         * Encode a message into binary form.
-         *
-         * @param buf The output buffer.
-         * @param offset Encoding starts at thie byte offset into @p buf.
-         * @param maxlen Maximum number of bytes to write.  This should generally be
-         *  equal to getEncodedSize().
-         * @return The number of bytes encoded, or <0 on error.
-         */
-        inline int encode(void *buf, int offset, int maxlen) const;
+  public:
+    /**
+     * Encode a message into binary form.
+     *
+     * @param buf The output buffer.
+     * @param offset Encoding starts at thie byte offset into @p buf.
+     * @param maxlen Maximum number of bytes to write.  This should generally be
+     *  equal to getEncodedSize().
+     * @return The number of bytes encoded, or <0 on error.
+     */
+    inline int encode(void *buf, int offset, int maxlen) const;
 
-        /**
-         * Check how many bytes are required to encode this message.
-         */
-        inline int getEncodedSize() const;
+    /**
+     * Check how many bytes are required to encode this message.
+     */
+    inline int getEncodedSize() const;
 
-        /**
-         * Decode a message from binary form into this instance.
-         *
-         * @param buf The buffer containing the encoded message.
-         * @param offset The byte offset into @p buf where the encoded message starts.
-         * @param maxlen The maximum number of bytes to reqad while decoding.
-         * @return The number of bytes decoded, or <0 if an error occured.
-         */
-        inline int decode(const void *buf, int offset, int maxlen);
+    /**
+     * Decode a message from binary form into this instance.
+     *
+     * @param buf The buffer containing the encoded message.
+     * @param offset The byte offset into @p buf where the encoded message starts.
+     * @param maxlen The maximum number of bytes to reqad while decoding.
+     * @return The number of bytes decoded, or <0 if an error occured.
+     */
+    inline int decode(const void *buf, int offset, int maxlen);
 
-        /**
-         * Retrieve the 64-bit fingerprint identifying the structure of the message.
-         * Note that the fingerprint is the same for all instances of the same
-         * message type, and is a fingerprint on the message type definition, not on
-         * the message contents.
-         */
-        inline static int64_t getHash();
+    /**
+     * Retrieve the 64-bit fingerprint identifying the structure of the message.
+     * Note that the fingerprint is the same for all instances of the same
+     * message type, and is a fingerprint on the message type definition, not on
+     * the message contents.
+     */
+    inline static int64_t getHash();
 
-        /**
-         * Returns "joint_state_t"
-         */
-        inline static const char* getTypeName();
+    /**
+     * Returns "joint_state_t"
+     */
+    inline static const char *getTypeName();
 
-        // LCM support functions. Users should not call these
-        inline int _encodeNoHash(void *buf, int offset, int maxlen) const;
-        inline int _getEncodedSizeNoHash() const;
-        inline int _decodeNoHash(const void *buf, int offset, int maxlen);
-        inline static uint64_t _computeHash(const __lcm_hash_ptr *p);
+    // LCM support functions. Users should not call these
+    inline int _encodeNoHash(void *buf, int offset, int maxlen) const;
+    inline int _getEncodedSizeNoHash() const;
+    inline int _decodeNoHash(const void *buf, int offset, int maxlen);
+    inline static uint64_t _computeHash(const __lcm_hash_ptr *p);
 };
 
-int joint_state_t:: encode(void *buf, int offset, int maxlen) const
+int joint_state_t::encode(void *buf, int offset, int maxlen) const
 {
     int pos = 0, tlen;
-    int64_t hash = (int64_t)getHash();
+    int64_t hash = (int64_t) getHash();
 
     tlen = __int64_t_encode_array(buf, offset + pos, maxlen - pos, &hash, 1);
-    if(tlen < 0) return tlen; else pos += tlen;
+    if (tlen < 0)
+        return tlen;
+    else
+        pos += tlen;
 
     tlen = this->_encodeNoHash(buf, offset + pos, maxlen - pos);
-    if (tlen < 0) return tlen; else pos += tlen;
+    if (tlen < 0)
+        return tlen;
+    else
+        pos += tlen;
 
     return pos;
 }
@@ -101,11 +105,18 @@ int joint_state_t::decode(const void *buf, int offset, int maxlen)
 
     int64_t msg_hash;
     thislen = __int64_t_decode_array(buf, offset + pos, maxlen - pos, &msg_hash, 1);
-    if (thislen < 0) return thislen; else pos += thislen;
-    if (msg_hash != getHash()) return -1;
+    if (thislen < 0)
+        return thislen;
+    else
+        pos += thislen;
+    if (msg_hash != getHash())
+        return -1;
 
     thislen = this->_decodeNoHash(buf, offset + pos, maxlen - pos);
-    if (thislen < 0) return thislen; else pos += thislen;
+    if (thislen < 0)
+        return thislen;
+    else
+        pos += thislen;
 
     return pos;
 }
@@ -121,7 +132,7 @@ int64_t joint_state_t::getHash()
     return hash;
 }
 
-const char* joint_state_t::getTypeName()
+const char *joint_state_t::getTypeName()
 {
     return "joint_state_t";
 }
@@ -131,30 +142,51 @@ int joint_state_t::_encodeNoHash(void *buf, int offset, int maxlen) const
     int pos = 0, tlen;
 
     tlen = __int64_t_encode_array(buf, offset + pos, maxlen - pos, &this->utime, 1);
-    if(tlen < 0) return tlen; else pos += tlen;
+    if (tlen < 0)
+        return tlen;
+    else
+        pos += tlen;
 
     tlen = __int16_t_encode_array(buf, offset + pos, maxlen - pos, &this->num_joints, 1);
-    if(tlen < 0) return tlen; else pos += tlen;
+    if (tlen < 0)
+        return tlen;
+    else
+        pos += tlen;
 
     for (int a0 = 0; a0 < this->num_joints; a0++) {
-        char* __cstr = (char*) this->joint_name[a0].c_str();
+        char *__cstr = (char *) this->joint_name[a0].c_str();
         tlen = __string_encode_array(buf, offset + pos, maxlen - pos, &__cstr, 1);
-        if(tlen < 0) return tlen; else pos += tlen;
+        if (tlen < 0)
+            return tlen;
+        else
+            pos += tlen;
     }
 
-    if(this->num_joints > 0) {
-        tlen = __float_encode_array(buf, offset + pos, maxlen - pos, &this->joint_position[0], this->num_joints);
-        if(tlen < 0) return tlen; else pos += tlen;
+    if (this->num_joints > 0) {
+        tlen = __float_encode_array(buf, offset + pos, maxlen - pos, &this->joint_position[0],
+                                    this->num_joints);
+        if (tlen < 0)
+            return tlen;
+        else
+            pos += tlen;
     }
 
-    if(this->num_joints > 0) {
-        tlen = __float_encode_array(buf, offset + pos, maxlen - pos, &this->joint_velocity[0], this->num_joints);
-        if(tlen < 0) return tlen; else pos += tlen;
+    if (this->num_joints > 0) {
+        tlen = __float_encode_array(buf, offset + pos, maxlen - pos, &this->joint_velocity[0],
+                                    this->num_joints);
+        if (tlen < 0)
+            return tlen;
+        else
+            pos += tlen;
     }
 
-    if(this->num_joints > 0) {
-        tlen = __float_encode_array(buf, offset + pos, maxlen - pos, &this->joint_effort[0], this->num_joints);
-        if(tlen < 0) return tlen; else pos += tlen;
+    if (this->num_joints > 0) {
+        tlen = __float_encode_array(buf, offset + pos, maxlen - pos, &this->joint_effort[0],
+                                    this->num_joints);
+        if (tlen < 0)
+            return tlen;
+        else
+            pos += tlen;
     }
 
     return pos;
@@ -165,37 +197,59 @@ int joint_state_t::_decodeNoHash(const void *buf, int offset, int maxlen)
     int pos = 0, tlen;
 
     tlen = __int64_t_decode_array(buf, offset + pos, maxlen - pos, &this->utime, 1);
-    if(tlen < 0) return tlen; else pos += tlen;
+    if (tlen < 0)
+        return tlen;
+    else
+        pos += tlen;
 
     tlen = __int16_t_decode_array(buf, offset + pos, maxlen - pos, &this->num_joints, 1);
-    if(tlen < 0) return tlen; else pos += tlen;
+    if (tlen < 0)
+        return tlen;
+    else
+        pos += tlen;
 
     this->joint_name.resize(this->num_joints);
     for (int a0 = 0; a0 < this->num_joints; a0++) {
         int32_t __elem_len;
         tlen = __int32_t_decode_array(buf, offset + pos, maxlen - pos, &__elem_len, 1);
-        if(tlen < 0) return tlen; else pos += tlen;
-        if(__elem_len > maxlen - pos) return -1;
-        this->joint_name[a0].assign(((const char*)buf) + offset + pos, __elem_len -  1);
+        if (tlen < 0)
+            return tlen;
+        else
+            pos += tlen;
+        if (__elem_len > maxlen - pos)
+            return -1;
+        this->joint_name[a0].assign(((const char *) buf) + offset + pos, __elem_len - 1);
         pos += __elem_len;
     }
 
-    if(this->num_joints) {
+    if (this->num_joints) {
         this->joint_position.resize(this->num_joints);
-        tlen = __float_decode_array(buf, offset + pos, maxlen - pos, &this->joint_position[0], this->num_joints);
-        if(tlen < 0) return tlen; else pos += tlen;
+        tlen = __float_decode_array(buf, offset + pos, maxlen - pos, &this->joint_position[0],
+                                    this->num_joints);
+        if (tlen < 0)
+            return tlen;
+        else
+            pos += tlen;
     }
 
-    if(this->num_joints) {
+    if (this->num_joints) {
         this->joint_velocity.resize(this->num_joints);
-        tlen = __float_decode_array(buf, offset + pos, maxlen - pos, &this->joint_velocity[0], this->num_joints);
-        if(tlen < 0) return tlen; else pos += tlen;
+        tlen = __float_decode_array(buf, offset + pos, maxlen - pos, &this->joint_velocity[0],
+                                    this->num_joints);
+        if (tlen < 0)
+            return tlen;
+        else
+            pos += tlen;
     }
 
-    if(this->num_joints) {
+    if (this->num_joints) {
         this->joint_effort.resize(this->num_joints);
-        tlen = __float_decode_array(buf, offset + pos, maxlen - pos, &this->joint_effort[0], this->num_joints);
-        if(tlen < 0) return tlen; else pos += tlen;
+        tlen = __float_decode_array(buf, offset + pos, maxlen - pos, &this->joint_effort[0],
+                                    this->num_joints);
+        if (tlen < 0)
+            return tlen;
+        else
+            pos += tlen;
     }
 
     return pos;
@@ -218,9 +272,9 @@ int joint_state_t::_getEncodedSizeNoHash() const
 uint64_t joint_state_t::_computeHash(const __lcm_hash_ptr *)
 {
     uint64_t hash = 0x1f1bbda675e2c9d2LL;
-    return (hash<<1) + ((hash>>63)&1);
+    return (hash << 1) + ((hash >> 63) & 1);
 }
 
-}
+}  // namespace pronto
 
 #endif

--- a/examples/cpp/lcm_log_writer/main.cpp
+++ b/examples/cpp/lcm_log_writer/main.cpp
@@ -1,46 +1,43 @@
 #include <lcm/lcm.h>
-#include <lcm/lcm-cpp.hpp>
-#include <joint_state_t.hpp>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <cmath>
 #include <fstream>
 #include <iostream>
+#include <joint_state_t.hpp>
+#include <lcm/lcm-cpp.hpp>
 #include <string>
-#include <unistd.h>
-#include <sys/time.h>
-#include <cmath>
-
 
 using namespace std;
 
-int64_t utime_now() {
+int64_t utime_now()
+{
     struct timeval tv;
-    gettimeofday (&tv, NULL);
+    gettimeofday(&tv, NULL);
     return (int64_t) tv.tv_sec * 1000000 + tv.tv_usec;
 }
 
 class LcmLogWriter {
-public:
+  public:
     LcmLogWriter(std::string filename);
     ~LcmLogWriter();
     void run();
 
-private:
+  private:
     ifstream is;
     uint64_t eventnum;
     std::string filename_;
 
-
-    lcm::LogFile* lf;
+    lcm::LogFile *lf;
     lcm::LogEvent le;
     lcm::LCM mylcm;
     pronto::joint_state_t test_msg;
-
 };
 
-LcmLogWriter::LcmLogWriter(std::string filename) : filename_(filename),
-    eventnum(0), lf(NULL) {
-
+LcmLogWriter::LcmLogWriter(std::string filename) : filename_(filename), eventnum(0), lf(NULL)
+{
     is.open(filename_.c_str());
-
 
     // we set them now forever
     test_msg.num_joints = 12;
@@ -69,18 +66,20 @@ LcmLogWriter::LcmLogWriter(std::string filename) : filename_(filename),
 
     lf = new lcm::LogFile(filename_, "w");
 
-    if(!lf->good()) {
+    if (!lf->good()) {
         std::cerr << "ERROR: logfile not ready!" << std::endl;
     }
 }
 
-LcmLogWriter::~LcmLogWriter() {
+LcmLogWriter::~LcmLogWriter()
+{
     delete lf;
     is.close();
 }
 
-void LcmLogWriter::run() {
-    while(eventnum < 2500) {
+void LcmLogWriter::run()
+{
+    while (eventnum < 2500) {
         std::cout << "Eventnum: " << eventnum << std::endl;
         struct timeval tv;
         gettimeofday(&tv, NULL);
@@ -91,11 +90,11 @@ void LcmLogWriter::run() {
         // 2 Hz
         double f3 = 3;
         // 3 Hz
-        test_msg.joint_position[0] = sin(2 * M_PI * f1 * (double)test_msg.utime / 1000000.0);
+        test_msg.joint_position[0] = sin(2 * M_PI * f1 * (double) test_msg.utime / 1000000.0);
         // we want seconds inside
-        test_msg.joint_velocity[0] = sin(2 * M_PI * f2 * (double)test_msg.utime / 1000000.0);
+        test_msg.joint_velocity[0] = sin(2 * M_PI * f2 * (double) test_msg.utime / 1000000.0);
         // we want seconds inside
-        test_msg.joint_effort[0] = sin(2 * M_PI * f3 * (double)test_msg.utime / 1000000.0);
+        test_msg.joint_effort[0] = sin(2 * M_PI * f3 * (double) test_msg.utime / 1000000.0);
         // we want seconds inside
         lcm::LogEvent le;
         le.channel = "JOINT_TEST";
@@ -103,7 +102,7 @@ void LcmLogWriter::run() {
         le.data = malloc(le.datalen);
         le.eventnum = eventnum;
         le.timestamp = test_msg.utime;
-        test_msg.encode(le.data,0,le.datalen);
+        test_msg.encode(le.data, 0, le.datalen);
         lf->writeEvent(&le);
         mylcm.publish(le.channel, &test_msg);
         eventnum++;
@@ -111,9 +110,9 @@ void LcmLogWriter::run() {
     }
 }
 
-
-int main(int argc, char* argv[]) {
-    if(argc >= 2) {
+int main(int argc, char *argv[])
+{
+    if (argc >= 2) {
         LcmLogWriter stl(argv[1]);
         stl.run();
     } else {
@@ -122,4 +121,3 @@ int main(int argc, char* argv[]) {
 
     return 0;
 }
-

--- a/examples/cpp/listener.cpp
+++ b/examples/cpp/listener.cpp
@@ -11,6 +11,7 @@
 #include <stdio.h>
 
 #include <lcm/lcm-cpp.hpp>
+
 #include "exlcm/example_t.hpp"
 
 class Handler {

--- a/format_code.sh
+++ b/format_code.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+set -o errexit
+set -o nounset
+set -o pipefail
+IFS=$'\n\t'
+
 # Bash script to automatically format LCM source code (currently C and C++).
 # Requires `clang-format` utilily, which is part of the LLVM project. More
 # information can be found here: https://clang.llvm.org/docs/ClangFormat.html
@@ -8,23 +13,43 @@
 #
 #     $ sudo apt install clang-format
 #
-# On Windows 10 you are recommended to use the Linux Subsystem. You can install
-# the Linux Subsystem by doing the following:
-#
-#   1. Open PowerShell as Administrator, enter the command:
-#
-#     PS C:\> Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux
-#
-#   2. Restart the computer.
-#   3. Go to the Microsoft Store, install the Ubuntu app.
-#
 # This script does not format Java, Python, or Lua source code. At the moment,
 # it only formats C and C++ sources, i.e., *.h, *.c, *.hpp, and *.cpp. It only
 # formats code in certain directories, see below for the full list.
 
 LCM_ROOT="$(cd $(dirname "$0") && pwd)"
 
-# format_c_cpp_dir_r DIR [EXCUDE_PATTERN...]
+# Define which directories should be formatted, with an optional list of
+# exceptions as regex. Format is: `dir:regex1:regex2:...`
+LCM_FORMAT_DIRS=(
+    "${LCM_ROOT}/examples"
+    "${LCM_ROOT}/lcm:/lcmtypes/"
+    "${LCM_ROOT}/lcmgen"
+    "${LCM_ROOT}/lcm-lite"
+    "${LCM_ROOT}/lcm-logger"
+    "${LCM_ROOT}/lcm-lua"
+    "${LCM_ROOT}/lcm-python"
+    "${LCM_ROOT}/liblcm-test"
+    "${LCM_ROOT}/test:/gtest/"
+)
+
+# Function: show_usage
+#
+# Shows usage of this script.
+
+function show_usage {
+    cat <<EOF 1>&2
+Usage: $(basename "$0") [-c | --check]
+
+Formats source code for C (*.h, *.c), C++ (*.hpp, *.cpp), etc.
+
+    -c | --check    Do not format, only check existing formatting
+    -h | --help     Display this help message
+
+EOF
+}
+
+# Function: format_c_cpp_dir_r DIR [EXCUDE_PATTERN...]
 #
 # Formats all C and C++ sources in a directory recursively. DIR is the source
 # directory for the recursive formatting. The optional EXCLUDE_PATTERN is an
@@ -47,13 +72,85 @@ function format_c_cpp_dir_r {
         | xargs clang-format -i
 }
 
-format_c_cpp_dir_r "${LCM_ROOT}/lcm" "/lcmtypes/"
-format_c_cpp_dir_r "${LCM_ROOT}/lcmgen"
-format_c_cpp_dir_r "${LCM_ROOT}/examples"
-format_c_cpp_dir_r "${LCM_ROOT}/test" "/gtest/"
-format_c_cpp_dir_r "${LCM_ROOT}/lcm-logger"
-format_c_cpp_dir_r "${LCM_ROOT}/lcm-python"
-format_c_cpp_dir_r "${LCM_ROOT}/lcm-lua"
-format_c_cpp_dir_r "${LCM_ROOT}/liblcm-test"
+# Function: check_format_c_cpp_dir_r DIR [EXCUDE_PATTERN...]
+#
+# Checks format of all C and C++ sources in a directory recursively. DIR is the
+# source directory for the recursive formatting. The optional EXCLUDE_PATTERN is
+# an Extended Regex matched against each file path, where the file is excluded
+# from formatting if it matches. There can be multiple exclude patterns.
+#
+# This function will return 0 if all code is formatted, and 1 otherwise.
 
-exit 0
+function check_format_c_cpp_dir_r {
+    include_dir="$1"
+    exclude_patterns=("${@:2}")
+    if [ "${#exclude_patterns[@]}" -eq 0 ]; then
+        # Use an empty pattern to not match anything
+        exclude_patterns="^$"
+    fi
+    exclude_pattern_opts=""
+    for exclude_pattern in "${exclude_patterns[@]}"; do
+        exclude_pattern_opts="${exclude_pattern_opts} -e \"${exclude_pattern}\" "
+    done
+    find "$1" -regex '.*\.\(c\|h\)\(pp\)?' \
+        | eval "grep -E -v" "${exclude_pattern_opts}" \
+        | xargs clang-format --dry-run --Werror --ferror-limit=1 &>/dev/null
+}
+
+# Default option values
+check_mode=0
+
+# Convert long options to short options, preserving order
+for arg in "${@}"; do
+    case "${arg}" in
+        "--check" ) set -- "${@}" "-c" ;;
+        "--help" ) set -- "${@}" "-h" ;;
+        * ) set -- "${@}" "${arg}" ;;
+    esac
+    shift
+done
+
+# Parse short options using getopts
+while getopts "ch" arg &>/dev/null; do
+    case "${arg}" in
+        "c" ) check_mode=1 ;;
+        "h" ) show_usage ; exit 0 ;;
+        "?" ) show_usage ; exit 1 ;;
+    esac
+done
+
+# Check for clang-format
+if ! command -v clang-format &>/dev/null; then
+    echo "ERROR: Can not find clang-format!" 1>&2
+    echo "Please add clang-format to your PATH" 1>&2
+    echo "On Ubuntu, install it with: sudo apt install clang-format" 1>&2
+    exit 1
+fi
+
+# Determine which function to run
+func="format_c_cpp_dir_r"
+if [ ${check_mode} -ne 0 ]; then
+    func="check_format_c_cpp_dir_r"
+fi
+
+# Run the function for all directories
+error_code=0
+for entry in "${LCM_FORMAT_DIRS[@]}"; do
+    IFS=":" read -r -a args <<< "${entry}"
+    if ! eval "${func}" "${args[@]}"; then
+        error_code=1
+        break
+    fi
+done
+
+# Show check results
+if [ ${check_mode} -ne 0 ]; then
+    if [ ${error_code} -eq 0 ]; then
+        echo "FORMATTING OK!"
+    else
+        echo "UNFORMATTED FILES!"
+        echo "Please run the formatting script: ./format_code.sh"
+    fi
+fi
+
+exit ${error_code}

--- a/lcm-lite/lcmlite.h
+++ b/lcm-lite/lcmlite.h
@@ -50,8 +50,7 @@
 typedef struct lcmlite_subscription lcmlite_subscription_t;
 typedef struct lcmlite lcmlite_t;
 
-struct fragment_buffer
-{
+struct fragment_buffer {
     int32_t last_fragment_count;
 
     uint64_t from_addr;
@@ -63,8 +62,7 @@ struct fragment_buffer
     uint8_t frag_received[LCM3_MAX_FRAGMENTS];
 };
 
-struct lcmlite_subscription
-{
+struct lcmlite_subscription {
     char *channel;
 
     void (*callback)(lcmlite_t *lcm, const char *channel, const void *buf, int buf_len, void *user);
@@ -74,8 +72,7 @@ struct lcmlite_subscription
     lcmlite_subscription_t *next;
 };
 
-struct lcmlite
-{
+struct lcmlite {
     /** Buffers for reassembling multi-fragment messages. **/
     struct fragment_buffer fragment_buffers[LCM3_NUM_BUFFERS];
 
@@ -96,7 +93,8 @@ struct lcmlite
 };
 
 // Caller allocates the lcmlite_t object, which we initialize.
-int lcmlite_init(lcmlite_t *lcm, void (*transmit_packet)(const void *_buf, int buf_len, void *user), void *transmit_user);
+int lcmlite_init(lcmlite_t *lcm, void (*transmit_packet)(const void *_buf, int buf_len, void *user),
+                 void *transmit_user);
 
 // The user is responsible for creating and listening on a UDP
 // multicast socket. When a packet is received, call this function. Do

--- a/lcm-lite/lcmlite_ios.h
+++ b/lcm-lite/lcmlite_ios.h
@@ -7,25 +7,24 @@
  *
  */
 
-#include <stdint.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
 #include <arpa/inet.h>
-#include <unistd.h>
+#include <assert.h>
+#include <netinet/in.h>
+#include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
-#include <assert.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include "lcmlite.h"
 
 #ifndef _LCMLITE_IMPL_H
 #define _LCMLITE_IMPL_H
 
-struct lcmlite_impl
-{
-	struct sockaddr_in read_addr;
+struct lcmlite_impl {
+    struct sockaddr_in read_addr;
     struct sockaddr_in send_addr;
     int send_fd, read_fd;
 };

--- a/lcm-logger/glib_util.c
+++ b/lcm-logger/glib_util.c
@@ -121,9 +121,9 @@ int signal_pipe_attach_glib(signal_pipe_glib_handler_t func, gpointer user_data)
         return -1;
 
     g_sp.ioc = g_io_channel_unix_new(g_sp.fds[0]);
-    g_io_channel_set_flags(g_sp.ioc,
-                           (GIOFlags)(g_io_channel_get_flags(g_sp.ioc) | G_IO_FLAG_NONBLOCK), NULL);
-    g_sp.ios = g_io_add_watch(g_sp.ioc, (GIOCondition)(G_IO_IN | G_IO_PRI),
+    g_io_channel_set_flags(
+        g_sp.ioc, (GIOFlags) (g_io_channel_get_flags(g_sp.ioc) | G_IO_FLAG_NONBLOCK), NULL);
+    g_sp.ios = g_io_add_watch(g_sp.ioc, (GIOCondition) (G_IO_IN | G_IO_PRI),
                               (GIOFunc) signal_handler_glib, NULL);
 
     g_sp.userfunc = func;

--- a/lcm-logger/lcm_logger.c
+++ b/lcm-logger/lcm_logger.c
@@ -1,15 +1,13 @@
 #include <assert.h>
 #include <errno.h>
 #include <getopt.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <lcm/lcm.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-
-#include <glib.h>
-#include <glib/gstdio.h>
-
-#include <lcm/lcm.h>
 
 // Several thread and synchronization API functions (e.g. g_mutex_init,
 // g_cond_init, g_thread_new, etc) require 2.32
@@ -140,8 +138,8 @@ static int open_logfile(logger_t *logger)
         /* Loop through possible file names until we find one that doesn't
          * already exist.  This way, we never overwrite an existing file. */
         do {
-            int ret = snprintf(logger->fname, sizeof(logger->fname), "%s.%02d", logger->fname_prefix,
-                     logger->next_increment_num);
+            int ret = snprintf(logger->fname, sizeof(logger->fname), "%s.%02d",
+                               logger->fname_prefix, logger->next_increment_num);
             if (ret < 0) {
                 fprintf(stderr, "Error: failed to create filename string");
                 return 1;
@@ -532,7 +530,7 @@ int main(int argc, char *argv[])
     }
 
     logger.time0 = g_get_real_time();
-    logger.max_write_queue_size = (int64_t)(max_write_queue_size_mb * (1 << 20));
+    logger.max_write_queue_size = (int64_t) (max_write_queue_size_mb * (1 << 20));
 
     if (0 != open_logfile(&logger))
         return 1;

--- a/lcm-logger/lcm_logplayer.c
+++ b/lcm-logger/lcm_logplayer.c
@@ -1,10 +1,8 @@
 #include <getopt.h>
+#include <lcm/lcm.h>
 #include <stdio.h>
 #include <stdlib.h>
-
 #include <string.h>
-
-#include <lcm/lcm.h>
 
 typedef struct logplayer logplayer_t;
 struct logplayer {

--- a/lcm-lua/lualcm_hash.c
+++ b/lcm-lua/lualcm_hash.c
@@ -1,4 +1,5 @@
 #include "lualcm_hash.h"
+
 #include "lua_ver_helper.h"
 #include "stdio.h"
 
@@ -39,14 +40,18 @@ void ll_hash_makemetatable(lua_State *L)
     }
 
     const struct luaL_Reg metas[] = {
-        {"__add", impl_hash_add}, {"__tostring", impl_hash_tostring}, {NULL, NULL},
+        {"__add", impl_hash_add},
+        {"__tostring", impl_hash_tostring},
+        {NULL, NULL},
     };
 
     /* register to meta */
     luaX_registertable(L, metas);
 
     const struct luaL_Reg methods[] = {
-        {"tobytes", impl_hash_tobytes}, {"rotate", impl_hash_rotate}, {NULL, NULL},
+        {"tobytes", impl_hash_tobytes},
+        {"rotate", impl_hash_rotate},
+        {NULL, NULL},
     };
 
     /* register methods to new table, set __index */
@@ -75,7 +80,8 @@ void ll_hash_makemetatable(lua_State *L)
 void ll_hash_register_new(lua_State *L)
 {
     const struct luaL_Reg new_function[] = {
-        {"new", impl_hash_new}, {NULL, NULL},
+        {"new", impl_hash_new},
+        {NULL, NULL},
     };
 
     luaX_registerglobal(L, "lcm._hash", new_function);

--- a/lcm-lua/lualcm_lcm.c
+++ b/lcm-lua/lualcm_lcm.c
@@ -1,4 +1,5 @@
 #include "lualcm_lcm.h"
+
 #include "lcm/lcm.h"
 #include "lua_ref_helper.h"
 #include "lua_ver_helper.h"
@@ -96,7 +97,9 @@ void ll_lcm_makemetatable(lua_State *L)
     }
 
     const struct luaL_Reg metas[] = {
-        {"__tostring", impl_lcm_tostring}, {"__gc", impl_lcm_gc}, {NULL, NULL},
+        {"__tostring", impl_lcm_tostring},
+        {"__gc", impl_lcm_gc},
+        {NULL, NULL},
     };
 
     /* register to meta */
@@ -139,7 +142,8 @@ void ll_lcm_makemetatable(lua_State *L)
 void ll_lcm_register_new(lua_State *L)
 {
     const struct luaL_Reg new_function[] = {
-        {"new", impl_lcm_new}, {NULL, NULL},
+        {"new", impl_lcm_new},
+        {NULL, NULL},
     };
 
     luaX_registerglobal(L, "lcm.lcm", new_function);

--- a/lcm-lua/lualcm_pack.c
+++ b/lcm-lua/lualcm_pack.c
@@ -1,4 +1,5 @@
 #include "lualcm_pack.h"
+
 #include "errno.h"
 #include "lua_ver_helper.h"
 #include "lualcm_hash.h"
@@ -465,7 +466,7 @@ static int impl_get_required_stack_size(impl_pack_op_t *ops, size_t num_ops)
         case DATATYPE_UNKNOWN:
             fprintf(stderr, "WARNING! Encountered unknown datatype.\n");
             num_values += 1;
-            break;;
+            break;
         }
     }
 
@@ -754,7 +755,7 @@ static void impl_unpack_byte(lua_State *L, const uint8_t *buf, size_t *offset, s
 {
     /* unpack as a Lua "byte string" which is really just a string */
     const uint8_t *bytes = (const uint8_t *) (buf + *offset);
-    lua_pushlstring(L, (const char*)bytes, bytes_size);
+    lua_pushlstring(L, (const char *) bytes, bytes_size);
     *offset += bytes_size * sizeof(uint8_t);
 }
 
@@ -897,7 +898,8 @@ static void impl_pack_byte(lua_State *L, uint8_t *buf, size_t *offset, int *stac
                            size_t bytes_size, bool swap)
 {
     size_t other_bytes_size;
-    const uint8_t *other_bytes = (const uint8_t *)luaL_checklstring(L, *stack_pos, &other_bytes_size);
+    const uint8_t *other_bytes =
+        (const uint8_t *) luaL_checklstring(L, *stack_pos, &other_bytes_size);
     uint8_t *bytes = (uint8_t *) (buf + *offset);
 
     int i;

--- a/lcm-lua/utf8_check.c
+++ b/lcm-lua/utf8_check.c
@@ -32,7 +32,7 @@
 
 int utf8_check(const char *p, size_t length)
 {
-    const unsigned char* s = (const unsigned char*)p;
+    const unsigned char *s = (const unsigned char *) p;
 
     size_t i = 0;
     while (i < length) {

--- a/lcm-python/module.c
+++ b/lcm-python/module.c
@@ -1,4 +1,5 @@
 #include <Python.h>
+
 #include "pylcm_subscription.h"
 
 //#define dbg(...) fprintf (stderr, __VA_ARGS__)
@@ -11,7 +12,7 @@
 
 // to support python 3.9.0a3 and earlier
 #if PY_VERSION_HEX < 0x030900A4
-#define Py_SET_TYPE(obj, type) ((Py_TYPE(obj) = (type)), (void)0)
+#define Py_SET_TYPE(obj, type) ((Py_TYPE(obj) = (type)), (void) 0)
 #endif
 
 extern PyTypeObject pylcmeventlog_type;

--- a/lcm-python/pyeventlog.c
+++ b/lcm-python/pyeventlog.c
@@ -1,6 +1,5 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-
 #include <lcm/eventlog.h>
 
 // to support python 2.5 and earlier

--- a/lcm/eventlog.c
+++ b/lcm/eventlog.c
@@ -126,9 +126,9 @@ int lcm_eventlog_write_event(lcm_eventlog_t *l, lcm_eventlog_event_t *le)
     if (0 != fwrite32(l->f, le->datalen))
         return -1;
 
-    if (le->channellen != (int32_t)fwrite(le->channel, 1, le->channellen, l->f))
+    if (le->channellen != (int32_t) fwrite(le->channel, 1, le->channellen, l->f))
         return -1;
-    if (le->datalen != (int32_t)fwrite(le->data, 1, le->datalen, l->f))
+    if (le->datalen != (int32_t) fwrite(le->data, 1, le->datalen, l->f))
         return -1;
 
     l->eventcount++;
@@ -187,7 +187,7 @@ int lcm_eventlog_seek_to_timestamp(lcm_eventlog_t *l, int64_t timestamp)
 
     while (1) {
         frac = 0.5 * (frac1 + frac2);
-        off_t offset = (off_t)(frac * file_len);
+        off_t offset = (off_t) (frac * file_len);
         fseeko(l->f, offset, SEEK_SET);
         cur_time = get_event_time(l);
         if (cur_time < 0)

--- a/lcm/ioutils.h
+++ b/lcm/ioutils.h
@@ -59,7 +59,7 @@ static inline int fread64(FILE *f, int64_t *v64)
     //  See Section 5.8 paragraph 3 of the standard
     //  http://open-std.org/JTC1/SC22/WG21/docs/papers/2015/n4527.pdf
     //  use uint for shifting instead if int
-    *v64 = (int64_t)(((uint64_t) v1) << 32) | (((int64_t) v2) & 0xffffffff);
+    *v64 = (int64_t) (((uint64_t) v1) << 32) | (((int64_t) v2) & 0xffffffff);
 
     return 0;
 }

--- a/lcm/lcm-cpp.hpp
+++ b/lcm/lcm-cpp.hpp
@@ -12,6 +12,7 @@
 #include <cstdio> /* needed for FILE* */
 #include <string>
 #include <vector>
+
 #include "lcm.h"
 
 #if LCM_CXX_11_ENABLED
@@ -664,6 +665,6 @@ class LogFile {
 #define __lcm_cpp_impl_ok__
 #include "lcm-cpp-impl.hpp"
 #undef __lcm_cpp_impl_ok__
-}
+}  // namespace lcm
 
 #endif

--- a/lcm/lcm.c
+++ b/lcm/lcm.c
@@ -1,14 +1,14 @@
 
+#include "lcm.h"
+
 #include <assert.h>
+#include <glib.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
 
-#include <glib.h>
-
 #include "dbg.h"
-#include "lcm.h"
 #include "lcm_internal.h"
 
 #ifdef WIN32
@@ -151,7 +151,7 @@ fail:
 // the lcm_subscription_t*s.
 static void map_free_handlers_callback(gpointer _key, gpointer _value, gpointer _data)
 {
-    (void)_data;
+    (void) _data;
     GPtrArray *handlers = (GPtrArray *) _value;
     g_ptr_array_free(handlers, TRUE);
     free(_key);
@@ -272,7 +272,7 @@ static void map_add_handler_callback(gpointer _key, gpointer _value, gpointer _d
 // remove from a channel's handler list
 static void map_remove_handler_callback(gpointer _key, gpointer _value, gpointer _data)
 {
-    (void)_key;
+    (void) _key;
     lcm_subscription_t *h = (lcm_subscription_t *) _data;
     GPtrArray *handlers = (GPtrArray *) _value;
     g_ptr_array_remove_fast(handlers, h);

--- a/lcm/lcm_internal.h
+++ b/lcm/lcm_internal.h
@@ -2,6 +2,7 @@
 #define __LCM_INTERNAL_H__
 
 #include <glib.h>
+
 #include "lcm.h"
 
 // Several thread and synchronization API functions (e.g. g_mutex_init,
@@ -13,6 +14,7 @@
 
 #ifdef WIN32
 #include <winsock2.h>
+
 #include "windows/WinPorting.h"
 #else
 // in POSIX systems, the normal read/write/close/pipe functions are fine for

--- a/lcm/lcm_memq.c
+++ b/lcm/lcm_memq.c
@@ -66,8 +66,8 @@ static void lcm_memq_destroy(lcm_memq_t *self)
 
 static lcm_provider_t *lcm_memq_create(lcm_t *parent, const char *target, const GHashTable *args)
 {
-    (void)target;
-    (void)args;
+    (void) target;
+    (void) args;
     lcm_memq_t *self = (lcm_memq_t *) calloc(1, sizeof(lcm_memq_t));
     self->lcm = parent;
     self->queue = g_queue_new();

--- a/lcm/lcm_mpudpm.c
+++ b/lcm/lcm_mpudpm.c
@@ -22,10 +22,9 @@
 #include "dbg.h"
 #include "lcm.h"
 #include "lcm_internal.h"
+#include "lcmtypes/channel_port_map_update_t.h"
 #include "ringbuffer.h"
 #include "udpm_util.h"
-
-#include "lcmtypes/channel_port_map_update_t.h"
 
 // Lets reserve channels starting with #! for internal use
 #define RESERVED_CHANNEL_PREFIX "#!"
@@ -290,7 +289,7 @@ void lcm_mpudpm_destroy(lcm_mpudpm_t *lcm)
     g_mutex_clear(&lcm->transmit_lock);
     if (lcm->p_create_read_thread_mutex) {
         g_mutex_clear(&lcm->create_read_thread_mutex);
-	lcm->p_create_read_thread_mutex = NULL;
+        lcm->p_create_read_thread_mutex = NULL;
         g_cond_clear(&lcm->create_read_thread_cond);
     }
 
@@ -398,7 +397,7 @@ static int recv_message_fragment(lcm_mpudpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz
 
     // any existing fragment buffer for this message source?
     lcm_frag_key_t key;
-    key.from = (struct sockaddr_in*)&(lcmb->from);
+    key.from = (struct sockaddr_in *) &(lcmb->from);
     key.msg_seqno = msg_seqno;
     lcm_frag_buf_t *fbuf = lcm_frag_buf_store_lookup(lcm->frag_bufs, &key);
 
@@ -414,7 +413,7 @@ static int recv_message_fragment(lcm_mpudpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz
         return 0;
     }
 
-    //if this is the first packet, set some values
+    // if this is the first packet, set some values
     char *channel = NULL;
     if (hdr->fragment_no == 0) {
         channel = (char *) (hdr + 1);
@@ -429,14 +428,14 @@ static int recv_message_fragment(lcm_mpudpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz
     }
 
     // create a new fragment buffer if necessary
-    if(!fbuf){
-        fbuf = lcm_frag_buf_new(*((struct sockaddr_in *) &lcmb->from), msg_seqno,
-                                data_size, fragments_in_msg, lcmb->recv_utime);
+    if (!fbuf) {
+        fbuf = lcm_frag_buf_new(*((struct sockaddr_in *) &lcmb->from), msg_seqno, data_size,
+                                fragments_in_msg, lcmb->recv_utime);
         lcm_frag_buf_store_add(lcm->frag_bufs, fbuf);
     }
 
-    if (channel!=NULL) {
-        memcpy (fbuf->channel, channel, sizeof (fbuf->channel));
+    if (channel != NULL) {
+        memcpy(fbuf->channel, channel, sizeof(fbuf->channel));
     }
 
 #ifdef __linux__
@@ -1345,27 +1344,27 @@ static int mpudpm_self_test(lcm_mpudpm_t *lcm)
     int recvfd = lcm->notify_pipe[0];
 
     do {
-	struct timeval selectto;
-	selectto.tv_sec = (next_retransmit - now) / G_TIME_SPAN_SECOND;
-	selectto.tv_usec = (next_retransmit - now) - selectto.tv_sec;
+        struct timeval selectto;
+        selectto.tv_sec = (next_retransmit - now) / G_TIME_SPAN_SECOND;
+        selectto.tv_usec = (next_retransmit - now) - selectto.tv_sec;
 
         fd_set readfds;
         FD_ZERO(&readfds);
         FD_SET(recvfd, &readfds);
 
-	now = g_get_real_time();
+        now = g_get_real_time();
         if (now > next_retransmit) {
             g_mutex_lock(&lcm->transmit_lock);
             status = publish_message_internal(lcm, SELF_TEST_CHANNEL, (uint8_t *) msg, strlen(msg));
             g_mutex_unlock(&lcm->transmit_lock);
-	    next_retransmit = now + retransmit_interval;
+            next_retransmit = now + retransmit_interval;
         }
 
         status = select(recvfd + 1, &readfds, 0, 0, &selectto);
         if (status > 0 && FD_ISSET(recvfd, &readfds)) {
             lcm_mpudpm_handle(lcm);
         }
-	now = g_get_real_time();
+        now = g_get_real_time();
 
     } while (!success && now < endtime);
 
@@ -1529,7 +1528,7 @@ static int setup_recv_parts(lcm_mpudpm_t *lcm)
         }
 
         // ugly bit with two mutexes because we can't use a GRecMutex with a GCond
-	// TODO: investigate whether this is still true
+        // TODO: investigate whether this is still true
         g_mutex_lock(lcm->p_create_read_thread_mutex);
         g_mutex_unlock(&lcm->receive_lock);
 

--- a/lcm/lcm_udpm.c
+++ b/lcm/lcm_udpm.c
@@ -174,7 +174,7 @@ void lcm_udpm_destroy(lcm_udpm_t *lcm)
     g_mutex_clear(&lcm->transmit_lock);
     if (lcm->p_create_read_thread_mutex) {
         g_mutex_clear(&lcm->create_read_thread_mutex);
-	lcm->p_create_read_thread_mutex = NULL;
+        lcm->p_create_read_thread_mutex = NULL;
         g_cond_clear(&lcm->create_read_thread_cond);
     }
     free(lcm);
@@ -242,7 +242,7 @@ static int _recv_message_fragment(lcm_udpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz)
 
     // any existing fragment buffer for this message source?
     lcm_frag_key_t key;
-    key.from = (struct sockaddr_in*)&(lcmb->from);
+    key.from = (struct sockaddr_in *) &(lcmb->from);
     key.msg_seqno = msg_seqno;
     lcm_frag_buf_t *fbuf = lcm_frag_buf_store_lookup(lcm->frag_bufs, &key);
 
@@ -262,10 +262,10 @@ static int _recv_message_fragment(lcm_udpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz)
         return 0;
     }
 
-    //if this is the first packet, set some values
+    // if this is the first packet, set some values
     char *channel = NULL;
     if (hdr->fragment_no == 0) {
-        channel = (char*) (hdr + 1);
+        channel = (char *) (hdr + 1);
         char *channel = (char *) (hdr + 1);
         int channel_sz = strlen(channel);
         if (channel_sz > LCM_MAX_CHANNEL_NAME_LENGTH) {
@@ -277,16 +277,16 @@ static int _recv_message_fragment(lcm_udpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz)
         frag_size -= (channel_sz + 1);
     }
 
-    if(!fbuf){
-        fbuf = lcm_frag_buf_new(*((struct sockaddr_in *) &lcmb->from), msg_seqno,
-                                data_size, fragments_in_msg, lcmb->recv_utime);
+    if (!fbuf) {
+        fbuf = lcm_frag_buf_new(*((struct sockaddr_in *) &lcmb->from), msg_seqno, data_size,
+                                fragments_in_msg, lcmb->recv_utime);
         lcm_frag_buf_store_add(lcm->frag_bufs, fbuf);
     }
 
-    if (channel!=NULL) {
-        memcpy (fbuf->channel, channel, sizeof (fbuf->channel));
+    if (channel != NULL) {
+        memcpy(fbuf->channel, channel, sizeof(fbuf->channel));
     }
-    
+
 #ifdef __linux__
     if (lcm->kernel_rbuf_sz < 262145 && data_size > lcm->kernel_rbuf_sz &&
         !lcm->warned_about_small_kernel_buf) {
@@ -809,25 +809,25 @@ static int udpm_self_test(lcm_udpm_t *lcm)
     int recvfd = lcm->notify_pipe[0];
 
     do {
-	struct timeval selectto;
-	selectto.tv_sec = (next_retransmit - now) / G_TIME_SPAN_SECOND;
-	selectto.tv_usec = (next_retransmit - now) - selectto.tv_sec;
+        struct timeval selectto;
+        selectto.tv_sec = (next_retransmit - now) / G_TIME_SPAN_SECOND;
+        selectto.tv_usec = (next_retransmit - now) - selectto.tv_sec;
 
         fd_set readfds;
         FD_ZERO(&readfds);
         FD_SET(recvfd, &readfds);
 
-	now = g_get_real_time();
+        now = g_get_real_time();
         if (now > next_retransmit) {
             status = lcm_udpm_publish(lcm, SELF_TEST_CHANNEL, (uint8_t *) msg, strlen(msg));
-	    next_retransmit = now + retransmit_interval;
+            next_retransmit = now + retransmit_interval;
         }
 
         status = select(recvfd + 1, &readfds, 0, 0, &selectto);
         if (status > 0 && FD_ISSET(recvfd, &readfds)) {
             lcm_udpm_handle(lcm);
         }
-	now = g_get_real_time();
+        now = g_get_real_time();
 
     } while (!success && now < endtime);
 
@@ -856,7 +856,7 @@ static int _setup_recv_parts(lcm_udpm_t *lcm)
         }
 
         // ugly bit with two mutexes because we can't use a GRecMutex with a GCond
-	// TODO: investigate whether this is still true
+        // TODO: investigate whether this is still true
         g_mutex_lock(lcm->p_create_read_thread_mutex);
         g_rec_mutex_unlock(&lcm->mutex);
 

--- a/lcm/ringbuffer.c
+++ b/lcm/ringbuffer.c
@@ -1,11 +1,11 @@
+#include "ringbuffer.h"
+
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include "ringbuffer.h"
 
 // must be power of 2
 #define ALIGNMENT 32

--- a/lcm/udpm_util.c
+++ b/lcm/udpm_util.c
@@ -10,9 +10,8 @@
 #define LCM_MAX_UNFRAGMENTED_PACKET_SIZE 65536
 
 /******************** fragment buffer **********************/
-lcm_frag_buf_t *lcm_frag_buf_new(struct sockaddr_in from, uint32_t msg_seqno,
-                                 uint32_t data_size, uint16_t nfragments,
-                                 int64_t first_packet_utime)
+lcm_frag_buf_t *lcm_frag_buf_new(struct sockaddr_in from, uint32_t msg_seqno, uint32_t data_size,
+                                 uint16_t nfragments, int64_t first_packet_utime)
 {
     lcm_frag_buf_t *fbuf = (lcm_frag_buf_t *) malloc(sizeof(lcm_frag_buf_t));
     fbuf->from = from;
@@ -34,26 +33,25 @@ void lcm_frag_buf_destroy(lcm_frag_buf_t *fbuf)
 
 /******************** fragment buffer store **********************/
 
-static guint
-_lcm_frag_key_hash (const void * key)
+static guint _lcm_frag_key_hash(const void *key)
 {
     lcm_frag_key_t *frag_key = (lcm_frag_key_t *) key;
-    //try to combine 3 ints to create a unique into using bit shifting 
-    //ints are not completely unique, but old mult method also had collisions
-    int v = (((int) frag_key->from->sin_addr.s_addr ^  frag_key->from->sin_port) << 16) | (0x0000FFFF & frag_key->msg_seqno);
-    return g_int_hash (&v);
+    // try to combine 3 ints to create a unique into using bit shifting
+    // ints are not completely unique, but old mult method also had collisions
+    int v = (((int) frag_key->from->sin_addr.s_addr ^ frag_key->from->sin_port) << 16) |
+            (0x0000FFFF & frag_key->msg_seqno);
+    return g_int_hash(&v);
 }
 
-static gboolean
-_lcm_frag_key_equal (const void * a, const void *b)
+static gboolean _lcm_frag_key_equal(const void *a, const void *b)
 {
-    lcm_frag_key_t *a_key = (lcm_frag_key_t*) a;
-    lcm_frag_key_t *b_key = (lcm_frag_key_t*) b;
+    lcm_frag_key_t *a_key = (lcm_frag_key_t *) a;
+    lcm_frag_key_t *b_key = (lcm_frag_key_t *) b;
 
     return a_key->from->sin_addr.s_addr == b_key->from->sin_addr.s_addr &&
-           a_key->from->sin_port        == b_key->from->sin_port &&
-           a_key->from->sin_family      == b_key->from->sin_family &&
-           a_key->msg_seqno            == b_key->msg_seqno;
+           a_key->from->sin_port == b_key->from->sin_port &&
+           a_key->from->sin_family == b_key->from->sin_family &&
+           a_key->msg_seqno == b_key->msg_seqno;
 }
 
 static void _find_lru_frag_buf(gpointer key, gpointer value, void *user_data)
@@ -72,9 +70,8 @@ lcm_frag_buf_store *lcm_frag_buf_store_new(uint32_t max_total_size, uint32_t max
     store->max_total_size = max_total_size;
     store->max_n_frag_bufs = max_n_frag_bufs;
 
-    store->frag_bufs = g_hash_table_new_full(_lcm_frag_key_hash,
-                                       _lcm_frag_key_equal, NULL,
-                                       (GDestroyNotify) lcm_frag_buf_destroy);
+    store->frag_bufs = g_hash_table_new_full(_lcm_frag_key_hash, _lcm_frag_key_equal, NULL,
+                                             (GDestroyNotify) lcm_frag_buf_destroy);
     return store;
 }
 
@@ -84,7 +81,7 @@ void lcm_frag_buf_store_destroy(lcm_frag_buf_store *store)
     free(store);
 }
 
-lcm_frag_buf_t *lcm_frag_buf_store_lookup(lcm_frag_buf_store *store, lcm_frag_key_t* key)
+lcm_frag_buf_t *lcm_frag_buf_store_lookup(lcm_frag_buf_store *store, lcm_frag_key_t *key)
 {
     return (lcm_frag_buf_t *) g_hash_table_lookup(store->frag_bufs, key);
 }
@@ -100,14 +97,14 @@ void lcm_frag_buf_store_add(lcm_frag_buf_store *store, lcm_frag_buf_t *fbuf)
             lcm_frag_buf_store_remove(store, lru_fbuf);
         }
     }
-    g_hash_table_insert (store->frag_bufs, &fbuf->key, fbuf);
+    g_hash_table_insert(store->frag_bufs, &fbuf->key, fbuf);
     store->total_size += fbuf->data_size;
 }
 
 void lcm_frag_buf_store_remove(lcm_frag_buf_store *store, lcm_frag_buf_t *fbuf)
 {
     store->total_size -= fbuf->data_size;
-    g_hash_table_remove (store->frag_bufs, &fbuf->key);
+    g_hash_table_remove(store->frag_bufs, &fbuf->key);
 }
 
 /*** Functions for managing a queue of lcm buffers ***/

--- a/lcm/udpm_util.h
+++ b/lcm/udpm_util.h
@@ -139,23 +139,22 @@ void lcm_buf_free_data(lcm_buf_t *lcmb, lcm_ringbuf_t *ringbuf);
 /******************** fragment buffer **********************/
 typedef struct _lcm_frag_key {
     uint32_t msg_seqno;
-    struct   sockaddr_in *from;
+    struct sockaddr_in *from;
 } lcm_frag_key_t;
 
 typedef struct _lcm_frag_buf {
-    char            channel[LCM_MAX_CHANNEL_NAME_LENGTH+1];
-    struct          sockaddr_in from;
-    char            *data;
-    uint32_t        data_size;
-    uint16_t        fragments_remaining;
-    uint32_t        msg_seqno;
-    int64_t         last_packet_utime;
-    lcm_frag_key_t  key;
+    char channel[LCM_MAX_CHANNEL_NAME_LENGTH + 1];
+    struct sockaddr_in from;
+    char *data;
+    uint32_t data_size;
+    uint16_t fragments_remaining;
+    uint32_t msg_seqno;
+    int64_t last_packet_utime;
+    lcm_frag_key_t key;
 } lcm_frag_buf_t;
 
-lcm_frag_buf_t *lcm_frag_buf_new(struct sockaddr_in from, uint32_t msg_seqno,
-                                 uint32_t data_size, uint16_t nfragments,
-                                 int64_t first_packet_utime);
+lcm_frag_buf_t *lcm_frag_buf_new(struct sockaddr_in from, uint32_t msg_seqno, uint32_t data_size,
+                                 uint16_t nfragments, int64_t first_packet_utime);
 void lcm_frag_buf_destroy(lcm_frag_buf_t *fbuf);
 
 /******************** fragment buffer store **********************/
@@ -168,7 +167,7 @@ typedef struct _lcm_frag_buf_store {
 
 lcm_frag_buf_store *lcm_frag_buf_store_new(uint32_t max_total_size, uint32_t max_n_frag_bufs);
 void lcm_frag_buf_store_destroy(lcm_frag_buf_store *store);
-lcm_frag_buf_t *lcm_frag_buf_store_lookup(lcm_frag_buf_store *store, lcm_frag_key_t* key);
+lcm_frag_buf_t *lcm_frag_buf_store_lookup(lcm_frag_buf_store *store, lcm_frag_key_t *key);
 
 void lcm_frag_buf_store_remove(lcm_frag_buf_store *store, lcm_frag_buf_t *fbuf);
 void lcm_frag_buf_store_add(lcm_frag_buf_store *store, lcm_frag_buf_t *fbuf);

--- a/lcm/windows/WinPorting.cpp
+++ b/lcm/windows/WinPorting.cpp
@@ -1,11 +1,12 @@
 
 #define _WIN32_WINNT 0x0501
-#include <stdio.h>
-#include <cstdint>
-#include <winsock2.h>
-#include <Mswsock.h>
-
 #include "WinPorting.h"
+
+#include <Mswsock.h>
+#include <stdio.h>
+#include <winsock2.h>
+
+#include <cstdint>
 
 #define ARBITRARY_START_PORT 10000
 //	The following data allows multiple processes to access the LastSocket variable

--- a/lcmgen/emit_cpp.c
+++ b/lcmgen/emit_cpp.c
@@ -10,7 +10,6 @@
 #include <unistd.h> /* _exit */
 #endif
 #include <inttypes.h>
-
 #include <sys/stat.h>
 #include <sys/types.h>
 

--- a/lcmgen/emit_csharp.c
+++ b/lcmgen/emit_csharp.c
@@ -1,16 +1,14 @@
+#include <assert.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
-#include <inttypes.h>
-
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#include "lcmgen.h"
-
 #include "getopt.h"
+#include "lcmgen.h"
 
 #define INDENT(n) (4 * (n))
 

--- a/lcmgen/emit_go.c
+++ b/lcmgen/emit_go.c
@@ -297,7 +297,7 @@ static char *go_membername(lcm_struct_t *ls, const char *const str, int method)
         membername = realloc(membername, len + 6);
         // add Get at the end to distinguish between field name and method
         strcat(membername, "Get()");
-        membername[len+5] = '\0';
+        membername[len + 5] = '\0';
     }
     return membername;
 }
@@ -534,12 +534,12 @@ static unsigned int emit_go_array_loops(FILE *f, lcmgen_t *lcm, lcm_struct_t *ls
             const char *type =
                 map_builtintype_name(lcm_find_member(ls, dim->size)->type->lctypename);
 
-            if (slice_emit){
-	        lcm_struct_t *ls_lm = lcm_find_struct(lcm, lm);
-		uint64_t lm_fingerprint = lcm_get_fingerprint(lcm, ls_lm);
+            if (slice_emit) {
+                lcm_struct_t *ls_lm = lcm_find_struct(lcm, lm);
+                uint64_t lm_fingerprint = lcm_get_fingerprint(lcm, ls_lm);
                 emit_go_slice_make(f, n + 1, ls->structname->package, lm, n, slicestr->str, size,
                                    lm_fingerprint);
-	    }
+            }
 
             emit(1 + n, "for i%d := %s(0); i%d < p.%s; i%d++ {", n, type, n, size, n);
 

--- a/lcmgen/emit_java.c
+++ b/lcmgen/emit_java.c
@@ -1,16 +1,14 @@
+#include <assert.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
-#include <inttypes.h>
-
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#include "lcmgen.h"
-
 #include "getopt.h"
+#include "lcmgen.h"
 
 #define INDENT(n) (4 * (n))
 
@@ -237,7 +235,8 @@ void decode_recursive(lcmgen_t *lcm, lcm_member_t *lm, FILE *f, primitive_info_t
         // byte array
         if (!strcmp(pinfo->storage, "byte")) {
             lcm_dimension_t *dim = (lcm_dimension_t *) g_ptr_array_index(lm->dimensions, depth);
-            emit_start(2 + depth, "ins.readFully(this.%s, 0, (int) %s);", accessor_array, dim->size);
+            emit_start(2 + depth, "ins.readFully(this.%s, 0, (int) %s);", accessor_array,
+                       dim->size);
             return;
         }
 

--- a/lcmgen/emit_lua.c
+++ b/lcmgen/emit_lua.c
@@ -1,17 +1,15 @@
 #include <assert.h>
 #include <ctype.h>
+#include <fcntl.h>
+#include <glib.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-
-#include <fcntl.h>
-#include <inttypes.h>
 #include <unistd.h>
-
-#include <glib.h>
 
 #include "lcmgen.h"
 
@@ -47,7 +45,7 @@ static void mkdir_with_parents(const char *path, mode_t mode)
     g_mkdir_with_parents(path, 0755);
 #else
     int len = strlen(path);
-    char* dirpath = malloc(len+1);
+    char *dirpath = malloc(len + 1);
     for (int i = 0; i < len; i++) {
         if (path[i] == '/') {
             strncpy(dirpath, path, i);

--- a/lcmgen/emit_python.c
+++ b/lcmgen/emit_python.c
@@ -1,17 +1,15 @@
 #include <assert.h>
 #include <ctype.h>
+#include <fcntl.h>
+#include <glib.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-
-#include <fcntl.h>
-#include <inttypes.h>
 #include <unistd.h>
-
-#include <glib.h>
 
 #include "lcmgen.h"
 
@@ -46,7 +44,7 @@ static void mkdir_with_parents(const char *path, mode_t mode)
     g_mkdir_with_parents(path, 0755);
 #else
     int len = strlen(path);
-    char* dirpath = malloc(len+1);
+    char *dirpath = malloc(len + 1);
     for (int i = 0; i < len; i++) {
         if (path[i] == '/') {
             strncpy(dirpath, path, i);
@@ -200,10 +198,11 @@ static void _emit_decode_list(const lcmgen_t *lcm, FILE *f, lcm_struct_t *ls, lc
         emit(indent, "%sbuf.read(%s%s)%s", accessor, fixed_len ? "" : "self.", len, suffix);
     } else if (!strcmp("boolean", tn)) {
         if (fixed_len) {
-            emit(indent, "%s[bool(x) for x in struct.unpack('>%s%c', buf.read(%d))]%s", accessor, len,
-                 _struct_format(lm), atoi(len) * _primitive_type_size(tn), suffix);
+            emit(indent, "%s[bool(x) for x in struct.unpack('>%s%c', buf.read(%d))]%s", accessor,
+                 len, _struct_format(lm), atoi(len) * _primitive_type_size(tn), suffix);
         } else {
-            emit(indent, "%s[bool(x) for x in struct.unpack('>%%d%c' %% self.%s, buf.read(self.%s))]%s",
+            emit(indent,
+                 "%s[bool(x) for x in struct.unpack('>%%d%c' %% self.%s, buf.read(self.%s))]%s",
                  accessor, _struct_format(lm), len, len, suffix);
         }
     } else if (!strcmp("int8_t", tn) || !strcmp("int16_t", tn) || !strcmp("int32_t", tn) ||
@@ -892,7 +891,7 @@ emit_package (lcmgen_t *lcm, _package_contents_t *pc)
         if (ret < 0) {
             fprintf(stderr, "Error: failed to create path string");
             return -1;
-        } 
+        }
 
         if (init_py_fp && !g_hash_table_lookup(init_py_imports, ls->structname->shortname))
             fprintf(init_py_fp, "from .%s import %s\n", ls->structname->shortname,

--- a/lcmgen/getopt.c
+++ b/lcmgen/getopt.c
@@ -1,10 +1,10 @@
+#include "getopt.h"
+
 #include <assert.h>
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include "getopt.h"
 
 #define GOO_BOOL_TYPE 1
 #define GOO_STRING_TYPE 2

--- a/lcmgen/lcmgen.c
+++ b/lcmgen/lcmgen.c
@@ -1,14 +1,14 @@
+#include "lcmgen.h"
+
 #include <assert.h>
-#include <stdlib.h>
-#include <string.h>
 #include <ctype.h>
 #include <inttypes.h>
-
+#include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 
-#include "lcmgen.h"
 #include "tokenize.h"
 
 #ifdef WIN32

--- a/lcmgen/main.c
+++ b/lcmgen/main.c
@@ -11,10 +11,10 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include "../lcm/lcm_version.h"
-#include "lcmgen.h"
 
+#include "../lcm/lcm_version.h"
 #include "getopt.h"
+#include "lcmgen.h"
 #include "tokenize.h"
 
 void setup_c_options(getopt_t *gopt);

--- a/lcmgen/tokenize.c
+++ b/lcmgen/tokenize.c
@@ -1,10 +1,10 @@
+#include "tokenize.h"
+
 #include <assert.h>
 #include <ctype.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include "tokenize.h"
 
 static const char single_char_toks[] = "();\",:\'[]";  // no '.' so that name spaces are one token
 static const char op_chars[] = "!~<>=&|^%*+=";

--- a/liblcm-test/buftest-receiver.c
+++ b/liblcm-test/buftest-receiver.c
@@ -1,9 +1,8 @@
+#include <glib.h>
+#include <lcm/lcm.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <glib.h>
-#include <lcm/lcm.h>
 
 lcm_t *lcm = NULL;
 lcm_subscription_t *subscription = NULL;

--- a/liblcm-test/buftest-sender.c
+++ b/liblcm-test/buftest-sender.c
@@ -1,9 +1,8 @@
+#include <glib.h>
+#include <lcm/lcm.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <glib.h>
-#include <lcm/lcm.h>
 
 int main(int argc, char **argv)
 {

--- a/liblcm-test/lcm-example.c
+++ b/liblcm-test/lcm-example.c
@@ -9,7 +9,6 @@
 #endif
 
 #include <fcntl.h>
-
 #include <lcm/lcm.h>
 
 int test_count = 0;

--- a/liblcm-test/lcm-logfilter.c
+++ b/liblcm-test/lcm-logfilter.c
@@ -2,12 +2,10 @@
 // desc: utility to selectively extract channels from a logfile into a new one
 
 #include <getopt.h>
+#include <glib.h>
+#include <lcm/lcm.h>
 #include <stdio.h>
 #include <stdlib.h>
-
-#include <glib.h>
-
-#include <lcm/lcm.h>
 
 static void usage()
 {
@@ -62,14 +60,14 @@ int main(int argc, char **argv)
             double start_time = strtod(optarg, &eptr);
             if (*eptr != 0)
                 usage();
-            start_utime = (int64_t)(start_time * 1000000);
+            start_utime = (int64_t) (start_time * 1000000);
         } break;
         case 'e': {
             char *eptr = NULL;
             double end_time = strtod(optarg, &eptr);
             if (*eptr != 0)
                 usage();
-            end_utime = (int64_t)(end_time * 1000000);
+            end_utime = (int64_t) (end_time * 1000000);
             have_end_utime = 1;
         } break;
         case 'i':

--- a/liblcm-test/lcm-source.c
+++ b/liblcm-test/lcm-source.c
@@ -15,9 +15,8 @@
 #endif
 
 #include <getopt.h>
-#include <time.h>
-
 #include <lcm/lcm.h>
+#include <time.h>
 
 #define DEFAULT_TRANSMIT_INTERVAL_USEC 10000
 

--- a/liblcm-test/lcm-tester.c
+++ b/liblcm-test/lcm-tester.c
@@ -9,9 +9,7 @@
 #endif
 
 #include <fcntl.h>
-
 #include <glib.h>
-
 #include <lcm/lcm.h>
 
 static int64_t timestamp_seconds(int64_t v)

--- a/test/c/client.cpp
+++ b/test/c/client.cpp
@@ -1,10 +1,9 @@
 #include <gtest/gtest.h>
+#include <lcm/lcm.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-
-#include <lcm/lcm.h>
 
 #include "common.h"
 
@@ -18,40 +17,40 @@
 static lcm_t *g_lcm = NULL;
 
 // ====================================== node_t test
-#define MAKE_CLIENT_TEST(type, num_iters)                                                        \
-                                                                                                 \
-    static int g_##type##_response_count = 0;                                                    \
-                                                                                                 \
-    static void type##_handler(const lcm_recv_buf_t *, const char *, const type *msg, void *)    \
-    {                                                                                            \
-        if (!check_##type(msg, g_##type##_response_count + 1)) {                                 \
-            return;                                                                              \
-        }                                                                                        \
-        g_##type##_response_count++;                                                             \
-    }                                                                                            \
-                                                                                                 \
-    static int do_##type##_test(void)                                                            \
-    {                                                                                            \
-        type msg;                                                                                \
-        type##_subscription_t *subs =                                                            \
-            type##_subscribe(g_lcm, "test_" #type "_reply", type##_handler, NULL);               \
-        g_##type##_response_count = 0;                                                           \
-        int result = 1;                                                                          \
-        int iter;                                                                                \
-        for (iter = 0; iter < num_iters && result; iter++) {                                     \
-            fill_##type(iter, &msg);                                                             \
-            type##_publish(g_lcm, "test_" #type, &msg);                                          \
-            if (!lcm_handle_timeout(g_lcm, 500)) {                                               \
-                info(#type " test: Timeout waiting for reply");                                  \
-                result = 0;                                                                      \
-            } else if (g_##type##_response_count != iter + 1) {                                  \
-                info(#type " test: failed on iteration %d", iter);                               \
-                result = 0;                                                                      \
-            }                                                                                    \
-            clear_##type(&msg);                                                                  \
-        }                                                                                        \
-        type##_unsubscribe(g_lcm, subs);                                                         \
-        return result;                                                                           \
+#define MAKE_CLIENT_TEST(type, num_iters)                                                     \
+                                                                                              \
+    static int g_##type##_response_count = 0;                                                 \
+                                                                                              \
+    static void type##_handler(const lcm_recv_buf_t *, const char *, const type *msg, void *) \
+    {                                                                                         \
+        if (!check_##type(msg, g_##type##_response_count + 1)) {                              \
+            return;                                                                           \
+        }                                                                                     \
+        g_##type##_response_count++;                                                          \
+    }                                                                                         \
+                                                                                              \
+    static int do_##type##_test(void)                                                         \
+    {                                                                                         \
+        type msg;                                                                             \
+        type##_subscription_t *subs =                                                         \
+            type##_subscribe(g_lcm, "test_" #type "_reply", type##_handler, NULL);            \
+        g_##type##_response_count = 0;                                                        \
+        int result = 1;                                                                       \
+        int iter;                                                                             \
+        for (iter = 0; iter < num_iters && result; iter++) {                                  \
+            fill_##type(iter, &msg);                                                          \
+            type##_publish(g_lcm, "test_" #type, &msg);                                       \
+            if (!lcm_handle_timeout(g_lcm, 500)) {                                            \
+                info(#type " test: Timeout waiting for reply");                               \
+                result = 0;                                                                   \
+            } else if (g_##type##_response_count != iter + 1) {                               \
+                info(#type " test: failed on iteration %d", iter);                            \
+                result = 0;                                                                   \
+            }                                                                                 \
+            clear_##type(&msg);                                                               \
+        }                                                                                     \
+        type##_unsubscribe(g_lcm, subs);                                                      \
+        return result;                                                                        \
     }
 
 MAKE_CLIENT_TEST(lcmtest2_cross_package_t, 100);

--- a/test/c/common.c
+++ b/test/c/common.c
@@ -200,7 +200,7 @@ int check_lcmtest_primitives_list_t(const lcmtest_primitives_list_t *msg, int ex
         const lcmtest_primitives_t *ex = &msg->items[n];
         CHECK_FIELD(ex->i8, -(n % 100), "%d");
         CHECK_FIELD(ex->i16, -n * 10, "%d");
-        CHECK_FIELD(ex->i64, (int64_t)(-n * 10000), "%" PRId64);
+        CHECK_FIELD(ex->i64, (int64_t) (-n * 10000), "%" PRId64);
         CHECK_FIELD(ex->position[0], (double) -n, "%f");
         CHECK_FIELD(ex->position[1], (double) -n, "%f");
         CHECK_FIELD(ex->position[2], (double) -n, "%f");
@@ -269,7 +269,7 @@ int check_lcmtest_primitives_t(const lcmtest_primitives_t *msg, int expected)
     int n = expected;
     CHECK_FIELD(msg->i8, n % 100, "%d");
     CHECK_FIELD(msg->i16, n * 10, "%d");
-    CHECK_FIELD(msg->i64, (int64_t)(n * 10000), "%" PRId64);
+    CHECK_FIELD(msg->i64, (int64_t) (n * 10000), "%" PRId64);
     CHECK_FIELD(msg->position[0], (double) n, "%f");
     CHECK_FIELD(msg->position[1], (double) n, "%f");
     CHECK_FIELD(msg->position[2], (double) n, "%f");

--- a/test/c/eventlog_test.cpp
+++ b/test/c/eventlog_test.cpp
@@ -1,9 +1,9 @@
 #include <glib.h>
 #include <gtest/gtest.h>
+#include <lcm/lcm.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include <lcm/lcm.h>
 #include "common.h"
 
 TEST(LCM_C, EventLogBasic)

--- a/test/c/memq_test.cpp
+++ b/test/c/memq_test.cpp
@@ -1,8 +1,7 @@
 #include <gtest/gtest.h>
+#include <lcm/lcm.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <lcm/lcm.h>
 
 TEST(LCM_C, MemqConstructDestroy)
 {

--- a/test/c/udpm_test.cpp
+++ b/test/c/udpm_test.cpp
@@ -3,7 +3,6 @@
 #endif
 
 #include <gtest/gtest.h>
-
 #include <lcm/lcm.h>
 
 TEST(LCM_C, InvalidCreation)

--- a/test/cpp/client.cpp
+++ b/test/cpp/client.cpp
@@ -1,10 +1,9 @@
 #include <gtest/gtest.h>
+#include <lcm/lcm.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-
-#include <lcm/lcm.h>
 
 #include "common.hpp"
 
@@ -171,12 +170,12 @@ class LambdaTest {
     {
         LcmType msg;
         int response_count = 0;
-        lcm::LCM::HandlerFunction<LcmType> handler = [&response_count](
-            const lcm::ReceiveBuffer *, const std::string &, const LcmType *msg) {
-            if (CheckLcmType(msg, response_count + 1)) {
-                response_count++;
-            }
-        };
+        lcm::LCM::HandlerFunction<LcmType> handler =
+            [&response_count](const lcm::ReceiveBuffer *, const std::string &, const LcmType *msg) {
+                if (CheckLcmType(msg, response_count + 1)) {
+                    response_count++;
+                }
+            };
         lcm::Subscription *subscription = lcm_.subscribe(test_channel_ + "_reply", handler);
         bool result = true;
         for (int trial = 0; trial < num_trials_ && result; trial++) {

--- a/test/cpp/common.cpp
+++ b/test/cpp/common.cpp
@@ -1,7 +1,7 @@
+#include "common.hpp"
+
 #include <inttypes.h>
 #include <stdio.h>
-
-#include "common.hpp"
 
 #define info(...)                        \
     do {                                 \
@@ -182,7 +182,7 @@ int CheckLcmType(const lcmtest::primitives_list_t *msg, int expected)
         const lcmtest::primitives_t *ex = &msg->items[n];
         CHECK_FIELD(ex->i8, -(n % 100), "%d");
         CHECK_FIELD(ex->i16, -n * 10, "%d");
-        CHECK_FIELD(ex->i64, (int64_t)(-n * 10000), "%" PRId64);
+        CHECK_FIELD(ex->i64, (int64_t) (-n * 10000), "%" PRId64);
         CHECK_FIELD(ex->position[0], (double) -n, "%f");
         CHECK_FIELD(ex->position[1], (double) -n, "%f");
         CHECK_FIELD(ex->position[2], (double) -n, "%f");
@@ -246,7 +246,7 @@ int CheckLcmType(const lcmtest::primitives_t *msg, int expected)
     int n = expected;
     CHECK_FIELD(msg->i8, n % 100, "%d");
     CHECK_FIELD(msg->i16, n * 10, "%d");
-    CHECK_FIELD(msg->i64, (int64_t)(n * 10000), "%" PRId64);
+    CHECK_FIELD(msg->i64, (int64_t) (n * 10000), "%" PRId64);
     CHECK_FIELD(msg->position[0], (double) n, "%f");
     CHECK_FIELD(msg->position[1], (double) n, "%f");
     CHECK_FIELD(msg->position[2], (double) n, "%f");

--- a/test/cpp/common.hpp
+++ b/test/cpp/common.hpp
@@ -2,6 +2,7 @@
 #define __common_hpp__
 
 #include <lcm/lcm-cpp.hpp>
+
 #include "lcmtest/multidim_array_t.hpp"
 #include "lcmtest/node_t.hpp"
 #include "lcmtest/primitives_list_t.hpp"

--- a/test/cpp/memq_test.cpp
+++ b/test/cpp/memq_test.cpp
@@ -80,8 +80,7 @@ TEST(LCM_CPP, MemqBuffered)
     EXPECT_EQ(buffers, received_buffers);
 }
 
-void MemqTimeoutHandler(const lcm::ReceiveBuffer *, const std::string &,
-                        bool *msg_handled)
+void MemqTimeoutHandler(const lcm::ReceiveBuffer *, const std::string &, bool *msg_handled)
 {
     *msg_handled = true;
 }


### PR DESCRIPTION
Some time ago I formatted most of the C and C++ code, but there was no enforcement of this so obviously it lapsed. This PR re-applies formatting (using `clang-format` and the wrapper script `format_code.sh`), and adds a CI check to make sure that formatting is maintained.