### PR TITLE
Bump windows CI images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,7 @@ jobs:
   windows_msys2:
     strategy:
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022, windows-2025]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test_meson.yml
+++ b/.github/workflows/test_meson.yml
@@ -161,13 +161,13 @@ jobs:
           glib2:p
           gtest:p
           meson:p
-  
+
     - name: Setup Meson
       run: meson setup build --prefix /mingw64/
 
     - name: Build
       run: ninja -C build
-    
+
     - name: Install
       run: ninja -C build install
 

--- a/.github/workflows/test_meson.yml
+++ b/.github/workflows/test_meson.yml
@@ -138,7 +138,7 @@ jobs:
   windows:
     strategy:
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022, windows-2025]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
The 2019 server image was deprecated and the 2025 server image was added, causing jobs to fail. This PR drops the 2019 image and adds the 2025 image.