### PR TITLE
Use the 'bullet' utf-8 encoded value instead of the char directly

### DIFF
--- a/lcm-java/lcm/logging/LogPlayer.java
+++ b/lcm-java/lcm/logging/LogPlayer.java
@@ -1120,7 +1120,7 @@ public class LogPlayer extends JComponent
             }
 
             {
-                String spacer = "  •  ";
+                String spacer = "  \u2022  ";
                 String filename = p.logName.getText();
 
                 String title = "LogPlayer";

--- a/lcm-java/lcm/spy/Spy.java
+++ b/lcm-java/lcm/spy/Spy.java
@@ -38,7 +38,7 @@ public class Spy
         }
         String title = "LCM Spy";
         {
-            String spacer = "  •  ";
+            String spacer = "  \u2022  ";
             if (null != titleOptions.label) {
                 title += spacer + titleOptions.label;
             }


### PR DESCRIPTION
Related to the works of #486:

Compilation was broken on latest Debian Sid (gcc-13) complaining about unmappable character (0xE2) for encoding US-ASCII. 
```bash
[ 24%] Building C object lcmgen/CMakeFiles/lcm-gen.dir/emit_cpp.c.o
cd /builds/jrivero-guest/lcm/debian/output/source_dir/obj-x86_64-linux-gnu/lcmgen && /usr/lib/ccache/cc  -I/builds/jrivero-guest/lcm/debian/output/source_dir/obj-x86_64-linux-gnu/lcmgen -I/builds/jrivero-guest/lcm/debian/output/source_dir/lcmgen -isystem /usr/include/glib-2.0 -isystem /usr/lib/x86_64-linux-gnu/glib-2.0/include -g -O2 -ffile-prefix-map=/builds/jrivero-guest/lcm/debian/output/source_dir=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2 -std=gnu99 -Wno-format-zero-length -fvisibility=hidden -MD -MT lcmgen/CMakeFiles/lcm-gen.dir/emit_cpp.c.o -MF CMakeFiles/lcm-gen.dir/emit_cpp.c.o.d -o CMakeFiles/lcm-gen.dir/emit_cpp.c.o -c /builds/jrivero-guest/lcm/debian/output/source_dir/lcmgen/emit_cpp.c
lcm/spy/Spy.java:41: error: unmappable character (0xE2) for encoding US-ASCII
            String spacer = "  ???  ";
                               ^
lcm/spy/Spy.java:41: error: unmappable character (0x80) for encoding US-ASCII
            String spacer = "  ???  ";
                                ^
lcm/spy/Spy.java:41: error: unmappable character (0xA2) for encoding US-ASCII
            String spacer = "  ???  ";
                                 ^
lcm/logging/LogPlayer.java:1123: error: unmappable character (0xE2) for encoding US-ASCII
                String spacer = "  ???  ";
                                   ^
lcm/logging/LogPlayer.java:1123: error: unmappable character (0x80) for encoding US-ASCII
                String spacer = "  ???  ";
                                    ^
lcm/logging/LogPlayer.java:1123: error: unmappable character (0xA2) for encoding US-ASCII
                String spacer = "  ???  ";
                                     ^
6 errors
make[4]: *** [lcm-java/CMakeFiles/lcm-java.dir/build.make:120: lcm-java/CMakeFiles/lcm-java.dir/java_compiled_lcm-java] Error 1
```

The commit change the utf-8 dot char by its encoded representation \u2022 according to https://www.compart.com/en/unicode/U+2022.