### PR TITLE
Better CI Format Check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,4 +218,5 @@ jobs:
 
       - name: Check formatting
         run: |
-          ./format_code.sh --check
+          ./format_code.sh
+          git diff --exit-code

--- a/format_code.sh
+++ b/format_code.sh
@@ -6,12 +6,12 @@ set -o pipefail
 IFS=$'\n\t'
 
 # Bash script to automatically format LCM source code (currently C and C++).
-# Requires `clang-format` utilily, which is part of the LLVM project. More
+# Requires `clang-format-12` utility, which is part of the LLVM project. More
 # information can be found here: https://clang.llvm.org/docs/ClangFormat.html
 #
-# To install `clang-format` on Ubuntu do:
+# To install `clang-format-12` on Ubuntu do:
 #
-#     $ sudo apt install clang-format
+#     $ sudo apt install clang-format-12
 #
 # This script does not format Java, Python, or Lua source code. At the moment,
 # it only formats C and C++ sources, i.e., *.h, *.c, *.hpp, and *.cpp. It only
@@ -32,6 +32,8 @@ LCM_FORMAT_DIRS=(
     "${LCM_ROOT}/liblcm-test"
     "${LCM_ROOT}/test:/gtest/"
 )
+
+CLANG_FORMAT="clang-format-12"
 
 # Function: show_usage
 #
@@ -69,7 +71,7 @@ function format_c_cpp_dir_r {
     done
     find "$1" -regex '.*\.\(c\|h\)\(pp\)?' \
         | eval "grep -E -v" "${exclude_pattern_opts}" \
-        | xargs clang-format -i
+        | xargs $CLANG_FORMAT -i
 }
 
 # Function: check_format_c_cpp_dir_r DIR [EXCUDE_PATTERN...]
@@ -94,7 +96,7 @@ function check_format_c_cpp_dir_r {
     done
     find "$1" -regex '.*\.\(c\|h\)\(pp\)?' \
         | eval "grep -E -v" "${exclude_pattern_opts}" \
-        | xargs clang-format --dry-run --Werror --ferror-limit=1 &>/dev/null
+        | xargs $CLANG_FORMAT --dry-run --Werror --ferror-limit=1 &>/dev/null
 }
 
 # Default option values
@@ -119,11 +121,11 @@ while getopts "ch" arg &>/dev/null; do
     esac
 done
 
-# Check for clang-format
-if ! command -v clang-format &>/dev/null; then
-    echo "ERROR: Can not find clang-format!" 1>&2
-    echo "Please add clang-format to your PATH" 1>&2
-    echo "On Ubuntu, install it with: sudo apt install clang-format" 1>&2
+# Check for $CLANG_FORMAT
+if ! command -v $CLANG_FORMAT &>/dev/null; then
+    echo "ERROR: Can not find $CLANG_FORMAT!" 1>&2
+    echo "Please add $CLANG_FORMAT to your PATH" 1>&2
+    echo "On Ubuntu, install it with: sudo apt install $CLANG_FORMAT" 1>&2
     exit 1
 fi
 


### PR DESCRIPTION
Different versions of `clang-format` format differently. The CI uses `clang-format-12` for consistency, but `format_code.sh` does not specify a version. This can result in situations where `format_code.sh` reports well-formatted code locally but not on the CI, such as [in this case](https://github.com/lcm-proj/lcm/pull/465#issuecomment-1638923774). 

b1c8fece231c77014e4def55a87650d98e53854a remedies this by forcing `format_code.sh` to use `clang-format-12` and instructing the user to install that particular version if it's not available.

Unfortunately, this means that some people are much older or newer distributions might not be able to use the formatter locally. While docker is always an option, 6932d24b2dca653cafd871f4dc82c4725baa4c8a attempts to ease this pain by printing the desired format on the CI ([example CI success](https://github.com/nosracd/lcm/actions/runs/5769359383/job/15641309864), [example CI failure](https://github.com/nosracd/lcm/actions/runs/5769356563/job/15641302929)).