### PR TITLE
Update clang format to version 15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,14 +207,14 @@ jobs:
           path: build/docs/_build
 
   formatting:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Install Dependencies
         run: |
-          sudo apt install clang-format-12
+          sudo apt install clang-format-15
 
       - name: Check formatting
         run: |

--- a/format_code.sh
+++ b/format_code.sh
@@ -6,12 +6,12 @@ set -o pipefail
 IFS=$'\n\t'
 
 # Bash script to automatically format LCM source code (currently C and C++).
-# Requires `clang-format-12` utility, which is part of the LLVM project. More
+# Requires `clang-format-15` utility, which is part of the LLVM project. More
 # information can be found here: https://clang.llvm.org/docs/ClangFormat.html
 #
-# To install `clang-format-12` on Ubuntu do:
+# To install `clang-format-15` on Ubuntu do:
 #
-#     $ sudo apt install clang-format-12
+#     $ sudo apt install clang-format-15
 #
 # This script does not format Java, Python, or Lua source code. At the moment,
 # it only formats C and C++ sources, i.e., *.h, *.c, *.hpp, and *.cpp. It only
@@ -33,7 +33,7 @@ LCM_FORMAT_DIRS=(
     "${LCM_ROOT}/test:/gtest/"
 )
 
-CLANG_FORMAT="clang-format-12"
+CLANG_FORMAT="clang-format-15"
 
 # Function: show_usage
 #

--- a/lcm-logger/glib_util.c
+++ b/lcm-logger/glib_util.c
@@ -7,7 +7,7 @@
 #ifdef WIN32
 #define SIGKILL 2
 #include "../lcm/windows/WinPorting.h"
-//#include <Winsock2.h>
+// #include <Winsock2.h>
 #else
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/lcm-python/module.c
+++ b/lcm-python/module.c
@@ -2,7 +2,7 @@
 
 #include "pylcm_subscription.h"
 
-//#define dbg(...) fprintf (stderr, __VA_ARGS__)
+// #define dbg(...) fprintf (stderr, __VA_ARGS__)
 #define dbg(...)
 
 // to support python 2.5 and earlier

--- a/lcm-python/pylcm.c
+++ b/lcm-python/pylcm.c
@@ -21,8 +21,8 @@
     } while (0)
 #endif
 
-//#define dbg(...) fprintf (stderr, __VA_ARGS__)
-//#define dbg(...)
+// #define dbg(...) fprintf (stderr, __VA_ARGS__)
+// #define dbg(...)
 
 // to support python 2.5 and earlier
 #ifndef Py_TYPE

--- a/lcm/dbg.h
+++ b/lcm/dbg.h
@@ -104,10 +104,9 @@ extern "C" {
 { DBG_14, _BBLUE_ }, \
 { DBG_15, _BMAGENTA_ }, \
 { DBG_16, _BWHITE_ } \
-// clang-format on
+    // clang-format on
 
-#define DBG_ENV     "LCM_DBG"
-
+#define DBG_ENV "LCM_DBG"
 
 // ===================  do not modify after this line ==================
 
@@ -124,29 +123,21 @@ typedef struct dbg_mode_color {
     const char *color;
 } dbg_mode_color_t;
 
+static dbg_mode_color_t dbg_colortab[] = {DBG_COLORTAB};
 
-static dbg_mode_color_t dbg_colortab[] = {
-    DBG_COLORTAB
-};
+static dbg_mode_t dbg_nametab[] = {DBG_NAMETAB};
 
-static dbg_mode_t dbg_nametab[] = {
-    DBG_NAMETAB
-};
-
-static inline 
-const char* DCOLOR(unsigned long long d_mode)
+static inline const char *DCOLOR(unsigned long long d_mode)
 {
     dbg_mode_color_t *mode;
 
-    for (mode = dbg_colortab; mode->d_mode != 0; mode++)
-    {
+    for (mode = dbg_colortab; mode->d_mode != 0; mode++) {
         if (mode->d_mode & d_mode)
             return mode->color;
     }
 
     return _BWHITE_;
 }
-
 
 static void dbg_init()
 {
@@ -162,33 +153,31 @@ static void dbg_init()
         char env[256];
         strncpy(env, dbg_env, sizeof(env));
         env[sizeof(env) - 1] = '\0';
-        for (char *name = strtok(env,","); name; name = strtok(NULL, ",")) {
+        for (char *name = strtok(env, ","); name; name = strtok(NULL, ",")) {
             int cancel;
             dbg_mode_t *mode;
 
             if (*name == '-') {
                 cancel = 1;
                 name++;
-            }
-            else
+            } else
                 cancel = 0;
 
             for (mode = dbg_nametab; mode->d_name != NULL; mode++)
                 if (strcmp(name, mode->d_name) == 0)
                     break;
             if (mode->d_name == NULL) {
-                fprintf(stderr, "Warning: Unknown debug option: "
-                        "\"%s\"\n", name);
+                fprintf(stderr,
+                        "Warning: Unknown debug option: "
+                        "\"%s\"\n",
+                        name);
                 return;
             }
 
-            if (cancel) 
-            {
+            if (cancel) {
                 dbg_modes &= ~mode->d_mode;
-            }
-            else
-            {
-                dbg_modes = dbg_modes | mode->d_mode;    
+            } else {
+                dbg_modes = dbg_modes | mode->d_mode;
             }
         }
     }
@@ -196,28 +185,32 @@ static void dbg_init()
 
 #ifndef NO_DBG
 
-#define dbg(mode, ...) { \
-    if( !dbg_initiated) dbg_init(); \
-    if( dbg_modes & (mode) ) { \
-        printf("%s", DCOLOR(mode)); \
-        printf(__VA_ARGS__); \
-        printf(_NORMAL_); \
-    } \
-}
+#define dbg(mode, ...)                  \
+    {                                   \
+        if (!dbg_initiated)             \
+            dbg_init();                 \
+        if (dbg_modes & (mode)) {       \
+            printf("%s", DCOLOR(mode)); \
+            printf(__VA_ARGS__);        \
+            printf(_NORMAL_);           \
+        }                               \
+    }
 #define dbg_active(mode) (dbg_modes & (mode))
 
 #else
 
-#define dbg(mode, ...) 
+#define dbg(mode, ...)
 #define dbg_active(mode) false
-#define cdbg(mode,color,dtag,arg) 
+#define cdbg(mode, color, dtag, arg)
 
 #endif
 
-#define cprintf(color, ...) { printf(color); printf(__VA_ARGS__); \
-    printf(_NORMAL_); }
-
-
+#define cprintf(color, ...)  \
+    {                        \
+        printf(color);       \
+        printf(__VA_ARGS__); \
+        printf(_NORMAL_);    \
+    }
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Ubuntu 24.04 does not have `clang-format-12` in its apt repository. Bump `clang-format-12` to `clang-format-15` as it is the latest version of clang-format available for Ubuntu 22.04.