### PR TITLE
Fix/more unchecked calls

### DIFF
--- a/lcm-java/lcm/util/ParameterGUI.java
+++ b/lcm-java/lcm/util/ParameterGUI.java
@@ -364,7 +364,7 @@ public class ParameterGUI
     class StringValue extends PValue
     {
         JTextField textField;
-        JComboBox  comboBox;
+        JComboBox<String>  comboBox;
 
         String     value;
         String     values[];
@@ -392,12 +392,12 @@ public class ParameterGUI
             return textField;
         }
 
-        JComboBox getComboBox()
+        JComboBox<String> getComboBox()
         {
             assert(values != null);
 
             if (comboBox == null) {
-                comboBox = new JComboBox(values);
+                comboBox = new JComboBox<String>(values);
                 comboBox.addActionListener(new ActionListener() {
                     public void actionPerformed(ActionEvent e) {
                         setStringValue(values[comboBox.getSelectedIndex()]);

--- a/lcm-java/lcm/util/TableSorter.java
+++ b/lcm-java/lcm/util/TableSorter.java
@@ -89,8 +89,8 @@ public class TableSorter extends AbstractTableModel {
     private JTableHeader tableHeader;
     private MouseListener mouseListener;
     private TableModelListener tableModelListener;
-    private Map columnComparators = new HashMap();
-    private List sortingColumns = new ArrayList();
+    private Map<Class, Comparator> columnComparators = new HashMap<Class, Comparator>();
+    private List<Directive> sortingColumns = new ArrayList<Directive>();
 
     public TableSorter() {
         this.mouseListener = new MouseHandler();

--- a/lcm-java/lcm/util/TableSorter.java
+++ b/lcm-java/lcm/util/TableSorter.java
@@ -72,6 +72,7 @@ public class TableSorter extends AbstractTableModel {
     private static Directive EMPTY_DIRECTIVE = new Directive(-1, NOT_SORTED);
 
     public static final Comparator COMPARABLE_COMAPRATOR = new Comparator() {
+        @SuppressWarnings("unchecked")
         public int compare(Object o1, Object o2) {
             return ((Comparable) o1).compareTo(o2);
         }
@@ -282,6 +283,7 @@ public class TableSorter extends AbstractTableModel {
 
     // Helper classes
 
+    @SuppressWarnings("unchecked")
     private class Row implements Comparable {
         private int modelIndex;
 


### PR DESCRIPTION
Resolves unchecked call warnings in the following code.

- ParameterGUI: specifies type to avoid unchecked call on raw type.
- TableSorter
  - Specifies type of `columnComparators` and `sortingColumns` to avoid unchecked call on raw type
  - Suppresses unchecked call on raw type in `getComparator` and `COMPARABLE_COMAPRATOR.compare` since, as far as I can tell, fixing this would require rewriting a fair bit of this code and it seems to be working as-is.