### PR TITLE
Add support for manylinux armv7 wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -44,7 +44,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos_deployment_target }}
           CIBW_ARCHS: ${{ matrix.arch }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,8 @@ before-all = "yum install java-1.8.0-openjdk-devel -y"
 [[tool.cibuildwheel.overrides]]
 select = "*-musllinux*"
 before-all = ""
+
+# Experimental armv7l manylinux image is Ubuntu-based
+[[tool.cibuildwheel.overrides]]
+select = "*-manylinux_armv7l*"
+before-all = "apt update && apt install libglib2.0-dev openjdk-8-jdk -y"


### PR DESCRIPTION
Follow-up to #557. `cibuildwheel` recently added support for an Ubuntu-based manylinux image for armv7, so this PR bumps the version of `cibuildwheel` to enable building manylinux wheels for armv7. Because the image is Ubuntu-based, this PR also overrides the `before-all` command for that image to install the necessary dependencies via apt.