### PR TITLE
Fix Warnings in Release Build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
+        build_type: [Debug, Release]
 
     runs-on: ${{ matrix.os }}
 
@@ -22,7 +23,7 @@ jobs:
         sudo apt install liblua5.3-dev lua5.3
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build ${{env.CMAKE_FLAGS}}
+      run: cmake -B ${{github.workspace}}/build ${{env.CMAKE_FLAGS}} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build

--- a/lcm-lua/lualcm_lcm.c
+++ b/lcm-lua/lualcm_lcm.c
@@ -566,7 +566,7 @@ static int impl_lcm_unsubscribe(lua_State *L)
     int ref_num = luaL_checkint(L, 2);
 
     /* get subscription table entry, this pushes the handler on the stack */
-    lcm_subscription_t *subscription;
+    lcm_subscription_t *subscription = NULL;
     if (!impl_lcm_removefromsubscriptiontable(L, 1, ref_num, &subscription)) {
         /* made up reference number */
         lua_pushstring(L, "subscription number invalid");

--- a/lcm-lua/lualcm_pack.c
+++ b/lcm-lua/lualcm_pack.c
@@ -178,7 +178,7 @@ int impl_pack(lua_State *L)
     lua_remove(L, 1);
 
     /* use ops to pack */
-    size_t actual_buf_size;
+    size_t actual_buf_size = 0;
     success = impl_pack_buffer(L, ops, num_ops, is_little_endian, buf, buf_size, &actual_buf_size,
                                &error_message);
 

--- a/lcmgen/emit_lua.c
+++ b/lcmgen/emit_lua.c
@@ -751,10 +751,20 @@ static int emit_package(lcmgen_t *lcm, _package_contents_t *pc)
     int have_package = dirs[0] != NULL;
     int write_init_lua = !getopt_get_bool(lcm->gopt, "lua-no-init");
 
-    sprintf(package_dir_prefix, "%s%s", getopt_get_string(lcm->gopt, "lpath"),
-            strlen(getopt_get_string(lcm->gopt, "lpath")) > 0 ? G_DIR_SEPARATOR_S : "");
-    sprintf(package_dir, "%s%s%s", package_dir_prefix, pdname,
-            have_package ? G_DIR_SEPARATOR_S : "");
+    int ret = snprintf(package_dir_prefix, PATH_MAX, "%s%s", getopt_get_string(lcm->gopt, "lpath"),
+                       strlen(getopt_get_string(lcm->gopt, "lpath")) > 0 ? G_DIR_SEPARATOR_S : "");
+    if (ret >= PATH_MAX || ret < 0) {
+        free(pdname);
+        err("Could not create package directory prefix string\n");
+        return -1;
+    }
+    ret = snprintf(package_dir, PATH_MAX, "%s%s%s", package_dir_prefix, pdname,
+                   have_package ? G_DIR_SEPARATOR_S : "");
+    if (ret >= PATH_MAX || ret < 0) {
+        free(pdname);
+        err("Could not create package directory string\n");
+        return -1;
+    }
     free(pdname);
     if (strlen(package_dir)) {
         if (!g_file_test(package_dir, G_FILE_TEST_EXISTS)) {

--- a/lcmgen/emit_python.c
+++ b/lcmgen/emit_python.c
@@ -687,11 +687,20 @@ emit_package (lcmgen_t *lcm, _package_contents_t *pc)
     int have_package = dirs[0] != NULL;
     int write_init_py = !getopt_get_bool(lcm->gopt, "python-no-init");
 
-    sprintf (package_dir_prefix, "%s%s", getopt_get_string(lcm->gopt, "ppath"), 
-            strlen(getopt_get_string(lcm->gopt, "ppath")) > 0 ? 
-            G_DIR_SEPARATOR_S : "");
-    sprintf(package_dir, "%s%s%s", package_dir_prefix, pdname,
-            have_package ? G_DIR_SEPARATOR_S : "");
+    int ret = snprintf(package_dir_prefix, PATH_MAX, "%s%s", getopt_get_string(lcm->gopt, "ppath"),
+                       strlen(getopt_get_string(lcm->gopt, "ppath")) > 0 ? G_DIR_SEPARATOR_S : "");
+    if (ret >= PATH_MAX || ret < 0) {
+	    free(pdname);
+	    err("Could not create package directory prefix string\n");
+	    return -1;
+    }
+    ret = snprintf(package_dir, PATH_MAX, "%s%s%s", package_dir_prefix, pdname,
+                   have_package ? G_DIR_SEPARATOR_S : "");
+    if (ret >= PATH_MAX || ret < 0) {
+	    free(pdname);
+	    err("Could not create package directory string\n");
+	    return -1;
+    }
     free (pdname);
     if (strlen (package_dir)) {
         if (! g_file_test (package_dir, G_FILE_TEST_EXISTS)) {

--- a/lcmgen/tokenize.h
+++ b/lcmgen/tokenize.h
@@ -18,7 +18,7 @@ struct tokenize {
     char *token;
 
     // bytes allocated for token.
-    int token_capacity;
+    size_t token_capacity;
 
     int token_line, token_column;
 


### PR DESCRIPTION
This PR:

- Adds two addition CI jobs which run the Ubuntu builds with release flags (ea8a7404496a1a0f9475f1b2efd70a1102a63314)
- Initializes variables with a nominal value (d9327cf9e8598761d04717c8954efbfdef2c79cc)
- Refactors size variables to an unsigned integer (b96cb3c9f4400a00d653cb0201c22c7cad276016)
- Decreases the size of C strings so they can be appended to without warnings occurring (745cdd2df465cff72ed6d56e082dfe9247d33273)

Resolves #457.

This PR does not fix [GCC 12 release build warnings](https://github.com/nosracd/lcm/actions/runs/5125792015/jobs/9219438195) (it is possible to use the Fedora target to produce those).