### PR TITLE
Bump deploy pages actions versions

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -32,9 +32,9 @@ jobs:
           make doc
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: '${{github.workspace}}/build/docs/_build'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Intended to fix [this failure](https://github.com/lcm-proj/lcm/actions/runs/13242356772) on master due to a too-old version of a github action.