### PR TITLE
upgrade minimum cmake version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 if(POLICY CMP0111)
   cmake_policy(SET CMP0111 NEW)

--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(lcm_c_example)
 

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(lcm_cpp_example)
 

--- a/examples/cpp/lcm_log_writer/CMakeLists.txt
+++ b/examples/cpp/lcm_log_writer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(lcm_log_writer)
 

--- a/lcm-cmake/lcmUtilities.cmake
+++ b/lcm-cmake/lcmUtilities.cmake
@@ -27,7 +27,7 @@
 #   lcm_install_python([DESTINATION <PATH>]
 #                      <FILE> [<FILE>...])
 
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.10.0)
 include(CMakeParseArguments)
 
 #------------------------------------------------------------------------------
@@ -346,7 +346,7 @@ function(lcm_wrap_types)
         if(DEFINED _CSHARP_SOURCES)
           if(_package_dir STREQUAL ".")
             _lcm_add_outputs(_CSHARP_SOURCES LCMTypes/${_type}.cs)
-          else()  
+          else()
             _lcm_add_outputs(_CSHARP_SOURCES ${_package_dir}/${_type}.cs)
           endif()
         endif()


### PR DESCRIPTION
macOS ships with cmake 4.0.1 which has dropped support for cmake < 3.5, leading to this error when building:

```
| Configuring the build directory with CMake version 4.0.1
| Running CMake with: -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=True -DLCM_ENABLE_EXAMPLES=False -DLCM_ENABLE_GO=False -DLCM_ENABLE_JAVA=False -DLCM_ENABLE_LUA=False -DLCM_ENABLE_PYTHON=False -DLCM_ENABLE_TESTS=False
|   - build directory:          /Users/silv/Documents/Research/Projects/navtk/build/subprojects/lcm/__CMake_build
|   - source directory:         /Users/silv/Documents/Research/Projects/navtk/subprojects/lcm
|   - toolchain file:           /Users/silv/Documents/Research/Projects/navtk/build/subprojects/lcm/__CMake_build/CMakeMesonToolchainFile.cmake
|   - preload file:             /Users/silv/Documents/Research/Projects/virtual-environments/.venv-navtk/lib/python3.13/site-packages/mesonbuild/cmake/data/preload.cmake
|   - trace args:               --trace-expand --trace-format=json-v1 --no-warn-unused-cli --trace-redirect=cmake_trace.txt
|   - disabled policy warnings: [CMP0025, CMP0047, CMP0056, CMP0060, CMP0065, CMP0066, CMP0067, CMP0082, CMP0089, CMP0102]

| CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
| Compatibility with CMake < 3.5 has been removed from CMake.

| Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
| to tell CMake that the project requires at least <min> but has been updated
| to work with policies introduced by <max> or earlier.

| Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Updated minimum required version to 3.10

