### PR TITLE
Specify minimum required version of python

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The LCM project is active again. The current near-term plan is to:
   * Java
   * Lua
   * MATLAB
-  * Python
+  * Python (3.6 and later)
 
 ## Unmaintained languages
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ Supported platforms / languages
   * Java
   * Lua
   * MATLAB
-  * Python
+  * Python (3.6 and later)
 
 Forks
 ========


### PR DESCRIPTION
Resolves #471. There's not really a master list of minimum required versions anywhere so I've just documented the minimum required version of Python inside its bullet in the `Supported platforms and languages` lists.