### PR TITLE
liblcm-test: add GLib2::glib to target_link_libraries

### DIFF
--- a/liblcm-test/CMakeLists.txt
+++ b/liblcm-test/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_executable(lcm-sink lcm-sink.c)
-target_link_libraries(lcm-sink lcm)
+target_link_libraries(lcm-sink lcm GLib2::glib)
 
 add_executable(lcm-source lcm-source.c)
-target_link_libraries(lcm-source lcm)
+target_link_libraries(lcm-source lcm GLib2::glib)
 
 add_executable(lcm-tester lcm-tester.c)
 target_link_libraries(lcm-tester lcm GLib2::glib)
@@ -11,7 +11,7 @@ if(WIN32)
 endif()
 
 add_executable(lcm-example lcm-example.c)
-target_link_libraries(lcm-example lcm)
+target_link_libraries(lcm-example lcm GLib2::glib)
 if(WIN32)
   target_link_libraries(lcm-example ws2_32)
 endif()


### PR DESCRIPTION
Observed using the [Linaro](https://releases.linaro.org/components/toolchain/binaries/latest-7/arm-linux-gnueabihf/gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabihf.tar.xz) SDK.  GLib was also cross-compiled.

The error:
```
/gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabihf/bin/../lib/gcc/arm-linux-gnueabihf/7.5.0/../../../../arm-linux-gnueabihf/bin/ld: warning: libglib-2.0.so.0, needed by ../lcm/liblcm.so.1.5.0, not found (try using -rpath or -rpath-link)
../lcm/liblcm.so.1.5.0: undefined reference to `g_list_delete_link'
../lcm/liblcm.so.1.5.0: undefined reference to `g_free'
...
```

Toolchain file:

```cmake
set(CMAKE_SYSTEM_NAME "Linux")
set(CMAKE_SYSTEM_PROCESSOR "arm")
set(CMAKE_SIZEOF_VOID_P "4")
set(CMAKE_C_COMPILER "/gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc")
set(CMAKE_CXX_COMPILER "/gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabihf/bin/arm-linux-gnueabihf-g++")
set(GLIB2_GLIB_LIBRARY "/usr/local/arm-linux-gnueabihf/lib/libglib-2.0.so")
set(GLIB2_GLIB_INCLUDE_DIR "/usr/local/arm-linux-gnueabihf/include/glib-2.0")
set(GLIB2_GLIBCONFIG_INCLUDE_DIR "/usr/local/arm-linux-gnueabihf/lib/glib-2.0/include")
```