### PR TITLE
Fix lcm-bazel warnings

### DIFF
--- a/lcm-bazel/private/copts.bzl
+++ b/lcm-bazel/private/copts.bzl
@@ -1,10 +1,15 @@
-# Match the default warning suppressions from lcm-cmake/config.cmake.
+# Match the default warning suppressions from lcm-cmake/config.cmake, but don't
+# try to pass -Wno-stringop-truncation to clang, since it doesn't exist there.
 
 WARNINGS_COPTS = select({
-    "//lcm:windows": [],
-    "//conditions:default": [
+    "@rules_cc//cc/compiler:clang": [
+        "-Wno-unused-parameter",
+        "-Wno-format-zero-length",
+    ],
+    "@rules_cc//cc/compiler:gcc": [
         "-Wno-unused-parameter",
         "-Wno-format-zero-length",
         "-Wno-stringop-truncation",
     ],
+    "//conditions:default": [],
 })

--- a/lcm-logger/BUILD.bazel
+++ b/lcm-logger/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("//lcm-bazel/private:copts.bzl", "WARNINGS_COPTS")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -12,6 +13,7 @@ cc_binary(
         "glib_util.h",
         "lcm_logger.c",
     ],
+    copts = WARNINGS_COPTS,
     visibility = ["//visibility:public"],
     deps = [
         "//lcm:lcm-static",
@@ -23,6 +25,7 @@ cc_binary(
     srcs = [
         "lcm_logplayer.c",
     ],
+    copts = WARNINGS_COPTS,
     visibility = ["//visibility:public"],
     deps = [
         "//lcm:lcm-static",


### PR DESCRIPTION
Fix suppressions to avoid Clang complaints about unknown flags.

Add missing suppressions to lcm-logger.