### PR TITLE
Fix lua on windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,7 +166,8 @@ jobs:
           cmake:p
           glib2:p
           gtest:p
-  
+          lua:p
+
     - name: Configure CMake
       run: cmake -B build -DPython_FIND_REGISTRY=NEVER
 

--- a/lcm-lua/CMakeLists.txt
+++ b/lcm-lua/CMakeLists.txt
@@ -16,6 +16,10 @@ target_include_directories(lcm-lua PRIVATE
 )
 
 target_link_libraries(lcm-lua lcm ${LUA_LIBRARY})
+if (WIN32)
+  target_link_libraries(lcm-lua ws2_32)
+endif()
+
 
 install(TARGETS lcm-lua
   DESTINATION lib${LIB_SUFFIX}/lua/${LUA_VERSION_MAJOR}.${LUA_VERSION_MINOR}


### PR DESCRIPTION
Resolves #552. 

It appears on Windows lcm-lua needs to link against ws2_32. cff433f0e25e27070c29cbd5da2ae956bbd7a7d1 [reproduces the issue on CI](https://github.com/nosracd/lcm/actions/runs/12356152490/job/34481392150) and 5ff0302449286463f18d56b75517d3b963f4f18c addresses the issue.