### PR TITLE
Update release docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,45 @@
+December 23, 2024
+=================
+
+Release 1.5.1
+
+- General
+    - Various bug fixes
+        - Fixed a bug where `-l` option didn't work in lcm-logger
+        - Fixed a bug where not all compiler flags were being set
+        - Fixed a command in the post-install instructions for linux
+        - Fixed various compiler warnings
+    - Added `CONTRIBUTING.md`
+    - Added documentation for installing LCM
+- Build system
+    - No longer built with `-Werror` flags by default
+    - Builds with release flags by default
+    - Installed version of `libchar-2d` will be used if possible, rather than always building from
+      source
+    - Encoding no longer needs to be set in locale (e.g. the `LANG` environment variable) in order
+      to build the Java component
+    - Finding Glib with pkgconfig is now supported
+    - Added a missing library for lcm-lua on Windows
+    - Added meson build system support for some components
+- Python
+    - Minimum required version is 3.7
+    - `EventLog` now supports a Path argument, rather than just a string
+    - Added PEP-517 support (users can now `pip3 install .`)
+    - New wheels uploaded to PyPi, which support for newer versions of Python, macOS, and musl-based
+      linux (like Alpine)
+    - Typing information now supported via a stub file
+    - SIGINT no longer produces an exception when shutting down LCM executables installed via a
+      wheel
+- lcm-gen
+    - Python output uses absolute (package-level) import paths where possible rather than relative
+      import paths
+    - More comments are included in the generated output for C, C++, Python, and Java
+    - The version of lcm-gen is now included in the output
+    - Python output now uses the `@staticmethod` decorator rather than `= staticmethod()`
+    - Python output now exports symbols using Python's redundant alias convention
+- lcm-logger
+    - Added `--disk-quota` option
+
 April 19, 2023
 ==============
 
@@ -16,7 +58,7 @@ This is primarily a bugfix and maintenance release.
     - Location has moved from https://lcm-proj.github.io/ to https://lcm-proj.github.io/lcm/
 - Windows support
     - Moved from supporting Visual Studio to supporting a MSYS2 MGW64 environment
-- Java 
+- Java
     - Version 1.8 or later is now required
 
 August 30, 2018

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ feedback and involvement on new features.
   * Java
   * Lua
   * MATLAB
-  * Python (3.6 and later)
+  * Python (3.7 and later)
 
 ## Unmaintained languages
 

--- a/WinSpecific/README.md
+++ b/WinSpecific/README.md
@@ -7,7 +7,7 @@ the necessary dependencies, you can run:
 
 ```shell
 pacman -S pactoys git make
-pacboy -S git make toolchain cmake glib2 gtest python-pip
+pacboy -S make toolchain cmake glib2 gtest python-pip
 ```
 
 ## Java

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,7 +44,7 @@ Supported platforms / languages
   * Java
   * Lua
   * MATLAB
-  * Python (3.6 and later)
+  * Python (3.7 and later)
 
 Forks
 ========

--- a/docs/release_checklist
+++ b/docs/release_checklist
@@ -30,3 +30,11 @@
   a. Associate the release with tag vX.Y.Z
   b. Name the release title "vX.Y.Z"
   c. Add release notes from the NEWS file
+
+# PyPi Release
+
+1. Download all wheels generated from CI job from the latest push
+2. Test a macOS wheel and a Linux wheel
+    - Run `test/python/test_python_module.py`
+    - Run `lcm-logplayer-gui`
+3. Upload all wheels to PyPi

--- a/docs/release_checklist
+++ b/docs/release_checklist
@@ -30,7 +30,3 @@
   a. Associate the release with tag vX.Y.Z
   b. Name the release title "vX.Y.Z"
   c. Add release notes from the NEWS file
-
-# Notify the mailing list
-
-1. Send e-mail to lcm-users@googlegroups.com


### PR DESCRIPTION
This PR:

- Specifies the minimum version of Python is 3.7
    - Docs specified 3.6 but pyproject.toml requires 3.7
    - 3.6 has been EOL for a few years now
- Updates the release checklist
    - Removes section about mailing list, since it has been deactivated
    - Adds section for creating a release on PyPi
- Adds a draft for release notes for 1.5.1 release