### PR TITLE
Update documentation links printed in warning output

### DIFF
--- a/lcm/lcm_mpudpm.c
+++ b/lcm/lcm_mpudpm.c
@@ -449,7 +449,7 @@ static int recv_message_fragment(lcm_mpudpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz
                 "insufficient buffer space is very high.\n"
                 "\n"
                 "For more information, visit:\n"
-                "   http://lcm-proj.github.io/lcm/multicast_setup.html\n\n");
+                "   https://lcm-proj.github.io/lcm/content/multicast-setup.html\n\n");
         lcm->warned_about_small_kernel_buf = 1;
     }
 #endif
@@ -1454,7 +1454,7 @@ static mpudpm_socket_t *add_recv_socket(lcm_mpudpm_t *lcm, uint16_t port)
                 "LCM UDP receive buffer size (%d) \n"
                 "       is smaller than reqested (%d). "
                 "For more info:\n"
-                "       http://lcm-proj.github.io/lcm/multicast_setup.html\n",
+                "       https://lcm-proj.github.io/lcm/content/multicast-setup.html\n",
                 lcm->kernel_rbuf_sz, lcm->params.recv_buf_size);
         }
     }

--- a/lcm/lcm_udpm.c
+++ b/lcm/lcm_udpm.c
@@ -297,7 +297,7 @@ static int _recv_message_fragment(lcm_udpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz)
                 "insufficient buffer space is very high.\n"
                 "\n"
                 "For more information, visit:\n"
-                "   http://lcm-proj.github.io/lcm/multicast_setup.html\n\n");
+                "   https://lcm-proj.github.io/lcm/content/multicast-setup.html\n\n");
         lcm->warned_about_small_kernel_buf = 1;
     }
 #endif
@@ -969,7 +969,7 @@ static int _setup_recv_parts(lcm_udpm_t *lcm)
                 "LCM UDP receive buffer size (%d) \n"
                 "       is smaller than reqested (%d). "
                 "For more info:\n"
-                "       http://lcm-proj.github.io/lcm/multicast_setup.html\n",
+                "       https://lcm-proj.github.io/lcm/content/multicast-setup.html\n",
                 lcm->kernel_rbuf_sz, lcm->params.recv_buf_size);
         }
     }

--- a/lcm/udpm_util.c
+++ b/lcm/udpm_util.c
@@ -308,7 +308,7 @@ show_route_cmds:
             "   sudo route add -net 224.0.0.0 netmask 240.0.0.0 dev lo\n"
             "\n"
             "For more information, visit:\n"
-            "   http://lcm-proj.github.io/lcm/multicast_setup.html\n\n",
+            "   https://lcm-proj.github.io/lcm/content/multicast-setup.html\n\n",
             inet_ntoa(lcm_mcaddr));
 }
 #endif

--- a/lcmgen/emit_go.c
+++ b/lcmgen/emit_go.c
@@ -212,7 +212,7 @@ lcm_struct_t *lcm_find_struct(lcmgen_t *lcm, lcm_member_t *lm)
  * Calculates the fingerprint during code generation.
  *
  * Algorithm as described in:
- *     https://lcm-proj.github.io/lcm/type_specification.html
+ *     https://lcm-proj.github.io/lcm/content/lcm-type-ref.html#fingerprint-computation
  *
  * Returns calculated fingerprint or 0 on error
  */
@@ -1181,7 +1181,7 @@ static void emit_go_lcm_unmarshal_binary(FILE *f, lcmgen_t *lcm, lcm_struct_t *l
  * Emits code to calculate the fingerprint in runtime.
  *
  * Algorithm as described in:
- *     https://lcm-proj.github.io/lcm/type_specification.html
+ *     https://lcm-proj.github.io/lcm/content/lcm-type-ref.html#fingerprint-computation
  */
 static void emit_go_lcm_fingerprint(FILE *f, lcmgen_t *lcm, lcm_struct_t *ls,
                                     const char *const typename, const char *const gotype,


### PR DESCRIPTION
I observed a warning like the following: 

```
==== LCM Warning ===                                                                                         
LCM detected that large packets are being received, but the kernel UDP                               
receive buffer is very small.  The possibility of dropping packets due to                             
insufficient buffer space is very high.                                                                                                              
                                                                                                        
For more information, visit:                                                                            
   http://lcm-proj.github.io/multicast_setup.html  
```

When I followed the provided link I observed that the documentation page URL scheme had changed so I believe this points to the correct parts of the github.io page.