### PR TITLE
Add -Wl,-no_fixup_chains for macos build

### DIFF
--- a/lcm-python/CMakeLists.txt
+++ b/lcm-python/CMakeLists.txt
@@ -33,7 +33,7 @@ target_link_libraries(lcm-python PRIVATE
 )
 
 if(APPLE)
-  set_target_properties(lcm-python PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+  set_target_properties(lcm-python PROPERTIES LINK_FLAGS "-undefined dynamic_lookup -Wl,-no_fixup_chains")
 else()
   target_link_libraries(lcm-python PRIVATE
     ${PYTHON_LIBRARY}


### PR DESCRIPTION
This resolves the warning `ld: warning: -undefined dynamic_lookup may not work with chained fixups`.

The `-undefined dynamic_lookup` flag is used for linking with Python.  The best summary I could find is from the [CPython project](https://github.com/python/cpython/issues/97524#issuecomment-1458855301).  So, for our currently targeted MacOS version (14.2), `-Wl,-no_fixup_chains` is valid and silences this warning.  Compared to using chained fix-ups, the only potential downside for us is a slightly larger dylib, AFAICT.