### PR TITLE
Make lcm-sources.jar

### DIFF
--- a/docs/content/java-notes.md
+++ b/docs/content/java-notes.md
@@ -15,10 +15,52 @@ application, `lcm.jar` must be in your Java classpath.
 On Linux, OS/X, and other UNIX-like systems, `lcm.jar` is typically built
 automatically and installed along with the rest of LCM.  The exact location
 depends on the operating system and any configuration parameters, but it can
-often be found installed in <tt>/usr/local/share/java/</tt>. 
+often be found installed in `/usr/local/share/java/`. 
 
 Separately, `lcm.jar` can also be found in the `lcm-java` subdirectory of the
 source distribution after compiling LCM from source.
+
+A `lcm-sources.jar` is also built and installed. This can provide IDE Javadoc integration.
+
+LCM is currently not available on services like Maven Central. Your build system will need to be configured to point to a local jar.
+
+### Gradle project
+
+An example of using LCM in a Gradle project. Assuming you have placed `my-lcm-types.jar` in `./lib`:
+
+```gradle
+// build.gradle
+String osName = System.getProperty("os.name").toLowerCase();
+project.logger.lifecycle(osName)
+repositories { 
+    mavenCentral()
+
+    flatDir {
+        if (osName.contains("linux")) {        
+            dirs '/usr/local/share/java'
+        } // else TODO
+        dirs 'libs'
+    }
+}
+
+dependencies {
+    implementation ':lcm'
+    implementation ':my-lcm-types'
+}    
+```
+
+> Note: `flatDir` is preferred over `implementation files('/usr/local/share/java/lcm.jar')`. Both work, but IDEs may not be able to find `lcm-sources.jar` with the `files` approach.
+
+### Eclipse project
+See [SO: How to import a jar in Eclipse?](https://stackoverflow.com/questions/3280353/how-to-import-a-jar-in-eclipse) for an example of how to import a jar in Eclipse.
+
+See [SO: Attach the Source in Eclipse of a jar](https://stackoverflow.com/questions/15180411/attach-the-source-in-eclipse-of-a-jar) for instructions on how to attach a source jar in Eclipse (you might need to look at multiple answers).
+
+### InteliJ project
+See [SO: Correct way to add external jars (lib/*.jar) to an IntelliJ IDEA project](https://stackoverflow.com/questions/1051640/correct-way-to-add-external-jars-lib-jar-to-an-intellij-idea-project) for instructions on how to import a jar in IntelliJ.
+
+### Other
+Use another build system like Ant or Maven? Please contribute instructions that work for you.
 
 ## Namespace issues
 

--- a/lcm-java/CMakeLists.txt
+++ b/lcm-java/CMakeLists.txt
@@ -28,6 +28,8 @@ if(NOT jchart2d_JAR)
   set(jchart2d_JAR jchart2d)
 endif()
 
+set(top_package lcm)
+
 set(lcm_java_sources
   lcm/util/JImage.java
   lcm/util/TableSorter.java
@@ -70,6 +72,35 @@ add_jar(lcm-java
 )
 
 install_jar(lcm-java DESTINATION share/java)
+
+# Make a sources jar.
+# Starting point. Should probably provide a new answer once something more robust is put together.
+# https://stackoverflow.com/a/77086658/8954109
+set(sources_jar "lcm-sources.jar")
+
+add_custom_command(
+  OUTPUT 
+    "${sources_jar}"
+  COMMAND 
+    # -- Long options are not supported on all java distributions.
+    # -- ${Java_JAR_EXECUTABLE} --create --file "${sources_jar}" -C ${CMAKE_CURRENT_SOURCE_DIR} ${top_package}
+    ${Java_JAR_EXECUTABLE} cf "${CMAKE_CURRENT_BINARY_DIR}/${sources_jar}" ${top_package}
+  WORKING_DIRECTORY
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+  DEPENDS 
+    ${lcm_java_sources}
+  VERBATIM
+  COMMENT 
+    "Creating sources jar"
+)
+
+add_custom_target(lcm-java-src
+  DEPENDS "${sources_jar}"
+)
+add_dependencies(lcm-java lcm-java-src)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${sources_jar}" DESTINATION share/java)
+
 
 if(WIN32)
 


### PR DESCRIPTION
Provide lcm-sources.jar to go along with lcm-jar. IDEs can use this as the source of documentation for the library. 

Idk if I'm cmaking correctly. This is a normal thing for java projects, but is not part of cmake's usejava.