### PR TITLE
lcm-spy.sh: separate logic which finds jchart2d

### DIFF
--- a/lcm-java/lcm-spy.sh.in
+++ b/lcm-java/lcm-spy.sh.in
@@ -9,14 +9,25 @@ fi
 # Find dependency JARs
 if [ -e "$mydir/lcm.jar" ]; then
   jars="$mydir/lcm.jar"
-  jars="$jars:$mydir/jchart2d-code/jchart2d-3.2.2.jar"
-  ext="$mydir/jchart2d-code/ext"
 elif [ -e "$mydir/../share/java/lcm.jar" ]; then
   jars="$mydir/../share/java/lcm.jar"
-  jars="$jars:$mydir/../share/java/jchart2d-3.2.2.jar"
-  ext="$mydir/../share/java"
 else
   echo "Unable to find 'lcm.jar'; please check your installation" >&2
+  exit 1
+fi
+
+# Find jchart2d and its dependencies separately since it may not exist relative to lcm.jar.
+if [ -e "$mydir/jchart2d-code/jchart2d-3.2.2.jar" ]; then
+  jars="$jars:$mydir/jchart2d-code/jchart2d-3.2.2.jar"
+  ext="$mydir/jchart2d-code/ext"
+elif [ -e "$mydir/../share/java/jchart2d-3.2.2.jar" ]; then
+  jars="$jars:$mydir/../share/java/jchart2d-3.2.2.jar"
+  ext="$mydir/../share/java"
+elif [ -e "/usr/share/java/jchart2d-3.2.2.jar" ]; then
+  jars="$jars:/usr/share/java/jchart2d-3.2.2.jar"
+  ext="/usr/share/java"
+else
+  echo "Unable to find 'jchart2d-3.2.2.jar'; please check your installation" >&2
   exit 1
 fi
 


### PR DESCRIPTION
jchart2d can be installed to a system global directory while lcm-spy is installed to something like /usr/local.  Finding jchart2d in this case was not supported by the script.  We hardcode the typical path /usr/share/java since this is likely where it exists.