### PR TITLE
Docs suggestions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,3 +69,6 @@ docs/generate_man_pages.sh
 
 That script makes multiple assumptions about the environment it is run in. Please see its docstrings
 for more information.
+
+## Web Docs
+Docs are not built by the default CMake build `make` command. `make doc` will build the Sphinx site and run language specific API tools (Javadoc, Doxygen). To build only the Sphinx site, run `cd ./docs; make clean html` (Not `./build/docs`). "`clean`" is important for every rebuild. You can preview the docs by running (recommended from a new terminal) `cd ./docs/_build/html; python3 -m http.server 5000` (where 5000 is a stand-in for your port of choice).

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,8 @@
+
+/* The "Read the Docs" theme applies `uppercase` to the table of contents headings.
+ * But this turns "APIs" into "APIS", which is less helpful. 
+ */
+.wy-menu-vertical header,
+.wy-menu-vertical p.caption {
+    text-transform: unset;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,3 +38,12 @@ source_suffix = {
     '.rst': 'restructuredtext',
     '.md': 'markdown',
 }
+
+# These folders are copied to the documentation's HTML output
+html_static_path = ['_static']
+
+# These paths are either relative to html_static_path
+# or fully qualified paths (eg. https://...)
+html_css_files = [
+    'css/custom.css',
+]

--- a/docs/content/java-notes.md
+++ b/docs/content/java-notes.md
@@ -28,7 +28,7 @@ LCM is currently not available on services like Maven Central. Your build system
 
 An example of using LCM in a Gradle project. Assuming you have placed `my-lcm-types.jar` in `./lib`:
 
-```gradle
+```groovy
 // build.gradle
 String osName = System.getProperty("os.name").toLowerCase();
 project.logger.lifecycle(osName)

--- a/docs/content/tutorial.md
+++ b/docs/content/tutorial.md
@@ -1,6 +1,4 @@
-# Tutorial and examples
-
-## Introduction
+# LCM Introduction
 
 LCM is a package designed to allow multiple processes to exchange messages in
 a safe and high-performance way.   

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ Quick links
 * :ref:`Installing LCM`
 * `Downloads <https://github.com/lcm-proj/lcm/releases>`_
 * :ref:`Build Instructions`
-* :ref:`Tutorial and examples`
+* :ref:`LCM Introduction`
 * `GitHub site <https://github.com/lcm-proj/lcm>`_
 
 Features
@@ -115,8 +115,8 @@ sending a message to the `mailing list <http://groups.google.com/group/lcm-users
 .. toctree::
    :maxdepth: 1
    :caption: Contents
-   :glob:
-
+   
+   self
    content/install-instructions.md
    content/build-instructions.md
    content/java-notes.md
@@ -129,31 +129,38 @@ sending a message to the `mailing list <http://groups.google.com/group/lcm-users
 .. toctree::
    :maxdepth: 1
    :caption: Tutorials
-   :glob:
 
+   content/tutorial.md
+   content/tutorial-lcmgen.md
    content/tutorial-cmake.md
    content/tutorial-c.md
    content/tutorial-cpp.md
    content/tutorial-dotnet.md
    content/tutorial-go.md
    content/tutorial-java.md
-   content/tutorial-lcmgen.md
    content/tutorial-lua.md
    content/tutorial-matlab.md
-   content/tutorial.md
    content/tutorial-python.md
 
 .. toctree::
    :maxdepth: 1
-   :caption: APIs
-   :glob:
+   :caption: Language APIs
 
    doxygen_output/c_cpp/html/group__LcmC
    doxygen_output/c_cpp/html/group__LcmCpp
    doxygen_output/lcm-dotnet/html/namespaces
    javadocs/index
-   content/lua-api.md
+   Lua API <content/lua-api.md>
    python/index.rst
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Quick Links
+
+   GitHub Project <https://github.com/lcm-proj/lcm>
+   Contributing <https://github.com/lcm-proj/lcm/blob/master/CONTRIBUTING.md>
+   License <https://github.com/lcm-proj/lcm/blob/master/COPYING>
+
 
 Indices and tables
 ==================


### PR DESCRIPTION
I had trouble navigating the existing structure of the docs. Here's a small handful of tweaks I hope help.

* Create a custom style sheet. The "Read the Docs" theme makes TOC headings ALL CAPS. APIs -> APIS. New style undoes this.
* Fix Gradle Java build code block language to be `groovy` instead of `gradle`.
* Rename "Tutorial and examples" page to "LCM Introduction". (Did not change the file name. Not breaking links.)
* Move "LCM Introduction" and "LCM-gen Tutorial" pages to the top of the Tutorials section.
* Add the docs homepage to the toc (`self`)
* Make a Quick Links TOC section for links external to the docs, like the actual repo.
* Add info about building the docs to CONTRIBUTING.

Current sidebar on the left, new on the right:

<img width="594" height="1266" alt="image" src="https://github.com/user-attachments/assets/6402bbe0-a086-4895-b424-a1b5396a308e" />
