### PR TITLE
lcm-logger: New `--disk-quota` flag

### DIFF
--- a/lcm-logger/lcm_logger.c
+++ b/lcm-logger/lcm_logger.c
@@ -55,6 +55,7 @@ static int64_t get_free_disk_bytes(const char *path_on_disk)
 #ifdef WIN32
     // Not implemented; logger->disk_quota should be 0.
     assert(false);
+    return -1;
 #else
     /*
      * > f_bsize:  Filesystem block size

--- a/lcm-logger/lcm_logger.c
+++ b/lcm-logger/lcm_logger.c
@@ -671,7 +671,7 @@ int main(int argc, char *argv[])
         {"max-unwritten-mb", required_argument, 0, 'm'},
         {"quiet", no_argument, 0, 'q'},
         {"rotate", required_argument, 0, 'r'},
-        {"strftime", required_argument, 0, 's'},
+        {"strftime", no_argument, 0, 's'},
         {"flush-interval", required_argument, 0, 'u'},
         {"invert-channels", no_argument, 0, 'v'},
         {"disk-quota", required_argument, 0, 128},

--- a/lcm-logger/lcm_logger.c
+++ b/lcm-logger/lcm_logger.c
@@ -22,6 +22,10 @@
 #include <unistd.h> /* fdatasync */
 #endif
 
+#ifndef WIN32
+#include <sys/statvfs.h>
+#endif
+
 #include <inttypes.h>
 
 #include "glib_util.h"
@@ -36,11 +40,143 @@
 
 GMainLoop *_mainloop;
 
+// Force a log to close when a SIGHUP is received.
+// [2024-10-08 judfs: Why specifically that signal?]
 static int _reset_logfile = 0;
 
 static inline int64_t timestamp_seconds(int64_t v)
 {
     return v / 1000000;
+}
+
+static int64_t get_free_disk_bytes(const char *path_on_disk)
+{
+#ifdef WIN32
+    // Not implemented; logger->disk_quota should be 0.
+    assert(false);
+#else
+    struct statvfs fs;
+    statvfs(path_on_disk, &fs);
+    int64_t free_bytes = (int64_t) fs.f_bsize * (int64_t) fs.f_bavail;
+    return free_bytes;
+
+#endif
+}
+
+//
+
+/**
+ * Parse a string like "5.5MB" as a number of bytes.
+ * K and KiB are treated as 1024 kibibytes.
+ * KB is treated kilobytes.
+ * Input is case insensitive. KB and kb are both treated as kilobytes.
+ * Input will never be treated as kilobits.
+ *
+ * Suported unit prefixes: B, K, M, G, T, P, E
+ *
+ * str: A null terminated string in the form <value>[ ]<unit> .
+ *  Both the value and unit are required.
+ *  Spaces are permited between the value and the unit.
+ *  Value must be positive.
+ *
+ * Returns -1 on error.
+ * Otherwise the number of byte represented by the input.
+ */
+static int64_t parse_mem_size(const char *str)
+{
+    const int64_t INVALID_SIZE = -1;
+
+    // int64_t len = strlen(str);
+    char *end = NULL;
+    double val = strtod(str, &end);
+    if (str == end) {
+        // Could not parse a double
+        return INVALID_SIZE;
+    }
+    if (val < 0) {
+        return INVALID_SIZE;
+    }
+
+    // Munch spaces if they exist
+    while (*end && (*end) == ' ') {
+        end++;
+    }
+
+    // ---
+    // Parse unit
+    size_t unit_len = strlen(end);
+    if (unit_len == 0) {
+        // Could default to byte scale, but for our use case, that is probably unintentional.
+        return INVALID_SIZE;
+    }
+
+    double scale = 1;
+    double thous = 1000;  // 1024 vs 1000?
+    if (1 == unit_len) {
+        // 10 K
+        thous = 1024;
+    } else {
+        // 10 KB vs 10 Ki[B]
+        char mod = end[1];
+        switch (mod) {
+        case 'B':
+        case 'b':
+            thous = 1000;
+            break;
+        case 'I':
+        case 'i':
+            thous = 1024;
+            break;
+        default:
+            return INVALID_SIZE;
+        }
+    }
+    if (3 == unit_len) {
+        // KiB: Optional B following Ki
+        char b = end[3 - 1];
+        if (b != 'B' && b != 'b') {
+            return INVALID_SIZE;
+        }
+    } else if (unit_len > 3) {
+        return INVALID_SIZE;
+    }
+
+    char unit = end[0];
+    switch (unit) {
+    case 'B':
+    case 'b':
+        scale = 1;
+        break;
+    case 'K':
+    case 'k':
+        scale = thous;
+        break;
+    case 'M':
+    case 'm':
+        scale = thous * thous;
+        break;
+    case 'G':
+    case 'g':
+        scale = thous * thous * thous;
+        break;
+    case 'T':
+    case 't':
+        scale = thous * thous * thous * thous;
+        break;
+    case 'P':
+    case 'p':
+        scale = thous * thous * thous * thous * thous;
+        break;
+    case 'E':
+    case 'e':
+        scale = thous * thous * thous * thous * thous * thous;
+        break;
+
+    default:
+        return INVALID_SIZE;
+    }
+
+    return val * scale;
 }
 
 typedef struct logger logger_t;
