### PR TITLE
Fix warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,7 +169,7 @@ jobs:
           lua:p
 
     - name: Configure CMake
-      run: cmake -B build -DPython_FIND_REGISTRY=NEVER
+      run: cmake -B build ${{env.CMAKE_FLAGS}} -DPython_FIND_REGISTRY=NEVER
 
     - name: Build
       run: cmake --build build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         docker run -v $(pwd):/work -d --rm -it --name lcm-fedora lcm-fedora /bin/bash
 
     - name: Configure CMake
-      run: docker exec lcm-fedora cmake -B ${{github.workspace}}/build ${{env.CMAKE_FLAGS}} -DCMAKE_BUILD_TYPE=Debug
+      run: docker exec lcm-fedora cmake -B ${{github.workspace}}/build ${{env.CMAKE_FLAGS}}
 
     - name: Build
       run: docker exec lcm-fedora cmake --build ${{github.workspace}}/build

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ feedback and involvement on new features.
 * Platforms:
   * GNU/Linux
       * Ubuntu (22.04 and 24.04)
-      * Fedora (40)
+      * Fedora (41)
   * macOS (13 and 14)
   * Windows (2019 and 2022) via MSYS2
 * Languages

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM fedora:40
+FROM fedora:41
 
 # cmake3: To build LCM
 # clang: For compiling code with Clang

--- a/lcm/lcm_coretypes.h
+++ b/lcm/lcm_coretypes.h
@@ -122,7 +122,7 @@ static inline int __int8_t_encode_array(void *_buf, int offset, int maxlen, cons
 static inline int __int8_t_decode_array(const void *_buf, int offset, int maxlen, int8_t *p,
                                         int elements)
 {
-    if (maxlen < elements)
+    if (maxlen < elements || elements < 0)
         return -1;
 
     const int8_t *buf = (const int8_t *) _buf;

--- a/lcm/windows/WinPorting.cpp
+++ b/lcm/windows/WinPorting.cpp
@@ -162,7 +162,7 @@ int fcntl(int fd, int flag1, ...)  // Fake out F_GETFL, set socket to block or n
 
 size_t recvmsg(SOCKET s, struct msghdr *msg, int flags)
 {
-    DWORD nRead, status;
+    DWORD nRead;
 
     WSAMSG tmp_wsamsg;
     tmp_wsamsg.name = msg->msg_name;
@@ -174,7 +174,7 @@ size_t recvmsg(SOCKET s, struct msghdr *msg, int flags)
     tmp_wsamsg.dwFlags = msg->msg_flags;
 
     if (WSARecvMsg == NULL) {
-        status =
+        int status =
             WSAIoctl((SOCKET) s, SIO_GET_EXTENSION_FUNCTION_POINTER, &WSARecvMsg_GUID,
                      sizeof WSARecvMsg_GUID, &WSARecvMsg, sizeof WSARecvMsg, &nRead, NULL, NULL);
         if (status == SOCKET_ERROR) {

--- a/lcm/windows/WinPorting.cpp
+++ b/lcm/windows/WinPorting.cpp
@@ -11,9 +11,13 @@
 #define ARBITRARY_START_PORT 10000
 //	The following data allows multiple processes to access the LastSocket variable
 //	and always choose a valid new socket to use a UNIX pipe() emulation
+#ifdef _MSC_VER
 #pragma data_seg(".winlcm")
+#endif
 volatile LONG LastSocket = ARBITRARY_START_PORT;
+#ifdef _MSC_VER
 #pragma data_seg()
+#endif
 
 extern "C" {
 GUID WSARecvMsg_GUID = WSAID_WSARECVMSG;

--- a/lcm/windows/WinPorting.cpp
+++ b/lcm/windows/WinPorting.cpp
@@ -218,7 +218,7 @@ int gettimeofday(struct timeval *tv, struct timezone *tz)  // tz is not used in 
     UNIXStart.wSecond = 0;
     UNIXStart.wMilliseconds = 0;
 
-    BOOL Did = SystemTimeToFileTime(&UNIXStart, (FILETIME *) &ftUNIXTime);
+    SystemTimeToFileTime(&UNIXStart, (FILETIME *) &ftUNIXTime);
 
     GetSystemTimeAsFileTime((LPFILETIME) &ftNow);
     ftNow -= ftUNIXTime;


### PR DESCRIPTION
Currently the Windows and Fedora builds have compiler warnings when doing a release (default) build. This PR:

- Fixes the Fedora and Windows warnings for release builds
- Switches the Fedora build back to a release build
- Turns on Werror on the Windows builds
- Bumps Fedora to the latest release