### PR TITLE
More CI targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,11 @@ env:
 jobs:
 
   ubuntu:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,11 @@ jobs:
         LD_LIBRARY_PATH=/usr/local/lib/ build/lcm_log_writer build/example.log
 
   macos:
-    runs-on: macos-12
+    strategy:
+      matrix:
+        os: [macos-11, macos-12]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
         LD_LIBRARY_PATH=/usr/local/lib/ build/lcm_log_writer build/example.log
 
   macos:
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
     - uses: actions/checkout@v3
@@ -96,7 +96,7 @@ jobs:
         build/lcm_log_writer build/example.log
 
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     defaults:
       run:
@@ -135,7 +135,7 @@ jobs:
         ctest
 
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -158,7 +158,7 @@ jobs:
           path: build/docs/_build
 
   formatting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,11 @@ jobs:
         build/lcm_log_writer build/example.log
 
   windows:
-    runs-on: windows-2022
+    strategy:
+      matrix:
+        os: [windows-2019, windows-2022]
+
+    runs-on: ${{ matrix.os }}
 
     defaults:
       run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        sudo apt install liblua5.4-dev lua5.4
+        sudo apt install liblua5.3-dev lua5.3
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build ${{env.CMAKE_FLAGS}}


### PR DESCRIPTION
This PR ramps up automated testing in preparation for the next release. It makes the following changes:

- Switches from `foo-latest` labels to version-specific labels.
- Adds additional tests on `ubuntu-20.04`, `macos-11`, and `windows-2019` runners
- Switches the lua version on the Ubuntu target to 5.3, since both versions of Ubuntu have that package. If it's important to test on 5.4 then I can just split up the Ubuntu job into two jobs.