@@ -50,6 +186,8 @@ struct logger {
     char input_fname[PATH_MAX];
     char fname[PATH_MAX];
     char fname_prefix[PATH_MAX];
+    char *write_directory;
+
     lcm_t *lcm;
 
     int64_t max_write_queue_size;
@@ -62,6 +200,7 @@ struct logger {
     int rotate;
     int quiet;   // bool
     int append;  // bool
+    int64_t disk_quota;
 
     GThread *write_thread;
     GAsyncQueue *write_queue;
@@ -82,12 +221,15 @@ struct logger {
     int64_t events_since_last_report;
     int64_t last_report_time;
     int64_t last_report_logsize;
+    // Time (micro s) the logger started
     int64_t time0;
     int64_t last_fflush_time;
 
     int64_t dropped_packets_count;
     int64_t last_drop_report_utime;
     int64_t last_drop_report_count;
+
+    int64_t last_quota_time;
 };
 
 static void rotate_logfiles(logger_t *logger)
@@ -192,8 +334,9 @@ static void *write_thread(void *user_data)
     while (1) {
         void *msg = g_async_queue_pop(logger->write_queue);
 
+        // ---
         // Is it time to start a new logfile?
-        int split_log = 0;
+        gboolean split_log = 0;
         if (logger->auto_split_mb) {
             double logsize_mb = (double) logger->logsize / (1 << 20);
             split_log = (logsize_mb > logger->auto_split_mb);
@@ -206,36 +349,48 @@ static void *write_thread(void *user_data)
         if (split_log) {
             // Yes.  open up a new log file
             lcm_eventlog_destroy(logger->log);
-            if (logger->rotate > 0)
+
+            if (logger->rotate > 0) {
                 rotate_logfiles(logger);
-            if (0 != open_logfile(logger))
+            }
+
+            if (0 != open_logfile(logger)) {
+                printf("Failed to open next log. Aborting.\n");
                 exit(1);
+            }
             logger->logsize = 0;
             logger->last_report_logsize = 0;
         }
 
+        // ---
+        // Should the write thread exit?
+
         {
             // Looking at the address of write_thread_exit_flag instead of its value.
+            // [2024-10-08 judfs: Why though?]
             void *sentinel_msg = &(logger->sync.write_thread_exit_flag);
-            // Should the write thread exit?
+
             if (msg == sentinel_msg) {
                 return NULL;
             }
         }
 
+        // ---
+        // Track the pop
         lcm_eventlog_event_t *log_event = (lcm_eventlog_event_t *) msg;
         {  // LOCK
             g_mutex_lock(&logger->mutex);
 
-            // Track the pop
             int64_t sz =
                 sizeof(lcm_eventlog_event_t) + log_event->channellen + 1 + log_event->datalen;
             logger->sync.write_queue_size -= sz;
             g_mutex_unlock(&logger->mutex);
         }
 
+        // ---
         // Write the event to disk
         if (0 != lcm_eventlog_write_event(logger->log, log_event)) {
+            // Write error
             static int64_t last_spew_utime = 0;
             char *reason = strdup(strerror(errno));
             int64_t now = g_get_real_time();
@@ -252,8 +407,13 @@ static void *write_thread(void *user_data)
             }
         }
 
-        if (logger->fflush_interval_ms >= 0 &&
-            (log_event->timestamp - logger->last_fflush_time) > logger->fflush_interval_ms * 1000) {
+        // [2024-10-08 judfs: This asserted condition was in the needs_flushed condition.
+        // This seems to always be true?]
+        // @Review remove this assert + comment
+        assert(logger->fflush_interval_ms >= 0);
+        gboolean needs_flushed =
+            (log_event->timestamp - logger->last_fflush_time) > (logger->fflush_interval_ms * 1000);
+        if (needs_flushed) {
             fflush(logger->log->f);
 #ifndef WIN32
             // Perform a full fsync operation after flush
@@ -262,7 +422,8 @@ static void *write_thread(void *user_data)
             logger->last_fflush_time = log_event->timestamp;
         }
 
-        // bookkeeping, cleanup
+        // ---
+        // Bookkeeping, cleanup
         int64_t offset_utime = log_event->timestamp - logger->time0;
         logger->nevents++;
         logger->events_since_last_report++;
@@ -270,8 +431,11 @@ static void *write_thread(void *user_data)
 
         free(log_event);
 
-        if (!logger->quiet && (offset_utime - logger->last_report_time > 1000000)) {
-            double dt = (offset_utime - logger->last_report_time) / 1000000.0;
+        // ---
+        // UI update
+        const int64_t term_update_interval = 1000000;  // 1sec * 1e6
+        if (!logger->quiet && (offset_utime - logger->last_report_time > term_update_interval)) {
+            double dt = (offset_utime - logger->last_report_time) / 1e6;  // (Sec)
 
             double tps = logger->events_since_last_report / dt;
             double kbps = (logger->logsize - logger->last_report_logsize) / dt / 1024.0;
@@ -287,7 +451,26 @@ static void *write_thread(void *user_data)
             logger->events_since_last_report = 0;
             logger->last_report_logsize = logger->logsize;
         }
-    }
+
+        // ---
+        // Disk Quota @Review: This whole section
+
+        // judfs: Should this be its own thread?
+        // Should the interval be a flag?
+        const int64_t quota_check_interval = 1e6;
+        if (logger->disk_quota && (offset_utime - logger->last_quota_time > quota_check_interval)) {
+            logger->last_quota_time = offset_utime;
+
+            int64_t free_bytes = get_free_disk_bytes(logger->write_directory);
+            if (free_bytes < logger->disk_quota) {
+                printf("Disk quota exceeded. Exiting logger.\n");
+                // @Review: How should this exit? For now going with a graceful exit.
+                // But maybe this case warrants more urgency.
+                g_main_loop_quit(_mainloop);
+            }
+        }
+
+    }  // END while (1)
 }
 
 static void message_handler(const lcm_recv_buf_t *rbuf, const char *channel, void *u)
@@ -367,6 +550,8 @@ static void sighup_handler(int signum)
 
 static void usage()
 {
+    // Manually wrapped to 80cols Leaves 52 for flag help.
+    // "--------------------------------------------------------------------------------\n"
     fprintf(stderr,
             "usage: lcm-logger [options] [FILE]\n"
             "\n"
@@ -381,31 +566,49 @@ static void usage()
             "                             (default: \".*\")\n"
             "      --flush-interval=MS    Flush the log file to disk every MS milliseconds.\n"
             "                             (default: 100)\n"
-            "  -f, --force                Overwrite existing files\n"
-            "  -h, --help                 Shows this help text and exits\n"
+            "  -f, --force                Overwrite existing files.\n"
+            "  -h, --help                 Shows this help text and exits.\n"
             "  -i, --increment            Automatically append a suffix to FILE\n"
             "                             such that the resulting filename does not\n"
             "                             already exist.  This option precludes -f and\n"
-            "                             --rotate\n"
+            "                             --rotate.\n"
+            "\n"
             "  -l, --lcm-url=URL          Log messages on the specified LCM URL\n"
             "  -m, --max-unwritten-mb=SZ  Maximum size of received but unwritten\n"
             "                             messages to store in memory before dropping\n"
             "                             messages.  (default: 100 MB)\n"
+            "\n"
             "      --rotate=NUM           When creating a new log file, rename existing files\n"
-            "                             out of the way and always write to FILE.0.  If\n"
-            "                             FILE.0 already exists, it is renamed to FILE.1.  If\n"
-            "                             FILE.1 exists, it is renamed to FILE.2, etc.  If\n"
-            "                             FILE.NUM exists, then it is deleted.  This option\n"
-            "                             precludes -i.\n"
+            "                             out of the way and always write to FILE.0.\n"
+            "                             If FILE.0 already exists, it is renamed to FILE.1.\n"
+            "                             If FILE.1 exists, it is renamed to FILE.2, etc.\n"
+            "                             If FILE.NUM exists, then it is deleted.\n"
+            "                             This option precludes -i.\n"
+            "\n"
             "      --split-mb=N           Automatically start writing to a new log\n"
             "                             file once the log file exceeds N MB in size\n"
             "                             (can be fractional).  This option requires -i\n"
             "                             or --rotate.\n"
+            "\n"
             "  -q, --quiet                Suppress normal output and only report errors.\n"
             "  -a, --append               Append events to the given log file.\n"
             "  -s, --strftime             Format FILE with strftime.\n"
             "  -v, --invert-channels      Invert channels.  Log everything that CHAN\n"
             "                             does not match.\n"
+            "      --disk-quota=SIZE      Minimum amount of free space the disk written to\n"
+            "                             must maintain. lcm-logger will exit if the quota is\n"
+            "                             exceeded. This is NOT an explicit limit on how much\n"
+            "                             lcm-logger is allowed to write.\n"
+            "                             Units accepted: B\n"
+            "                             1024: K,   M,   G,   T,   P,   E,\n"
+            "                                   Ki,  Mi,  Gi,  Ti,  Pi,  Ei,\n"
+            "                                   KiB, MiB, GiB, TiB, PiB, EiB\n"
+            "                             1000: KB, MB, GB, TB, PB, EB\n"
+            "                             e.g. \"50G\" or \"0.05 TiB\". \n"
+            "                             Note: for `df`, -h is 1024 and -H is 1000 units.\n"
+            "                             Units are treated case insensitively. gb is treated\n"
+            "                             as GB (gigabytes) and not as gigabits.\n"
+            "                             NOT currently supported on Windows!\n"
             "\n"
             "Rotating / splitting log files\n"
             "==============================\n"
@@ -444,6 +647,7 @@ int main(int argc, char *argv[])
     logger.rotate = -1;
     logger.quiet = 0;
     logger.append = 0;
+    logger.disk_quota = 0;
 
     char *lcmurl = NULL;
 
@@ -468,6 +672,7 @@ int main(int argc, char *argv[])
         {"strftime", required_argument, 0, 's'},
         {"flush-interval", required_argument, 0, 'u'},
         {"invert-channels", no_argument, 0, 'v'},
+        {"disk-quota", required_argument, 0, 128},
         {0, 0, 0, 0},
     };
 
@@ -504,7 +709,7 @@ int main(int argc, char *argv[])
         case 'v': /* --invert-channels */
             logger.invert_channels = 1;
             break;
-        case 'm': /* --invert-channels */
+        case 'm': /* --max-unwritten-mb */
             max_write_queue_size_mb = strtod(optarg, NULL);
             if (max_write_queue_size_mb <= 0) {
                 usage();
@@ -529,6 +734,21 @@ int main(int argc, char *argv[])
         case 'a': /* --append */
             logger.append = 1;
             break;
+
+        case 128: {
+#ifdef WIN32
+            printf("--disk-quota not yet supported on windows.\n");
+            return 1;
+#endif
+            logger.disk_quota = parse_mem_size(optarg);
+            if (logger.disk_quota == -1 || logger.disk_quota == 0) {
+                printf("--disk-quota: Invalid argument\n\n");
+                usage();
+                return 1;
+            }
+        } break;
+
+        //
         case 'h':
         default: /* implicit --help */
             usage();
@@ -545,6 +765,27 @@ int main(int argc, char *argv[])
     } else if (optind < argc - 1) {
         usage();
         return 1;
+    }
+    logger.write_directory = g_path_get_dirname(logger.input_fname);
+    if (logger.disk_quota) {
+        GFormatSizeFlags fflags = 0 | G_FORMAT_SIZE_IEC_UNITS;
+
+        // https://docs.gtk.org/glib/flags.FormatSizeFlags.html
+        // > G_FORMAT_SIZE_IEC_UNITS
+        // > Use IEC (base 1024) units with “KiB”-style suffixes. IEC units should only be used for
+        // > reporting things with a strong “power of 2” basis, like RAM sizes or RAID stripe sizes.
+        // > Network and storage sizes should be reported in the normal SI units.
+        //
+        // HOWEVER, `df -h` (--human-readable) does 1024. -H (--si) uses 1000, but that is less
+        // common?
+
+        char *free_str = g_format_size_full(get_free_disk_bytes(logger.write_directory), fflags);
+        char *quota_str = g_format_size_full(logger.disk_quota, fflags);
+        printf("There is currently %s free on disk.\n", free_str);
+        printf("lcm-logger will exit should that value reach %s.\n", quota_str);
+
+        g_free(free_str);
+        g_free(quota_str);
     }
 
     if (logger.auto_split_mb > 0 && !(logger.auto_increment || (logger.rotate > 0))) {
@@ -629,10 +870,14 @@ int main(int argc, char *argv[])
     signal(SIGHUP, sighup_handler);
 #endif
 
-    // main loop
+    // ------------------------------------------------------------------------
+    // main loop - Returns after a stop signal (Ctrl-C)
+
     g_main_loop_run(_mainloop);
 
-    fprintf(stderr, "Logger exiting\n");
+    // ------------------------------------------------------------------------
+
+    fprintf(stderr, "\nLogger exiting\n");
 
     {  // LOCK
         // stop the write thread
@@ -652,6 +897,8 @@ int main(int argc, char *argv[])
     glib_mainloop_detach_lcm(logger.lcm);
     lcm_destroy(logger.lcm);
     lcm_eventlog_destroy(logger.log);
+
+    g_free(logger.write_directory);
 
     for (void *msg = g_async_queue_try_pop(logger.write_queue); msg;
          msg = g_async_queue_try_pop(logger.write_queue)) {


### PR DESCRIPTION
Fix #464 
```
      --disk-quota=SIZE      Minimum amount of free space the disk written to
                             must maintain. lcm-logger will exit if the quota is
                             exceeded. This is NOT an explicit limit on how much
                             lcm-logger is allowed to write.
                             Units accepted: B
                             1024: K,   M,   G,   T,   P,   E,
                                   Ki,  Mi,  Gi,  Ti,  Pi,  Ei,
                                   KiB, MiB, GiB, TiB, PiB, EiB
                             1000: KB, MB, GB, TB, PB, EB
                             e.g. "50G" or "0.05 TiB". 
                             Note: for `df`, -h is 1024 and -H is 1000 units.
                             Units are treated case insensitively. gb is treated
                             as GB (gigabytes) and not as gigabits.
                             NOT currently supported on Windows!
```

Currently put the check in the write thread and does not cause an immediate `exit(1)`. Please review.  