### PR TITLE
Bump macOS CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
   macos:
     strategy:
       matrix:
-        os: [macos-11, macos-12]
+        os: [macos-13, macos-14]
 
     runs-on: ${{ matrix.os }}
 

--- a/examples/cpp/lcm_log_writer/CMakeLists.txt
+++ b/examples/cpp/lcm_log_writer/CMakeLists.txt
@@ -16,4 +16,4 @@ target_include_directories(pjs_messages-cpp INTERFACE
 
 # Create executable
 add_executable(lcm_log_writer "main.cpp")
-lcm_target_link_libraries(lcm_log_writer pjs_messages-cpp ${LCM_NAMESPACE}lcm)
+lcm_target_link_libraries(lcm_log_writer pjs_messages-cpp ${LCM_NAMESPACE}lcm-static)

--- a/examples/cpp/lcm_log_writer/CMakeLists.txt
+++ b/examples/cpp/lcm_log_writer/CMakeLists.txt
@@ -2,6 +2,13 @@ cmake_minimum_required(VERSION 3.5)
 
 project(lcm_log_writer)
 
+# Include this directory for finding GLib2, using the file FindGLib2.cmake.
+# **WARNING** If you want to reuse this example, you will need to copy
+# FindGLib2.cmake to your new project and adjust your CMAKE_MODULE_PATH.
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
+
+find_package(GLib2 REQUIRED)
+
 find_package(lcm REQUIRED)
 include(${LCM_USE_FILE})
 


### PR DESCRIPTION
This PR bumps to using the two latest GitHub macOS CI runners.

c0564acf4ccd208622d4ff3169a9aa192f47b85d actually bumps to using the latest runners, but this by itself [results in](https://github.com/nosracd/lcm/actions/runs/8991368681/job/24700005656):

```
dyld[7691]: Library not loaded: liblcm.1.dylib
  Referenced from: <102511FD-1F60-33E8-8EC8-DA47AB3BC3D6> /Users/runner/work/lcm/lcm/examples/cpp/lcm_log_writer/build/lcm_log_writer
  Reason: tried: 'liblcm.1.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OSliblcm.1.dylib' (no such file), 'liblcm.1.dylib' (no such file), '/Users/runner/work/lcm/lcm/examples/cpp/lcm_log_writer/liblcm.1.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/runner/work/lcm/lcm/examples/cpp/lcm_log_writer/liblcm.1.dylib' (no such file), '/Users/runner/work/lcm/lcm/examples/cpp/lcm_log_writer/liblcm.1.dylib' (no such file)
/Users/runner/work/_temp/ff9e4820-2618-4e7a-96e7-700dbe91c18c.sh: line 3:  7691 Abort trap: 6           build/lcm_log_writer build/example.log
```

9b385522f54913ca2540ef3506537a4ccbbc6d37 resolves the above by refactoring the example to statically link against LCM. However, that [results in](https://github.com/nosracd/lcm/actions/runs/8991465935/job/24699147485):

```
  The link interface of target "lcm-static" contains:

    GLib2::glib

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  /usr/local/lib/lcm/cmake/lcmConfig.cmake:6 (include)
  CMakeLists.txt:5 (find_package)


CMake Generate step failed.  Build files cannot be regenerated correctly.
```

So 7728ab8672630f5f84a14157f8d0f7fd09ce7a02 continues the pattern in the other examples to resolve that.