### PR TITLE
Use --release flag instead of -source and -target

### DIFF
--- a/lcm-java/CMakeLists.txt
+++ b/lcm-java/CMakeLists.txt
@@ -1,13 +1,24 @@
 include(UseJava)
 
-set(LCM_JAVA_TARGET_VERSION "1.8" CACHE STRING
-  "Java version to target when building Java components (leave empty to use default)"
-)
-if(NOT LCM_JAVA_TARGET_VERSION STREQUAL "")
-  set(CMAKE_JAVA_COMPILE_FLAGS
-    -source ${LCM_JAVA_TARGET_VERSION}
-    -target ${LCM_JAVA_TARGET_VERSION}
+if (Java_VERSION VERSION_GREATER 1.9 OR Java_VERSION VERSION_EQUAL 1.9)
+  set(LCM_JAVA_TARGET_VERSION "8" CACHE STRING
+    "Java version to target when building Java components (leave empty to use default)"
   )
+  if(NOT LCM_JAVA_TARGET_VERSION STREQUAL "")
+    set(CMAKE_JAVA_COMPILE_FLAGS
+      --release ${LCM_JAVA_TARGET_VERSION}
+    )
+  endif()
+elseif (Java_VERSION VERSION_LESS 1.9)
+  set(LCM_JAVA_TARGET_VERSION "1.8" CACHE STRING
+    "Java version to target when building Java components (leave empty to use default)"
+  )
+  if(NOT LCM_JAVA_TARGET_VERSION STREQUAL "")
+    set(CMAKE_JAVA_COMPILE_FLAGS
+      -source ${LCM_JAVA_TARGET_VERSION}
+      -target ${LCM_JAVA_TARGET_VERSION}
+    )
+  endif()
 endif()
 
 add_subdirectory(jchart2d-code)


### PR DESCRIPTION
This fixes the warning:

warning: [options] bootstrap class path not set in conjunction with -source 8

According to JEP#247, using the --release flag is the correct method for setting the targetted version for JDK >= 9.

We retain the JDK 8 behavior since MacOS and Windows CI use it.

https://openjdk.org/jeps/247