### PR TITLE
Set CMAKE_MACOSX_RPATH on macOS to satisfy policy CMP0042

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ include(lcm-cmake/version.cmake)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+# Set CMAKE_MACOSX_RPATH on macOS to satisfy policy CMP0042.
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set(CMAKE_MACOSX_RPATH FALSE)
+endif()
+
 # Core modules
 add_subdirectory(lcm)
 add_subdirectory(lcmgen)


### PR DESCRIPTION
Fixes the warning:

```
CMake Warning (dev):
-- Generating done
  Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
  --help-policy CMP0042" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  MACOSX_RPATH is not specified for the following targets:

   lcm-test-types-c

This warning is for project developers.  Use -Wno-dev to suppress it.
```

