### PR TITLE
Remove LANG env var in Fedora dockerfile

### DIFF
--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -13,6 +13,3 @@ RUN dnf install -y \
     python3-devel
 
 WORKDIR /work
-
-# Necessary to encode certain characters when compiling the Java code.
-ENV LANG=C.UTF-8


### PR DESCRIPTION
Made unnecessary by 8cd5cd936605d2221316f640b7f4838a6bb046b0. In addition to simplifying the dockerfile, this will guard against unicode characters.