### PR TITLE
Remove doc-java from top-level docs CMakeLists.txt

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -56,4 +56,4 @@ add_custom_target(doc-sphinx
   WORKING_DIRECTORY ${lcm_SOURCE_DIR}/docs
   DEPENDS doc-setup lcm-python lcm-python-init)
 
-add_dependencies(doc doc-dotnet doc-doxygen doc-java )
+add_dependencies(doc doc-dotnet doc-doxygen)


### PR DESCRIPTION
Allow `lcm-java/CMakeLists.txt` to have control over adding `doc-java` to the `doc` target since it is created there.

This resolves the following error:

```
CMake Error at docs/CMakeLists.txt:59 (add_dependencies):
The dependency target "doc-java" of target "doc" does not exist.
```

Observed on Fedora 37.