### PR TITLE
Fix -Wunused-result in lcmgen/emit_go.c without changing functionality

### DIFF
--- a/lcmgen/emit_go.c
+++ b/lcmgen/emit_go.c
@@ -343,9 +343,7 @@ static char *go_typename(const char *const package, const char *const typepackag
         g_string_append_printf(name, "_%" PRIu64, (uint64_t) fingerprint);
     }
 
-    char *ret = name->str;
-    g_string_free(name, FALSE);
-    return ret;
+    return g_string_free(name, FALSE);
 }
 
 /*


### PR DESCRIPTION
Fixed -Wunused-result in lcmgen/emit_go.c without changing functionality