### PR TITLE
bugfix: network filesystem cannot fseek, remove next event check

### DIFF
--- a/lcm/eventlog.c
+++ b/lcm/eventlog.c
@@ -95,18 +95,6 @@ lcm_eventlog_event_t *lcm_eventlog_read_next_event(lcm_eventlog_t *l)
         return NULL;
     }
 
-    // Check that there's a valid event or the EOF after this event.
-    int32_t next_magic;
-    if (0 == fread32(l->f, &next_magic)) {
-        if (next_magic != MAGIC) {
-            fprintf(stderr, "Invalid header after log data\n");
-            free(le->channel);
-            free(le->data);
-            free(le);
-            return NULL;
-        }
-        fseeko(l->f, -4, SEEK_CUR);
-    }
     return le;
 }
 


### PR DESCRIPTION
some filesystem does support fseek, 
eg mount 'ftp://192.168.0.1' with gvfs.
