### PR TITLE
Add Python tests

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -12,7 +12,7 @@ jobs:
         # macos-13 is an intel runner, macos-14 is apple silicon
         os: [ubuntu-latest, macos-13, macos-14]
         arch: [auto, aarch64]
-        python: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*, cp312-*]
+        python: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*, cp312-*, cp313-*]
         include:
           - os: macos-13
             macos_deployment_target: 13
@@ -40,7 +40,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.2
+        uses: pypa/cibuildwheel@v2.21.3
         env:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos_deployment_target }}
           CIBW_ARCHS: ${{ matrix.arch }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -12,8 +12,7 @@ jobs:
         # macos-13 is an intel runner, macos-14 is apple silicon
         os: [ubuntu-latest, macos-13, macos-14]
         arch: [auto, aarch64]
-        python: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*, cp312-*,
-                 pp37-*, pp38-*, pp39-*, pp310-*]
+        python: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*, cp312-*]
         include:
           - os: macos-13
             macos_deployment_target: 13
@@ -30,8 +29,6 @@ jobs:
             arch: aarch64
           - os: macos-14
             python: cp37-*
-          - os: macos-14
-            python: pp37-*
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -7,6 +7,7 @@ jobs:
     name: ${{ matrix.os }} | ${{ matrix.arch }} | ${{ matrix.python }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
         os: [ubuntu-latest, macos-13, macos-14]

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -43,6 +43,8 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos_deployment_target }}
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ matrix.python }}
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: "pytest {project}"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -22,6 +22,10 @@ jobs:
         exclude:
           - os: macos-13
             arch: aarch64
+          - os: macos-13
+            python: cp37-*
+          - os: macos-13
+            python: cp310-*
           - os: macos-14
             arch: aarch64
           - os: macos-14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = true
 log_cli_level = "INFO"
 filterwarnings = ["error"]
+python_files = "test/python/test_python_module.py"
 
 [tool.cibuildwheel]
 build-verbosity = 1

--- a/test/python/test_python_module.py
+++ b/test/python/test_python_module.py
@@ -1,0 +1,67 @@
+import lcm
+from os import path, remove
+from tempfile import NamedTemporaryFile
+
+CHANNEL = 'test/channel'
+DATA = bytes(3)
+RECEIVED_MESSAGE = False
+
+
+def my_handler(channel, data):
+    assert channel == CHANNEL
+    assert data == DATA
+    global RECEIVED_MESSAGE
+    RECEIVED_MESSAGE = True
+
+
+def test_lcm():
+    lc = lcm.LCM()
+    subscription = lc.subscribe(CHANNEL, my_handler)
+    lc.publish(CHANNEL, DATA)
+    lc.handle()
+    assert RECEIVED_MESSAGE
+    lc.unsubscribe(subscription)
+
+
+def test_event():
+    event_number = 0
+    timestamp = 1
+    event = lcm.Event(event_number, timestamp, CHANNEL, DATA)
+    assert event.eventnum == event_number
+    assert event.timestamp == timestamp
+    assert event.channel == CHANNEL
+    assert event.data == DATA
+
+
+def test_event_log():
+    with NamedTemporaryFile() as f:
+        filename = f.name
+        # Create a log, write an event, and close it.
+        log = lcm.EventLog(filename, 'w', True)
+        assert log.mode == 'w'
+        assert log.size() == 0
+        assert log.tell() == 0
+        event = lcm.Event(0, 1, CHANNEL, DATA)
+        log.write_event(event.timestamp, event.channel, event.data)
+        log.close()
+        assert path.isfile(filename)
+
+        # Check log that was written.
+        log = lcm.EventLog(filename)
+        assert log.mode == 'r'
+        assert log.size() > 0
+        assert log.tell() == 0
+        read_event = log.read_next_event()
+        # End of log
+        assert log.tell() == log.size()
+        assert event.eventnum == read_event.eventnum
+        assert event.timestamp == read_event.timestamp
+        assert event.channel == read_event.channel
+        assert event.data == read_event.data
+        log.close()
+
+
+if __name__ == '__main__':
+    test_lcm()
+    test_event()
+    test_event_log()


### PR DESCRIPTION
This PR adds a set of unit tests to test the Python module and wires the CI to run the tests for each wheel that gets built. Some platforms failed the test, mainly due to import errors (although one was unable to install the wheel), so these platforms no longer have wheels built for them:

- On macOS 13, for C Python versions 3.7 and 3.10 ([example import failure](https://github.com/nosracd/lcm/actions/runs/11635405758/job/32405760782#step:4:661), [example install failure](https://github.com/nosracd/lcm/actions/runs/11633905129/job/32400015118#step:4:622))
- All PyPy builds ([example import failure](https://github.com/nosracd/lcm/actions/runs/11636254406/job/32407305810#step:4:1017))

Also, it appears that the latest version of `cibuildwheel` now supports Python 3.13 so I bumped the `cibuildwheel` version and added Python 3.13 targets.