### PR TITLE
fix echo command in linux post-install instructions

### DIFF
--- a/docs/content/build-instructions.md
+++ b/docs/content/build-instructions.md
@@ -122,7 +122,7 @@ or if you installed LCM to a different, non-standard prefix, you may wish to
 create a `ld.so.conf` file for lcm:
 
 ```shell
-echo $LCM_LIBRARY_DIR > /etc/ld.so.conf.d/lcm.conf
+echo $LCM_LIBRARY_DIR | sudo tee -a /etc/ld.so.conf.d/lcm.conf
 ```
 
 Python users may need to add the lcm install location to Python's site packages


### PR DESCRIPTION
The following command won't work on many systems, as `>` cannot be executed with root priviliges.
```sh
echo $LCM_LIBRARY_DIR > /etc/ld.so.conf.d/lcm.conf
```

Changed this command to:
```sh
echo $LCM_LIBRARY_DIR | sudo tee -a /etc/ld.so.conf.d/lcm.conf
```

Might not need the `-a` flag, since it seems unlikely that there's anything in that file that shouldn't be overwritten.