### PR TITLE
Mac MemoryError caused by interpreting _lcm_eventlog_event_t's datalen and channellen as 64 bit

### DIFF
--- a/lcm-python/pyeventlog.c
+++ b/lcm-python/pyeventlog.c
@@ -55,15 +55,15 @@ static PyObject *pylog_read_next_event(PyLogObject *self)
         return Py_None;
     }
 
+    Py_ssize_t channellen = next_event->channellen;
+    Py_ssize_t datalen = next_event->datalen;
 #if PY_MAJOR_VERSION >= 3
-    PyObject *result =
-        Py_BuildValue("LLs#y#",  // build from bytes
-                      next_event->eventnum, next_event->timestamp, next_event->channel,
-                      next_event->channellen, next_event->data, next_event->datalen);
+    PyObject *result = Py_BuildValue("LLs#y#",  // build from bytes
+                                     next_event->eventnum, next_event->timestamp,
+                                     next_event->channel, channellen, next_event->data, datalen);
 #else
-    PyObject *result =
-        Py_BuildValue("LLs#s#", next_event->eventnum, next_event->timestamp, next_event->channel,
-                      next_event->channellen, next_event->data, next_event->datalen);
+    PyObject *result = Py_BuildValue("LLs#s#", next_event->eventnum, next_event->timestamp,
+                                     next_event->channel, channellen, next_event->data, datalen);
 #endif
     lcm_eventlog_free_event(next_event);
 


### PR DESCRIPTION
The [`Py_BuildValue` format string specification](https://docs.python.org/3/c-api/arg.html#strings-and-buffers) being used in `pyeventlog.c`, `"y#"` expands to a `char *` and a `Py_ssize_t` parameter. The values passed in at the corresponding va_arg positions are `char*` and `int32_t`, respectively.

On Intel Macs, `int32_t` is not aligned to the same 64-bit boundary as `Py_ssize_t`, making this an invalid cast.

The symptom is a `MemoryError` which occurs when trying to `read_next_event()`

```
python3 -c 'import lcm; lcm.EventLog("path-to-an-event.log").read_next_event()'
```

The problem has been demonstrated by @ihilt with a [CI pipeline](https://github.com/ihilt/lcm/actions/runs/4577228192/jobs/8082384702#step:6:31) based on [this commit](https://github.com/ihilt/lcm/commit/c85dd18a0d9036cf9d2db35f0e86adde0240792a).

This PR widens the `channellen` and `datalen` before passing them into `Py_BuildValue`.