### PR TITLE
Amend release checklist with stable source archive

### DIFF
--- a/docs/release_checklist
+++ b/docs/release_checklist
@@ -31,6 +31,7 @@
   a. Associate the release with tag vX.Y.Z
   b. Name the release title "vX.Y.Z"
   c. Add release notes from the NEWS file
+  d. On the release page, download the "Source code (tar.gz)" file, then edit the release and re-upload it to the "Attach binaries" section and save.
 
 # PyPi Release
 


### PR DESCRIPTION
GitHub doesn't promise that the auto-generated "Source code" archive will have a stable checksum. Instead, we must manually upload the archive to ensure that.

See https://github.com/lcm-proj/lcm/issues/589#issuecomment-3369085785.