### PR TITLE
Refactor exports to follow Python conventions

### DIFF
--- a/docs/content/python-notes.md
+++ b/docs/content/python-notes.md
@@ -1,0 +1,13 @@
+# Python application notes
+
+## Redundant module aliases
+
+At first glance the way that lcm-gen generates an `__init__.py` for the outputted Python module may
+seem strange. Symbols are exported using the [redundant alias convention defined by
+Python](https://typing.readthedocs.io/en/latest/spec/distributing.html#import-conventions).
+
+This allows tools to see exactly what symbols are exported by the module without having to first
+implicitly reexport. For example, consider a module which exported symbols using a convention like
+`from .file import Foo` rather than the redundant alias convention of 
+`from .file import Foo as Foo`. In this case, running `mypy` with `--no-implicit-reexport` would
+cause errors like `error: Module "foo" does not explicitly export attribute "Foo"  [attr-defined]`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -85,6 +85,7 @@ Publications and application notes
     - `Technical Report MIT-CSAIL-TR-2009-041, Massachusetts Institute of Technology, 2009`
  - :ref:`UDP Multicast Setup`
  - :ref:`Java application notes`
+ - :ref:`Python application notes`
 
 Who uses LCM?
 =============
@@ -119,6 +120,7 @@ sending a message to the `mailing list <http://groups.google.com/group/lcm-users
    content/install-instructions.md
    content/build-instructions.md
    content/java-notes.md
+   content/python-notes.md
    content/lcm-type-ref.md
    content/log-file-format.md
    content/multicast-setup.md

--- a/lcmgen/emit_python.c
+++ b/lcmgen/emit_python.c
@@ -938,7 +938,8 @@ emit_package (lcmgen_t *lcm, _package_contents_t *package)
 
         if(init_py_fp && 
            !g_hash_table_lookup(init_py_imports, enumeration->enumname->shortname))
-            fprintf(init_py_fp, "from .%s import %s\n", 
+            fprintf(init_py_fp, "from .%s import %s as %s\n", 
+                    enumeration->enumname->shortname,
                     enumeration->enumname->shortname,
                     enumeration->enumname->shortname);
 
@@ -1023,8 +1024,8 @@ emit_package (lcmgen_t *lcm, _package_contents_t *package)
         }
 
         if (init_py_fp && !g_hash_table_lookup(init_py_imports, structure->structname->shortname))
-            fprintf(init_py_fp, "from .%s import %s\n", structure->structname->shortname,
-                    structure->structname->shortname);
+            fprintf(init_py_fp, "from .%s import %s as %s\n", structure->structname->shortname,
+                    structure->structname->shortname, structure->structname->shortname);
 
         if (!lcm_needs_generation(lcm, structure->lcmfile, path))
             continue;


### PR DESCRIPTION
Currently the `__init__.py` generated by lcm-gen exports symbols using the `from .file import Foo` pattern. Python has defined a set of conventions for exporting symbols:

https://typing.readthedocs.io/en/latest/spec/distributing.html#import-conventions

but the current approach does not follow any of the conventions defined by Python. While the current exports should generally still work it means that some tools won't be able to detect the symbols without implicitly exporting them. For example, running `mypy` with `--no-implicit-reexport` would cause errors like `error: Module "foo" does not explicitly export attribute "Foo"  [attr-defined]`.

This PR refactors the Python output to export symbols using one of the "redundant symbol alias" conventions defined by Python, or `from .file import Foo as Foo`. My biggest concern with this change is it will be confusing to people who aren't familiar with the Python export conventions, since at first glance it looks like unnecessary aliasing. I considered generating a comment in the `__init__.py` to explain the pattern, but I'm unsure if that would be helpful or just junk up the output.