### PR TITLE
Switch to manual cache action for vcpkg

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -95,6 +95,8 @@ jobs:
   windows-msvc:
     name: windows | auto | ${{ matrix.python }}
     runs-on: windows-2022
+    env:
+      VCPKG_DEFAULT_BINARY_CACHE: ${{github.workspace}}\vcpkg-cache
     strategy:
       fail-fast: false
       matrix:
@@ -102,18 +104,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      # Set up vcpkg, leveraging cache. This does not build any packages.
-      - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11
+      - uses: actions/cache@v4
         with:
-          vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-          vcpkgGitCommitId: 'a42af01b72c28a8e1d7b48107b33e4f286a55ef6'
+          path: ${{github.workspace}}\vcpkg-cache
+          key: ${{ hashFiles('vcpkg.json') }}-vcpkg-wheel-cache
+          restore-keys: vcpkg-wheel-cache
 
-      # Builds dependencies using vcpkg, leveraging cache
-      - name: Run CMake
-        uses: lukka/run-cmake@v10
-        with:
-          configurePreset: 'vcpkg-vs-github'
+      - name: Create cache directory
+        run: mkdir ${{env.VCPKG_DEFAULT_BINARY_CACHE}} -Force
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,22 +180,23 @@ jobs:
 
   windows_msvc:
     runs-on: windows-2022
+    env:
+      VCPKG_DEFAULT_BINARY_CACHE: ${{github.workspace}}\vcpkg-cache
 
     steps:
     - uses: actions/checkout@v4
-
-      # Set up vcpkg, leveraging cache. This does not build any packages.
-    - name: Setup vcpkg
-      uses: lukka/run-vcpkg@v11
+    - uses: actions/cache@v4
       with:
-        vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-        vcpkgGitCommitId: 'a42af01b72c28a8e1d7b48107b33e4f286a55ef6'
+        path: ${{github.workspace}}\vcpkg-cache
+        key: ${{ hashFiles('vcpkg.json') }}-vcpkg-cache
+        restore-keys: vcpkg-cache
+
+    - name: Create cache directory
+      run: mkdir ${{env.VCPKG_DEFAULT_BINARY_CACHE}} -Force
 
     # Builds dependencies using vcpkg, leveraging cache
     - name: Run CMake
-      uses: lukka/run-cmake@v10
-      with:
-        configurePreset: 'vcpkg-vs-github'
+      run: cmake --preset=vcpkg-vs-github
 
     - name: Build
       run: cmake --build build --config Release


### PR DESCRIPTION
I saw some decent caching results on my fork from the `lukka/run-cmake` and `lukka/run-vcpk` actions but I'm disappointed by how unpredictable and often the cache misses are.

So this PR refactors to instead use the standard, but more manual `actions/cache` action. It sets `VCPKG_DEFAULT_BINARY_CACHE` to tell vcpkg to use a non-default directory for cache, adds a step to ensure that directory exists (in case there's a cache miss), and uses the action to save off and restore that directory.

The action is configured to save off two caches: one for `test.yml` and one for `build_wheels.yml`. They both need to cache win64 binaries but the latter also needs to cache win32 binaries. They are configured to get a cache miss if `vcpkg.json` changes, but start with a previous cache in the case of a cache miss.

With this approach I expect that the default branch will have a cache miss the first run. After that, there should be cache hits on both the default branch and other branches until `vcpkg.json` is updated.

For example, when I pushed this commit to the default branch on my fork it resulted in a cache miss and the following run times:

- [test](https://github.com/nosracd/lcm/actions/runs/14519537351) 27m 27s
- [build wheels](https://github.com/nosracd/lcm/actions/runs/14519537392) 48m 47s

Then when I pushed a new branch up based off of the same commit, I got the following run times:

- [test](https://github.com/nosracd/lcm/actions/runs/14520417677) 4m 10s
- [build wheels](https://github.com/nosracd/lcm/actions/runs/14520417674) 11m 6s