### PR TITLE
Basic contributing documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 build*/
 __pycache__
-
+docs/_build/
 
 .vscode/
 .idea/

--- a/docs/content/contributing-c.md
+++ b/docs/content/contributing-c.md
@@ -1,0 +1,7 @@
+# Contributing C
+
+Run `./format_code.sh` before committing to format the code.
+
+## Code Quality
+
+Code in the directory `lcmgen` leaks memory. It is not an uncommon practice to allow this for short lived CLI tools. 

--- a/docs/content/contributing-java.md
+++ b/docs/content/contributing-java.md
@@ -1,0 +1,6 @@
+# Contributing Java
+
+`lcm.jar` along with `lcm-spy` and `lcm-logplayer-gui` are built with Cmake. There is not a Ant/Maven/Gradle project.
+ To edit the code, use your IDE of choice to create a project in the `lcm-java` folder. `lcm-java/lcm` should be the top level package (`lcm.lcm.LCM` is the fully qualified name for the `LCM` class). 
+ 
+ To get the best results from Visual Studio Code, it may be necessary to first create an Eclipse project by using Eclipse.

--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -1,0 +1,3 @@
+# Contributing 
+
+LCM uses the GNU LESSER GENERAL PUBLIC LICENSE. The full text may be found in the [COPYING](https://github.com/lcm-proj/lcm/blob/master/COPYING) file.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -151,6 +151,14 @@ sending a message to the `mailing list <http://groups.google.com/group/lcm-users
    content/lua-api.md
    python/index.rst
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Contributing
+   :glob:
+
+   content/contributing.md
+   content/contributing-c.md
+   content/contributing-java.md
 
 Indices and tables
 ==================


### PR DESCRIPTION
Start basic documentation for project developers. Includes some notes discussed in #420.

I noticed that lcm-gen willfully leaks memory. That isn't really a problem for a short lived CLI tool, but I felt compelled that such reasoning should be documented somewhere.

Maintainers please add anything you feel is needed.