### PR TITLE
Cmake: Set default build type to release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
         docker run -v $(pwd):/work -d --rm -it --name lcm-fedora lcm-fedora /bin/bash
 
     - name: Configure CMake
-      run: docker exec lcm-fedora cmake -B ${{github.workspace}}/build ${{env.CMAKE_FLAGS}}
+      run: docker exec lcm-fedora cmake -B ${{github.workspace}}/build ${{env.CMAKE_FLAGS}} -DCMAKE_BUILD_TYPE=Debug
 
     - name: Build
       run: docker exec lcm-fedora cmake --build ${{github.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,19 @@ endif()
 
 project(lcm)
 
+# https://www.kitware.com/cmake-and-the-default-build-type/
+# Set a default build type if none was specified
+set(default_build_type "Release")
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 if(CMAKE_VERSION VERSION_LESS 3.7)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/3.7")

--- a/docs/content/build-instructions.md
+++ b/docs/content/build-instructions.md
@@ -33,6 +33,14 @@ generators. To users familiar with CMake, we recommend using
 A detailed description of how to use CMake is not specific to LCM and is beyond
 the scope of these instructions.
 
+By default CMake is configured to produce a release build. To build with debug symbols instead, use:
+
+```shell
+cmake .. -DCMAKE_BUILD_TYPE=Debug
+```
+
+when configuring a build directory in the following sections.
+
 ## Ubuntu and Debian
 
 Required packages:


### PR DESCRIPTION
The build instructions simply say `cmake ..` so I kinda assumed this was already in place.