### PR TITLE
Update release checklist

### DIFF
--- a/docs/release_checklist
+++ b/docs/release_checklist
@@ -9,17 +9,6 @@
 5. Commit the above changes and create the vX.Y.Z git tag.
   $ git commit -a -m "Release X.Y.Z"
   $ git tag vX.Y.Z
-6. Create the release artifact
-  $ git archive --format zip -o lcm-X.Y.Z.zip --prefix lcm-X.Y.Z/ vX.Y.Z
-7. Take the resulting artifact, extract it, build it, install it, make sure
-  the basic executables run
-  $ unzip lcm-X.Y.Z.zip
-  $ cd lcm-X.Y.Z
-  $ mkdir build
-  $ cd build
-  $ cmake ..
-  $ make
-  $ make install
 
 # Test
 

--- a/docs/release_checklist
+++ b/docs/release_checklist
@@ -5,7 +5,7 @@
 3. Verify that supported platforms and version numbers are correct in the README
 4. Bump the version number in:
   a. lcm/lcm_version.h
-  b. lcm-lua/rock/lcm-<version>-0.rockspec
+  b. lcm-lua/rock/lcm-<version>-0.rockspec (both filename and contents of file)
 5. Commit the above changes and create the vX.Y.Z git tag.
   $ git commit -a -m "Release X.Y.Z"
   $ git tag vX.Y.Z


### PR DESCRIPTION
The `.rockspec` file has a couple places where the version should be updated, so this PR tries to make that very clear. 

Also removes the instructions to manually create a zip archive. It appears that GitHub automatically creates a zip and tarball archive when a new release is associated with a tag, meaning that each release so far as had two identical zip archives. Removing the manually generated archive will be slightly less work and it will be less confusing for people trying to figure out which archive to download.