### PR TITLE
lcmgen python: Use `@staticmethod` instead of `= staticmethod()`

### DIFF
--- a/lcmgen/emit_python.c
+++ b/lcmgen/emit_python.c
@@ -257,6 +257,7 @@ static void _flush_read_struct_fmt(const lcmgen_t *lcm, FILE *f, GQueue *formats
 
 static void emit_python_decode_one(const lcmgen_t *lcm, FILE *f, lcm_struct_t *structure)
 {
+    emit(1, "@staticmethod");
     emit(1, "def _decode_one(buf):");
     emit(2, "self = %s()", structure->structname->shortname);
 
@@ -349,13 +350,13 @@ static void emit_python_decode_one(const lcmgen_t *lcm, FILE *f, lcm_struct_t *s
 
     g_queue_free(struct_fmt);
     g_queue_free(struct_members);
-    emit(1, "_decode_one = staticmethod(_decode_one)");
     fprintf(f, "\n");
 }
 
 static void emit_python_decode(const lcmgen_t *lcm, FILE *f, lcm_struct_t *structure)
 {
     // clang-format off
+    emit(1, "@staticmethod");
     emit(1, "def decode(data):");
     emit(2,     "if hasattr(data, 'read'):");
     emit(3,         "buf = data");
@@ -364,7 +365,6 @@ static void emit_python_decode(const lcmgen_t *lcm, FILE *f, lcm_struct_t *struc
     emit(2,     "if buf.read(8) != %s._get_packed_fingerprint():", structure->structname->shortname);
     emit(3,         "raise ValueError(\"Decode error\")");
     emit(2,     "return %s._decode_one(buf)", structure->structname->shortname);
-    emit(1, "decode = staticmethod(decode)");
     fprintf (f, "\n");
     // clang-format on
 }
@@ -598,6 +598,7 @@ static void emit_python_init(const lcmgen_t *lcm, FILE *f, lcm_struct_t *structu
 static void emit_python_fingerprint(const lcmgen_t *lcm, FILE *f, lcm_struct_t *structure)
 {
     const char *short_name = structure->structname->shortname;
+    emit(1, "@staticmethod");
     emit(1, "def _get_hash_recursive(parents):");
     emit(2, "if %s in parents: return 0", short_name);
     for (unsigned int m = 0; m < structure->members->len; m++) {
@@ -626,15 +627,17 @@ static void emit_python_fingerprint(const lcmgen_t *lcm, FILE *f, lcm_struct_t *
     emit(2,     "tmphash  = (((tmphash<<1)&0xffffffffffffffff) + "
                              "(tmphash>>63)) & 0xffffffffffffffff");
     emit(2,     "return tmphash");
-    emit(1, "_get_hash_recursive = staticmethod(_get_hash_recursive)");
+    
+    
     emit(1, "_packed_fingerprint = None");
     emit(0, "");
+
+    emit(1, "@staticmethod");
     emit(1, "def _get_packed_fingerprint():");
     emit(2,     "if %s._packed_fingerprint is None:", short_name);
     emit(3,         "%s._packed_fingerprint = struct.pack("
                              "\">Q\", %s._get_hash_recursive([]))", short_name, short_name);
     emit(2,     "return %s._packed_fingerprint", short_name);
-    emit(1, "_get_packed_fingerprint = staticmethod(_get_packed_fingerprint)");
     // clang-format off
     fprintf (f, "\n");
 
@@ -877,12 +880,13 @@ emit_package (lcmgen_t *lcm, _package_contents_t *package)
         emit(2,     "self.value = value");
         fprintf(f, "\n");
 
+        emit(1, "@staticmethod");
         emit(1, "def _get_hash_recursive(parents):");
         emit(2,     "return 0x%"PRIx64, enumeration->hash);
-        emit(1, "_get_hash_recursive=staticmethod(_get_hash_recursive)");
+
+        emit(1, "@staticmethod");
         emit(1, "def _get_packed_fingerprint():");
         emit(2,     "return %s._packed_fingerprint", enumeration->enumname->shortname);
-        emit(1, "_get_packed_fingerprint = staticmethod(_get_packed_fingerprint)");
         fprintf(f, "\n");
 
         emit(1, "def encode(self):");
@@ -892,6 +896,7 @@ emit_package (lcmgen_t *lcm, _package_contents_t *package)
         emit(2,     "buf.write (struct.pack(\">i\", self.value))");
         fprintf(f, "\n");
 
+        emit(1, "@staticmethod");
         emit(1, "def decode(data):");
         emit(2,     "if hasattr (data, 'read'):");
         emit(3,         "buf = data");
@@ -900,11 +905,11 @@ emit_package (lcmgen_t *lcm, _package_contents_t *package)
         emit(2,     "if buf.read(8) != %s._packed_fingerprint:", enumeration->enumname->shortname);
         emit(3,         "raise ValueError(\"Decode error\")");
         emit(2,     "return %s(struct.unpack(\">i\", buf.read(4))[0])", enumeration->enumname->shortname);
-        emit(1, "decode = staticmethod(decode)");
 
+
+        emit(1, "@staticmethod");
         emit(1, "def _decode_one(buf):");
         emit(2,     "return %s(struct.unpack(\">i\", buf.read(4))[0])", enumeration->enumname->shortname);
-        emit(1, "_decode_one = staticmethod(_decode_one)");
         // clang-format on
 
         fprintf(f, "\n");


### PR DESCRIPTION
Easier for both humans and machines to read. I can't think of a compelling reason that it was done the other way. As I understand, this change should have no impact to callers of the function.