### PR TITLE
Add lcm-bazel option for passing args to lcmgen

### DIFF
--- a/examples/bazel/BUILD.bazel
+++ b/examples/bazel/BUILD.bazel
@@ -43,6 +43,7 @@ lcm_library(
 lcm_c_library_srcs(
     name = "exlcm_c_srcs",
     src = ":exlcm",
+    args = ["--cpp-std=c++11"],
 )
 
 cc_library(

--- a/lcm-bazel/lcm_cc_library_srcs.bzl
+++ b/lcm-bazel/lcm_cc_library_srcs.bzl
@@ -15,6 +15,7 @@ lcm_library(
 lcm_cc_library_srcs(
     name = "foo_bar_cc_srcs",
     src = ":foo_bar",
+    args = ["--cpp-std=c++11"],
 )
 
 cc_library(

--- a/lcm-bazel/private/lcm_c_library_srcs.bzl
+++ b/lcm-bazel/private/lcm_c_library_srcs.bzl
@@ -20,7 +20,7 @@ def _impl(ctx):
         "--c",
         "--c-cpath=" + output_dir,
         "--c-hpath=" + output_dir,
-    ]
+    ] + ctx.attr.args
 
     # Run lcm-gen.
     ctx.actions.run(
@@ -49,5 +49,6 @@ lcm_c_library_srcs = rule(
             executable = True,
             default = Label("//lcmgen:lcm-gen"),
         ),
+        "args": attr.string_list(),
     },
 )

--- a/lcm-bazel/private/lcm_cc_library_srcs.bzl
+++ b/lcm-bazel/private/lcm_cc_library_srcs.bzl
@@ -18,7 +18,7 @@ def _impl(ctx):
     arguments = [
         "--cpp",
         "--cpp-hpath=" + output_dir,
-    ]
+    ] + ctx.attr.args
 
     # Run lcm-gen.
     ctx.actions.run(
@@ -47,5 +47,6 @@ lcm_cc_library_srcs = rule(
             executable = True,
             default = Label("//lcmgen:lcm-gen"),
         ),
+        "args": attr.string_list(),
     },
 )

--- a/lcm-bazel/private/lcm_java_library_srcs.bzl
+++ b/lcm-bazel/private/lcm_java_library_srcs.bzl
@@ -18,7 +18,7 @@ def _impl(ctx):
     arguments = [
         "--java",
         "--jpath=" + output_dir,
-    ]
+    ] + ctx.attr.args
 
     # Run lcm-gen.
     ctx.actions.run(
@@ -47,5 +47,6 @@ lcm_java_library_srcs = rule(
             executable = True,
             default = Label("//lcmgen:lcm-gen"),
         ),
+        "args": attr.string_list(),
     },
 )

--- a/lcm-bazel/private/lcm_py_library_srcs.bzl
+++ b/lcm-bazel/private/lcm_py_library_srcs.bzl
@@ -20,7 +20,7 @@ def _impl(ctx):
     arguments = [
         "--python",
         "--ppath=" + output_dir,
-    ]
+    ] + ctx.attr.args
 
     # Run lcm-gen.
     ctx.actions.run(
@@ -49,5 +49,6 @@ lcm_py_library_srcs = rule(
             executable = True,
             default = Label("//lcmgen:lcm-gen"),
         ),
+        "args": attr.string_list(),
     },
 )


### PR DESCRIPTION
This allows opt-in for C++11 mode (instead of C++98).