### PR TITLE
Refactor windows stuff

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -52,3 +52,40 @@ jobs:
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
+
+  windows:
+
+    runs-on: windows-2022
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: mingw64
+          update: false
+          install: >-
+            git
+            make
+          pacboy: >-
+            toolchain:p
+            cmake:p
+            glib2:p
+            python-pip:p
+
+      - name: Build wheel
+        run: pip3 wheel -v .
+
+      - name: Test wheel
+        run: |
+          pip3 install lcm*.whl --break-system-packages
+          python test/python/test_python_module.py
+
+      - name: 'Upload Artifact'
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-wheel
+          path: '*.whl'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,7 +169,7 @@ jobs:
           lua:p
 
     - name: Configure CMake
-      run: cmake -B build ${{env.CMAKE_FLAGS}} -DPython_FIND_REGISTRY=NEVER
+      run: cmake -B build ${{env.CMAKE_FLAGS}}
 
     - name: Build
       run: cmake --build build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,16 +174,8 @@ jobs:
     - name: Build
       run: cmake --build build
 
-    # Needs to be installed for the tests to be able to find DLLs.
-    - name: Install
-      run: cmake --install build --prefix /mingw64/
-
     - name: Test
-      run: |
-        cd build
-        # Copy DLLs that don't get installed into the directories of the tests that need them.
-        cp test/types/liblcm-test-types.dll test/c/
-        ctest --output-on-failure
+      run: ctest --output-on-failure
 
   docs:
     runs-on: ubuntu-24.04

--- a/WinSpecific/README.md
+++ b/WinSpecific/README.md
@@ -1,16 +1,28 @@
 # LCM port to Windows
 
-We currently support and test on an [MSYS2](https://www.msys2.org/) MINGW64 environment. Please
-reference the GitHub actions that test on Windows in this project for packages necessary to build
-LCM in an MSYS2 environment.
+## Core Dependencies
+
+We currently support and test on an [MSYS2](https://www.msys2.org/) MINGW64 environment. To install
+the necessary dependencies, you can run:
+
+```shell
+pacman -S pactoys git make
+pacboy -S git make toolchain cmake glib2 gtest python-pip
+```
+
+## Java
+
+The above does not result in an environment with Java. If you need the Java-dependent components of
+LCM, please see the [openjdk docs](https://openjdk.org/groups/build/doc/building.html) in order to
+install a JDK.
+
+## Other Notes
 
 There are a few things to watch out for:
 
-1. Before running any LCM executables locally, LCM should be installed. Otherwise Windows will not
-   be able to load the built DLLs.
-2. When installing LCM, CMake defaults to the usual Windows directories rather than the MSYS2
+1. When installing LCM, CMake defaults to the usual Windows directories rather than the MSYS2
    environment. You can use CMake's `--prefix` option when installing to override this.
-3. If there is an installation of Python on the system in addition to the MSYS2 version, cmake may
+2. If there is an installation of Python on the system in addition to the MSYS2 version, cmake may
    pick it up instead. If that is the case, it may be necessary to set
    `-DPython_FIND_REGISTRY=NEVER` or [one of the other
    hints](https://cmake.org/cmake/help/latest/module/FindPython.html#hints) when configuring a build

--- a/test/python/test_python_module.py
+++ b/test/python/test_python_module.py
@@ -1,6 +1,6 @@
 import lcm
-from os import path, remove
-from tempfile import NamedTemporaryFile
+from os import path
+from tempfile import TemporaryDirectory
 
 CHANNEL = 'test/channel'
 DATA = bytes(3)
@@ -34,8 +34,8 @@ def test_event():
 
 
 def test_event_log():
-    with NamedTemporaryFile() as f:
-        filename = f.name
+    with TemporaryDirectory() as temp_dir:
+        filename = f'{temp_dir}/test.log'
         # Create a log, write an event, and close it.
         log = lcm.EventLog(filename, 'w', True)
         assert log.mode == 'w'


### PR DESCRIPTION
Blocked by #547 (based off of its branch). This PR:

- Refactors the Windows jobs to no longer install or copy DLLs around before running the tests (I think this was made unnecessary by #521 refactoring the build targets to statically link)
- Refactors CI to no longer build with `-DPython_FIND_REGISTRY=NEVER` (doesn't seem to be necessary currently, although I kept the advice in `WinSpecific/README.md`). I'd be fine with keeping it around as a guard though.
- Refactors the Python module's tests to use `TemporaryDirectory` rather than `NamedTemporaryFile` (it was creating a file then overwriting it, which resulted in permissions errors on Windows)
- Adds a CI job to build a Windows wheel. This is something that has been requested (#526). Although I'm unsure how useful this particular wheel. It's still limited to an MSYS environment.
- Refactors `WinSpecific/README.md` to give some shell commands for installing LCM's dependencies in an MSYS environment. It seems that is a common source of issues, so hopefully this makes it easier to get started.