### PR TITLE
Optional Werror

### DIFF
--- a/lcm-lua/CMakeLists.txt
+++ b/lcm-lua/CMakeLists.txt
@@ -9,7 +9,7 @@ set(lcm_lua_sources
 
 add_library(lcm-lua MODULE ${lcm_lua_sources})
 set_target_properties(lcm-lua PROPERTIES OUTPUT_NAME "lcm" PREFIX "")
-target_compile_options(lcm-lua PRIVATE -Werror -Wall -Wextra)
+target_compile_options(lcm-lua PRIVATE -Wall -Wextra)
 
 target_include_directories(lcm-lua PRIVATE
   ${LUA_INCLUDE_DIR}


### PR DESCRIPTION
Unfortunately, it appears that if Werror is turned on in this fashion cmake won't let it be overridden via the usual command-line arguments:

- `-DCMAKE_C_FLAGS="-Wno-error" -DCMAKE_CXX_FLAGS="-Wno-error"`
- `--compile-no-warning-as-error`

This PR removes all arguments from `lcm-lua/CMakeLists.txt` which modify the number of warnings and how they're treated, instead preferring opt-in command-line arguments to increase the number of warnings and treat them as errors.

Resolves #457.