### PR TITLE
Fix Custom Install Location

### DIFF
--- a/lcm-python/CMakeLists.txt
+++ b/lcm-python/CMakeLists.txt
@@ -1,7 +1,8 @@
 execute_process(
   COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
-    import sysconfig as sc
-    print(sc.get_path('platlib'))"
+    from sysconfig import get_path
+    from os.path import sep
+    print(get_path('platlib').replace(get_path('data') + sep, ''))"
   OUTPUT_VARIABLE PYTHON_SITE
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 


### PR DESCRIPTION
74a323fe8b071171ca4750bb95e34a6b4340bcbf changed `PYTHON_SITE` from a relative path to an absolute path which breaks custom install locations specified via ` -DCMAKE_INSTALL_PREFIX` when configuring a build directory (`DESTDIR` and `--prefix` still seem OK). This happens because `install` ignores `CMAKE_INSTALL_PREFIX` if the given install location is an absolute path.

This PR makes it so that `PYTHON_SITE` should be the same as it was before 74a323fe8b071171ca4750bb95e34a6b4340bcbf. In addition to testing locally, I [tested on our CI targets](https://github.com/nosracd/lcm/actions/runs/4491242361) with a series of test commits which refactored the CI to set `CMAKE_INSTALL_PREFIX`.