### PR TITLE
Switch to using native arm runner

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -10,8 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, macos-13, macos-14]
-        arch: [auto, aarch64, armv7l]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-14]
+        arch: [auto, armv7l]
         python: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*, cp312-*, cp313-*]
         include:
           - os: macos-13
@@ -19,16 +19,14 @@ jobs:
           - os: macos-14
             macos_deployment_target: 14
         exclude:
-          - os: macos-13
-            arch: aarch64
+          - os: ubuntu-24.04
+            arch: armv7l
           - os: macos-13
             arch: armv7l
           - os: macos-13
             python: cp37-*
           - os: macos-13
             python: cp310-*
-          - os: macos-14
-            arch: aarch64
           - os: macos-14
             arch: armv7l
           - os: macos-14


### PR DESCRIPTION
Currently, the aarch64 wheel builds are failing due to a qemu bug:

- [failure on unrelated PR](https://github.com/lcm-proj/lcm/actions/runs/13217307278/job/36898086665)
- [failure on my fork](https://github.com/nosracd/lcm/actions/runs/13226754999/job/36918579212) (same revision as master here)

Relevant issue on cibuildwheel project discussing the bug: https://github.com/pypa/cibuildwheel/issues/2257

This PR bypasses the issue by switching to the native ARM GitHub runner. The advantages of this approach are:

Faster build times. For example, the Python 3.7 jobs that used qemu took:

- [ubuntu-latest | aarch64 | cp37-*](https://github.com/nosracd/lcm/actions/runs/12752220037/job/35541135201#logs): 13m 45s
- [ubuntu-latest | armv7l | cp37-*](https://github.com/nosracd/lcm/actions/runs/12752220037/job/35541137913#logs): 13m 31s

But the new, equivalent jobs take:

- [ubuntu-24.04-arm | auto | cp37-*](https://github.com/nosracd/lcm/actions/runs/13226972684/job/36919072582#logs): 2m 36s
- [ubuntu-24.04-arm | armv7l | cp37-*](https://github.com/nosracd/lcm/actions/runs/13226972684/job/36919073600#logs): 3m 12s

Also, this approach should result in a simpler build chain. By avoiding qemu we also avoid emulation errors, like the one currently affecting jobs.

The downside of this approach is that the `ubuntu-42.04-arm` runners are currently is public preview so there may be stability issues when using this image. If we'd rather not go this approach then the alternative workaround would probably be to pin qemu to a version without the bug.