### PR TITLE
Add glib dependency to docs job

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt update
-          sudo apt install doxygen liblua5.4-dev
+          sudo apt install doxygen liblua5.4-dev libglib2.0-dev
           pip install sphinx-rtd-theme Sphinx myst-parser
 
       - name: Build Docs


### PR DESCRIPTION
The job which builds the docs [has started failing](https://github.com/lcm-proj/lcm/actions/runs/12748696981/job/35530036308). Although the failure makes sense (glib is a critical dependency) what doesn't make sense is why it worked before and what changed to cause it to stop working.

Either way, this PR fixes the issue by installing glib before trying to build the docs. 