### PR TITLE
Enable tests on windows wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -120,6 +120,8 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python }}
           SKBUILD_CMAKE_ARGS: "--preset=vcpkg-vs-github"
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: "pytest {project}"
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Fixes an oversight in #567. Sets a couple cibuildwheel variables to enable cibuildwheel running the Python tests for each Windows wheel.