### PR TITLE
python: EventLog accept pathlib.Path

### DIFF
--- a/lcm-python/lcm/__init__.py
+++ b/lcm-python/lcm/__init__.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from lcm import _lcm
 from lcm._lcm import LCM, LCMSubscription
@@ -52,6 +53,9 @@ to next() returning the next L{Event<lcm.Event>} in the log.
                     "unless overwrite is set to True")
 
         self.mode = mode
+
+        if isinstance(path, Path):
+            path = str(path)
 
         self.c_eventlog = _lcm.EventLog (path, mode)
         self.f = None

--- a/lcm-python/lcm/__init__.py
+++ b/lcm-python/lcm/__init__.py
@@ -1,5 +1,22 @@
 import os
-from pathlib import Path
+import sys
+
+# Attempt to be backwards compatible
+if sys.version_info >= (3, 4):
+    from pathlib import Path
+else:
+    # All we do to the Path is call str on it, so this is a harmless fallback.
+    Path = str 
+
+if sys.version_info >= (3, 5):
+    import typing
+    if sys.version_info >= (3, 6):
+        PathArgument = typing.Union[str, bytes, os.PathLike]
+    else: 
+        PathArgument = typing.Union[str, bytes, Path]
+else:
+    PathArgument = object
+
 
 from lcm import _lcm
 from lcm._lcm import LCM, LCMSubscription
@@ -34,7 +51,7 @@ to next() returning the next L{Event<lcm.Event>} in the log.
 
 @undocumented: __iter__
     """
-    def __init__ (self, path, mode = "r", overwrite = False):
+    def __init__ (self, path:PathArgument, mode = "r", overwrite = False):
         """
         Initializer
 

--- a/lcm-python/lcm/__init__.py
+++ b/lcm-python/lcm/__init__.py
@@ -2,18 +2,19 @@ import os
 import sys
 
 # Attempt to be backwards compatible
-if sys.version_info >= (3, 4):
-    from pathlib import Path
+if sys.version_info >= (3, 6):
+    from os import PathLike
+elif sys.version_info >= (3, 4):
+    from pathlib import Path as PathLike
 else:
     # All we do to the Path is call str on it, so this is a harmless fallback.
-    Path = str 
+    PathLike = str 
 
 if sys.version_info >= (3, 5):
     import typing
-    if sys.version_info >= (3, 6):
-        PathArgument = typing.Union[str, bytes, os.PathLike]
-    else: 
-        PathArgument = typing.Union[str, bytes, Path]
+    # Not including `bytes` like other APIs in the union as the native interface does not accept a byte string.
+    # Makes more sense for the user to .decode(encoding) the bytes than us.
+    PathArgument = typing.Union[str, PathLike]
 else:
     PathArgument = object
 
@@ -71,7 +72,7 @@ to next() returning the next L{Event<lcm.Event>} in the log.
 
         self.mode = mode
 
-        if isinstance(path, Path):
+        if isinstance(path, PathLike):
             path = str(path)
 
         self.c_eventlog = _lcm.EventLog (path, mode)


### PR DESCRIPTION
pathlib was introduced in 3.4 (2014). Could also add the type hint `typing.Union[str, bytes, os.PathLike]`. PathLike is from py 3.6 (2016)