### PR TITLE
lcmgen python: remove py 2 cStringIO compatibility

### DIFF
--- a/lcmgen/emit_python.c
+++ b/lcmgen/emit_python.c
@@ -834,10 +834,7 @@ emit_package (lcmgen_t *lcm, _package_contents_t *pc)
                 "DO NOT MODIFY BY HAND!!!!\n"
                 "\"\"\"\n"
                 "\n"
-                "try:\n"
-                "    import cStringIO.StringIO as BytesIO\n"
-                "except ImportError:\n"
-                "    from io import BytesIO\n"
+                "from io import BytesIO\n"
                 "import struct\n\n");
 
         // enums always encoded as int32
@@ -919,10 +916,7 @@ emit_package (lcmgen_t *lcm, _package_contents_t *pc)
                 "DO NOT MODIFY BY HAND!!!!\n"
                 "\"\"\"\n"
                 "\n"
-                "try:\n"
-                "    import cStringIO.StringIO as BytesIO\n"
-                "except ImportError:\n"
-                "    from io import BytesIO\n"
+                "from io import BytesIO\n"
                 "import struct\n\n");
 
         emit_python_dependencies(lcm, f, ls);


### PR DESCRIPTION
Python 2 support has been dropped so the `try ... execpt` of the py 2 module can be removed.

`import cStringIO.StringIO as BytesIO` was confusing pylance with `Module is not callable`. Therefore it couldn't determain that `encode` returned `bytes`.