### PR TITLE
Tweak previous strcpy changes

### DIFF
--- a/lcm/dbg.h
+++ b/lcm/dbg.h
@@ -159,11 +159,10 @@ static void dbg_init()
     if (!dbg_env) {
         return;
     } else {
-        char* env = malloc(strlen(dbg_env)+1);
-        strcpy(env, dbg_env);
-
-        char *name;
-        for (name = strtok(env,","); name; name = strtok(NULL, ",")) {
+        char env[256];
+        strncpy(env, dbg_env, sizeof(env));
+        env[sizeof(env) - 1] = '\0';
+        for (char *name = strtok(env,","); name; name = strtok(NULL, ",")) {
             int cancel;
             dbg_mode_t *mode;
 
@@ -180,7 +179,6 @@ static void dbg_init()
             if (mode->d_name == NULL) {
                 fprintf(stderr, "Warning: Unknown debug option: "
                         "\"%s\"\n", name);
-                free(env);
                 return;
             }
 
@@ -192,9 +190,7 @@ static void dbg_init()
             {
                 dbg_modes = dbg_modes | mode->d_mode;    
             }
-
         }
-        free(env);
     }
 }
 

--- a/lcm/lcm_mpudpm.c
+++ b/lcm/lcm_mpudpm.c
@@ -415,9 +415,10 @@ static int recv_message_fragment(lcm_mpudpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz
 
     // if this is the first packet, set some values
     char *channel = NULL;
+    int channel_sz = 0;
     if (hdr->fragment_no == 0) {
         channel = (char *) (hdr + 1);
-        int channel_sz = strlen(channel);
+        channel_sz = strlen(channel);
         if (channel_sz > LCM_MAX_CHANNEL_NAME_LENGTH) {
             dbg(DBG_LCM, "bad channel name length\n");
             lcm->udp_discarded_bad++;
@@ -435,7 +436,7 @@ static int recv_message_fragment(lcm_mpudpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz
     }
 
     if (channel != NULL) {
-        memcpy(fbuf->channel, channel, sizeof(fbuf->channel));
+        memcpy(fbuf->channel, channel, channel_sz + 1);
     }
 
 #ifdef __linux__

--- a/lcm/lcm_udpm.c
+++ b/lcm/lcm_udpm.c
@@ -264,10 +264,10 @@ static int _recv_message_fragment(lcm_udpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz)
 
     // if this is the first packet, set some values
     char *channel = NULL;
+    int channel_sz = 0;
     if (hdr->fragment_no == 0) {
         channel = (char *) (hdr + 1);
-        char *channel = (char *) (hdr + 1);
-        int channel_sz = strlen(channel);
+        channel_sz = strlen(channel);
         if (channel_sz > LCM_MAX_CHANNEL_NAME_LENGTH) {
             dbg(DBG_LCM, "bad channel name length\n");
             lcm->udp_discarded_bad++;
@@ -284,7 +284,7 @@ static int _recv_message_fragment(lcm_udpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz)
     }
 
     if (channel != NULL) {
-        memcpy(fbuf->channel, channel, sizeof(fbuf->channel));
+        memcpy(fbuf->channel, channel, channel_sz + 1);
     }
 
 #ifdef __linux__


### PR DESCRIPTION
For the changes to debug, there is no need to malloc there because 256 chars is more than enough to hold everything in DBG_NAMETAB. But if there is garbage in that variable, make sure to null terminate.

For mpudpm and udpm, there is no need to copy past the end of the string, so use strcpy for that. There is no need for strncpy because the size is already checked in those functions.