### PR TITLE
Fix Ubuntu CI

### DIFF
--- a/.github/workflows/check_man_pages.yml
+++ b/.github/workflows/check_man_pages.yml
@@ -10,7 +10,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Dependencies
-        run: sudo apt install help2man libglib2.0-dev
+        run: |
+          sudo apt update
+          sudo apt install help2man libglib2.0-dev
 
       - name: Configure CMake
         run: cmake -B ${{github.workspace}}/build ${{env.CMAKE_FLAGS}} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
+          sudo apt update
           sudo apt install doxygen liblua5.4-dev
           pip install sphinx-rtd-theme Sphinx myst-parser
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
 
     - name: Install Dependencies
       run: |
+        sudo apt update
         sudo apt install liblua5.3-dev lua5.3 libjchart2d-java libglib2.0-dev
 
     - name: Configure CMake
@@ -191,6 +192,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
+          sudo apt update
           sudo apt install doxygen liblua5.4-dev lua5.4 python3-sphinx-rtd-theme python3-sphinx python3-myst-parser libglib2.0-dev
 
       - name: Build Docs
@@ -213,6 +215,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
+          sudo apt update
           sudo apt install clang-format-15
 
       - name: Check formatting


### PR DESCRIPTION
[master jobs are now failing](https://github.com/nosracd/lcm/actions/runs/11933991836/job/33262181405) with no changes on our side. I'm not sure what changed on the GitHub side, but it seems we can no longer rely on apt to have a valid cache.  This PR fixes that by running `apt update` before `apt install`.