### PR TITLE
Include missing brief description in manpages

### DIFF
--- a/liblcm-test/lcm-example.1
+++ b/liblcm-test/lcm-example.1
@@ -1,6 +1,6 @@
 .TH lcm_example 1 2007-12-13 "LCM" "Lightweight Communications and Marshalling (LCM)"
 .SH NAME
-lcm_example
+lcm_example \- run an interprocess communications example.
 .SH SYNOPSIS
 .TP 5
 \fBlcm_example

--- a/liblcm-test/lcm-sink.1
+++ b/liblcm-test/lcm-sink.1
@@ -1,6 +1,6 @@
 .TH lcm_sink 1 2007-12-13 "LCM" "Lightweight Communications and Marshalling (LCM)"
 .SH NAME
-lcm_sink
+lcm_sink \- dumps the contents of received message to stdout
 .SH SYNOPSIS
 .TP 5
 \fBlcm_sink

--- a/liblcm-test/lcm-sink.1
+++ b/liblcm-test/lcm-sink.1
@@ -1,6 +1,6 @@
 .TH lcm_sink 1 2007-12-13 "LCM" "Lightweight Communications and Marshalling (LCM)"
 .SH NAME
-lcm_sink \- dumps the contents of received message to stdout
+lcm_sink \- dumps the contents of received messages to stdout
 .SH SYNOPSIS
 .TP 5
 \fBlcm_sink

--- a/liblcm-test/lcm-source.1
+++ b/liblcm-test/lcm-source.1
@@ -1,6 +1,6 @@
 .TH lcm_source 1 2007-12-13 "LCM" "Lightweight Communications and Marshalling (LCM)"
 .SH NAME
-lcm_source
+lcm_source \- transmit random messages over LC channels
 .SH SYNOPSIS
 .TP 5
 \fBlcm_source \fI[options]\fR

--- a/liblcm-test/lcm-tester.1
+++ b/liblcm-test/lcm-tester.1
@@ -1,6 +1,6 @@
 .TH lcm_tester 1 2007-12-13 "LCM" "Lightweight Communications and Marshalling (LCM)"
 .SH NAME
-lcm_tester \- testing the functionality of the LC Communications library
+lcm_tester \- testing the functionality of the Lightweight Communications library
 .SH SYNOPSIS
 .TP 5
 \fBlcm_tester

--- a/liblcm-test/lcm-tester.1
+++ b/liblcm-test/lcm-tester.1
@@ -1,6 +1,6 @@
 .TH lcm_tester 1 2007-12-13 "LCM" "Lightweight Communications and Marshalling (LCM)"
 .SH NAME
-lcm_tester
+lcm_tester \- testing the functionality of the LC Communications library
 .SH SYNOPSIS
 .TP 5
 \fBlcm_tester


### PR DESCRIPTION
Related to the works of #486:

The QA checker in Debian was reporting that some of the man pages lacks of a brief description in the naming section. This is the full message: http://web.mit.edu/ebj/Desktop/ebj/MacData/afs/sipb/project/debathena/lintian/www/tags/manpage-has-bad-whatis-entry.html.

The changes in the PR deal with the missing descriptions. Please feel free to change/correct.