### PR TITLE
Allow for old or new style Lua unpack

### DIFF
--- a/lcmgen/emit_lua.c
+++ b/lcmgen/emit_lua.c
@@ -422,12 +422,12 @@ static void _emit_encode_list(const lcmgen_t *lcm, FILE *f, lcm_struct_t *ls, lc
         !strcmp("int16_t", tn) || !strcmp("int32_t", tn) || !strcmp("int64_t", tn) ||
         !strcmp("float", tn) || !strcmp("double", tn)) {
         if (fixed_len) {
-            emit(indent, "table.insert(buf_table, lcm._pack.pack('>%s%c', table.unpack(%s)))", len,
+            emit(indent, "table.insert(buf_table, lcm._pack.pack('>%s%c', unpack(%s)))", len,
                  _struct_format(lm), accessor);
         } else {
             emit(indent,
                  "table.insert(buf_table, lcm._pack.pack(string.format('>%%d%c', self.%s), "
-                 "table.unpack(%s)))",
+                 "unpack(%s)))",
                  _struct_format(lm), len, accessor);
         }
     } else {
@@ -685,7 +685,7 @@ static void emit_lua_locals(const lcmgen_t *lcm, FILE *f, lcm_struct_t *ls)
     emit(0, "local ipairs = ipairs");
     emit(0, "local table = table");
     emit(0, "local string = string");
-    emit(0, "local unpack = unpack");
+    emit(0, "local unpack = unpack or table.unpack");
     emit(0, "");
 }
 


### PR DESCRIPTION
Changes the local `unpack` to fallback to `table.unpack`. This way Lua 5.4 still works, but Lua 5.1 can work as well.