### PR TITLE
Miscellaneous Documentation Fixes

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -33,7 +33,7 @@ add_custom_target(doc-doxygen
           ${lcm_SOURCE_DIR}/docs/redirect.html
           ${lcm_BINARY_DIR}/docs/_build/doxygen_output/c_cpp/html/index.html
   WORKING_DIRECTORY ${lcm_SOURCE_DIR}/docs
-  DEPENDS doc-setup)
+  DEPENDS doc-setup doc-sphinx)
 
 add_custom_target(doc-dotnet
   COMMAND ${CMAKE_COMMAND} -E make_directory ${lcm_BINARY_DIR}/docs/_build/doxygen_output/
@@ -54,6 +54,6 @@ endif()
 add_custom_target(doc-sphinx
   COMMAND "PYTHONPATH=${CMAKE_BINARY_DIR}/python" ${SPHINX_EXECUTABLE} ${lcm_SOURCE_DIR}/docs ${lcm_BINARY_DIR}/docs/_build
   WORKING_DIRECTORY ${lcm_SOURCE_DIR}/docs
-  DEPENDS doc-setup doc-dotnet doc-doxygen doc-java lcm-python lcm-python-init)
+  DEPENDS doc-setup lcm-python lcm-python-init)
 
-add_dependencies(doc doc-sphinx)
+add_dependencies(doc doc-dotnet doc-doxygen doc-java )

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -29,12 +29,18 @@ add_custom_target(doc-setup
 add_custom_target(doc-doxygen
   COMMAND ${CMAKE_COMMAND} -E make_directory ${lcm_BINARY_DIR}/docs/_build/doxygen_output/
   COMMAND ${DOXYGEN_EXECUTABLE} ${lcm_BINARY_DIR}/docs/Doxyfile
+  COMMAND ${CMAKE_COMMAND} -E copy
+          ${lcm_SOURCE_DIR}/docs/redirect.html
+          ${lcm_BINARY_DIR}/docs/_build/doxygen_output/c_cpp/html/index.html
   WORKING_DIRECTORY ${lcm_SOURCE_DIR}/docs
   DEPENDS doc-setup)
 
 add_custom_target(doc-dotnet
   COMMAND ${CMAKE_COMMAND} -E make_directory ${lcm_BINARY_DIR}/docs/_build/doxygen_output/
   COMMAND ${DOXYGEN_EXECUTABLE} ${lcm_BINARY_DIR}/lcm-dotnet/Doxyfile
+  COMMAND ${CMAKE_COMMAND} -E copy
+          ${lcm_SOURCE_DIR}/docs/redirect.html
+          ${lcm_BINARY_DIR}/docs/_build/doxygen_output/lcm-dotnet/html/index.html
   WORKING_DIRECTORY ${lcm_SOURCE_DIR}/lcm-dotnet
   DEPENDS doc-setup doc-doxygen)
 

--- a/docs/content/build-instructions.md
+++ b/docs/content/build-instructions.md
@@ -49,11 +49,13 @@ Optional packages (e.g., for language-specific support or building documentation
 
 From a terminal, run the following commands.
 
-    $ mkdir build
-    $ cd build
-    $ cmake ..
-    $ make
-    $ sudo make install
+```shell
+mkdir build
+cd build
+cmake ..
+make
+sudo make install
+```
 
 ## OS X
 
@@ -64,17 +66,21 @@ better than the others.
 
 Install Homebrew packages
 
-    $ brew install glib pkg-config cmake
+```shell
+brew install glib pkg-config cmake
+```
 
 Install Java.  Type `javac` in a terminal, then follow the instructions.
 
 Download and build LCM.
 
-    $ mkdir build
-    $ cd build
-    $ cmake ..
-    $ make
-    $ make install
+```shell
+mkdir build
+cd build
+cmake ..
+make
+make install
+```
 
 ## Windows
 
@@ -111,19 +117,25 @@ location (`/usr/local/lib/`) in the `ld.so.conf` search path. In this case,
 or if you installed LCM to a different, non-standard prefix, you may wish to
 create a `ld.so.conf` file for lcm:
 
-    $ echo $LCM_LIBRARY_DIR > /etc/ld.so.conf.d/lcm.conf
+```shell
+echo $LCM_LIBRARY_DIR > /etc/ld.so.conf.d/lcm.conf
+```
 
 Python users may need to add the lcm install location to Python's site packages
 search path using a .pth file:
 
-    $ PYTHON_VERSION=$(python -c "import sys; print(\"%s.%s\" % sys.version_info[:2])")
-    $ PYTHON_USER_SITE=$(python -m site --user-site)
-    $ echo "$LCM_LIBRARY_DIR/python$PYTHON_VERSION/site-packages" > $PYTHON_USER_SITE/lcm.pth
+```shell
+PYTHON_VERSION=$(python -c "import sys; print(\"%s.%s\" % sys.version_info[:2])")
+PYTHON_USER_SITE=$(python -m site --user-site)
+echo "$LCM_LIBRARY_DIR/python$PYTHON_VERSION/site-packages" > $PYTHON_USER_SITE/lcm.pth
+```
 
 Lua users may need to add to `LUA_CPATH`:
 
-    $ LUA_VERSION=$(lua -e "print(string.sub(_VERSION, 5))")
-    $ export LUA_CPATH=$LUA_CPATH:$LCM_LIBRARY_DIR/lua/$LUA_VERSION/?.so
+```shell
+LUA_VERSION=$(lua -e "print(string.sub(_VERSION, 5))")
+export LUA_CPATH=$LUA_CPATH:$LCM_LIBRARY_DIR/lua/$LUA_VERSION/?.so
+```
 
 If you install LCM to a non-standard location (i.e. other than the default
 `/usr/local`, other CMake projects using LCM may need help finding it. Although
@@ -131,8 +143,12 @@ you can always point to the directory where `lcmConfig.cmake` is installed by
 manually setting `lcm_DIR`, it may be convenient to add the location to the
 default search paths:
 
-    $ export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$LCM_INSTALL_PREFIX
+```shell
+export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$LCM_INSTALL_PREFIX
+```
 
 In addition, `pkgconfig` can be configured to find lcm.pc:
 
-    $ export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$LCM_LIBRARY_DIR/pkgconfig
+```shell
+export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$LCM_LIBRARY_DIR/pkgconfig
+```

--- a/docs/content/tutorial-dotnet.md
+++ b/docs/content/tutorial-dotnet.md
@@ -101,7 +101,7 @@ the constructor can accept variable number of parameters specifying individual
 connection strings.
 
 For detailed information on the LCM .NET API please see the
-<a href="../doxygen_output/lcm-dotnet/html/index.html">.NET API reference</a>.
+<a href="../doxygen_output/lcm-dotnet/html/namespaces.html">.NET API reference</a>.
 
 ## Publishing a message
   

--- a/docs/doxygen_output/c_cpp/html/group__LcmC.rst
+++ b/docs/doxygen_output/c_cpp/html/group__LcmC.rst
@@ -1,0 +1,5 @@
+C API
+=====
+
+This is a placeholder to trick sphinx so that it will create links to an external file that will
+exist later.

--- a/docs/doxygen_output/c_cpp/html/group__LcmCpp.rst
+++ b/docs/doxygen_output/c_cpp/html/group__LcmCpp.rst
@@ -1,0 +1,5 @@
+C++ API
+=======
+
+This is a placeholder to trick sphinx so that it will create links to an external file that will
+exist later.

--- a/docs/doxygen_output/lcm-dotnet/html/namespaces.rst
+++ b/docs/doxygen_output/lcm-dotnet/html/namespaces.rst
@@ -1,0 +1,5 @@
+C#/.NET API
+===========
+
+This is a placeholder to trick sphinx so that it will create links to an external file that will
+exist later.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -144,6 +144,10 @@ sending a message to the `mailing list <http://groups.google.com/group/lcm-users
    :caption: APIs
    :glob:
 
+   doxygen_output/c_cpp/html/group__LcmC
+   doxygen_output/c_cpp/html/group__LcmCpp
+   doxygen_output/lcm-dotnet/html/namespaces
+   javadocs/index
    content/lua-api.md
    python/index.rst
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,7 +60,7 @@ API Reference
 
  - `C <doxygen_output/c_cpp/html/group__LcmC.html>`_
  - `C++ <doxygen_output/c_cpp/html/group__LcmCpp.html>`_
- - `C# <doxygen_output/lcm-dotnet/html/index.html>`_
+ - `C# <doxygen_output/lcm-dotnet/html/namespaces.html>`_
  - `Go <https://godoc.org/github.com/lcm-proj/lcm/lcm-go/lcm>`_
  - `Java <javadocs/index.html>`_
  - :ref:`Lua <The Lua LCM API>`

--- a/docs/javadocs/index.rst
+++ b/docs/javadocs/index.rst
@@ -1,0 +1,5 @@
+Java API
+========
+
+This is a placeholder to trick sphinx so that it will create links to an external file that will
+exist later.

--- a/docs/redirect.html
+++ b/docs/redirect.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv='refresh' content='0; URL=../../../index.html'>
+</head>

--- a/lcm-java/CMakeLists.txt
+++ b/lcm-java/CMakeLists.txt
@@ -109,6 +109,6 @@ add_custom_target(doc-java
     -link http://docs.oracle.com/javase/8/docs/api/
     ${lcm_java_doc_classes}
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  DEPENDS doc-setup)
+  DEPENDS doc-setup doc-sphinx)
 
 add_dependencies(doc doc-java)


### PR DESCRIPTION
This PR:

- Updates the shell commands in the build instructions so they aren't prefaced by the `$` (makes it more copy/paste-able for shells like `zsh`
- Adds the C, C++, C#/.NET, and Java APIs to the toctree
- Hacks the doxygen main pages to redirect to the main docs 
- Resolves #419