### PR TITLE
Fix Cmake Tutorial and Python Installation

### DIFF
--- a/docs/content/tutorial-cmake.md
+++ b/docs/content/tutorial-cmake.md
@@ -34,7 +34,7 @@ parts. Alternatively, you may want to make them `REQUIRED`.)
     find_package(lcm REQUIRED)
     include(${LCM_USE_FILE})
 
-    find_package(PythonInterp)
+    find_package(Python COMPONENTS Interpreter)
     find_package(Java)
 
     if(JAVA_FOUND)
@@ -201,7 +201,7 @@ generate these bindings always, or opportunistically when Python and/or Java
 are available, you may want to make this logic conditional, as in the approach
 shown here:
 
-    if(PYTHONINTERP_FOUND)
+    if(${Python_Interpreter_FOUND})
       set(python_args PYTHON_SOURCES python_sources)
     endif()
     if(JAVA_FOUND)
@@ -243,7 +243,7 @@ As before, if you require Java, you can omit the `JAVA_FOUND` check.
 
 First, let's revisit our variable names:
 
-    if(PYTHONINTERP_FOUND)
+    if(${Python_Interpreter_FOUND})
       set(python_args PYTHON_SOURCES python_install_sources)
     endif()
     if(JAVA_FOUND)
@@ -278,7 +278,7 @@ Now, we'll install everything:
       ${cpp_install_headers}
     )
 
-    if(PYTHONINTERP_FOUND)
+    if(${Python_Interpreter_FOUND})
       lcm_install_python(${python_install_sources})
     endif()
 

--- a/lcm-cmake/lcmUtilities.cmake
+++ b/lcm-cmake/lcmUtilities.cmake
@@ -478,7 +478,7 @@ function(lcm_install_python)
 
   # Set default destination and relative path, if none given
   if(NOT DEFINED _DESTINATION)
-    if(NOT PYTHONINTERP_FOUND)
+    if(NOT Python_Interpreter_FOUND AND NOT PYTHONINTERP_FOUND)
       message(SEND_ERROR
         "lcm_install_python: no DESTINATION given"
         " and no Python interpreter found (required to guess DESTINATION)")

--- a/lcm-cmake/lcmUtilities.cmake
+++ b/lcm-cmake/lcmUtilities.cmake
@@ -486,8 +486,8 @@ function(lcm_install_python)
     endif()
     execute_process(
       COMMAND "${Python_EXECUTABLE}" -c "if True:
-        from distutils import sysconfig as sc
-        print(sc.get_python_lib(prefix='', plat_specific=True))"
+        import sysconfig as sc
+        print(sc.get_path('platlib'))"
       OUTPUT_VARIABLE _DESTINATION
       OUTPUT_STRIP_TRAILING_WHITESPACE)
   endif()


### PR DESCRIPTION
This PR resolves #575.

To test, I developed this from following the tutorial:

[CMakeLists.txt](https://github.com/user-attachments/files/20746177/CMakeLists.txt)

Alongside it, I had `mytype.lcm` which contained:

```
package exlcm;

struct mytype
{
    int64_t  timestamp;
    double   position[3];
    double   orientation[4];
    int32_t  num_ranges;
    int16_t  ranges[num_ranges];
    string   name;
    boolean  enabled;
}
```

16660db7c3dbfd1ae0fdf4eb124bd44dd2a09b40 may be enough to resolve the issue, but when trying to test it out I found that `FindPythonInterp` has been deprecated for a while so I updated the tutorial and `lcm_install_python` to use the replacement `FindPython`.

