### PR TITLE
Cast raw class type to parameterized class

### DIFF
--- a/lcm-java/lcm/spy/Spy.java
+++ b/lcm-java/lcm/spy/Spy.java
@@ -195,7 +195,7 @@ public class Spy
             for (Class iface : interfaces) {
                 if (iface.equals(SpyPlugin.class)) {
                     try {
-                        Constructor c = cls.getConstructor(new Class[0]);
+                        Constructor c = ((Class<?>)cls).getConstructor(new Class[0]);
                         SpyPlugin plugin = (SpyPlugin) c.newInstance(new Object[0]);
                         plugins.add(plugin);
                     } catch (Exception ex) {
@@ -367,7 +367,7 @@ public class Spy
 
                 cd.nreceived++;
 
-                o = cd.cls.getConstructor(DataInput.class).newInstance(dins);
+                o = ((Class<?>)cd.cls).getConstructor(DataInput.class).newInstance(dins);
                 cd.last = o;
 
                 if (cd.viewer != null)


### PR DESCRIPTION
Resolves the warnings:

```
lcm/spy/Spy.java:198: warning: [unchecked] unchecked call to getConstructor(Class<?>...) as a member of the raw type Class
                        Constructor c = cls.getConstructor(new Class[0]);
                                                          ^
  where T is a type-variable:
    T extends Object declared in class Class
lcm/spy/Spy.java:370: warning: [unchecked] unchecked call to getConstructor(Class<?>...) as a member of the raw type Class
                o = cd.cls.getConstructor(DataInput.class).newInstance(dins);
                                         ^
  where T is a type-variable:
    T extends Object declared in class Class
```