### PR TITLE
Wrap the initial `lcm_create(url)` on init in Py_BEGIN_ALLOW_THREADS

### DIFF
--- a/lcm-python/pylcm.c
+++ b/lcm-python/pylcm.c
@@ -402,7 +402,9 @@ static int pylcm_initobj(PyObject *self, PyObject *args, PyObject *kwargs)
     if (!PyArg_ParseTuple(args, "|s", &url))
         return -1;
 
+    Py_BEGIN_ALLOW_THREADS;
     lcm_obj->lcm = lcm_create(url);
+    Py_END_ALLOW_THREADS;
     if (!lcm_obj->lcm) {
         PyErr_SetString(PyExc_RuntimeError, "Couldn't create LCM");
         return -1;


### PR DESCRIPTION
Using tcpq:// for LCM communication, the initial `lcm_create` call attempts to do network IO, including a `recv` to get the version string from its remote server. This may block indefinitely (or at least until TCP times out), so we should release the GIL while it's happening.

Originally discovered by @pluviolithic, who was seeing background threads hanging on epoll until LCM's recv finished. He supplied this script that reproduces the error by trying to talk to itself:

```python
import selectors
import socket
import threading
import time

import lcm

select = selectors.DefaultSelector()


def connect_lcm() -> None:
    time.sleep(5)
    lcm.LCM("tcpq://127.0.0.1:8675")


def accept(_server_socket: socket.socket, _mask: int) -> None:
    print("Accepted...")


select = selectors.DefaultSelector()

server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
server_socket.bind(("127.0.0.1", 8675))

server_socket.listen(5)
server_socket.setblocking(False)  # noqa: FBT003

select.register(server_socket, selectors.EVENT_READ, accept)

threading.Thread(target=connect_lcm).start()

while True:
    print("selecting...")
    select.select(1)
    print("done selecting...")
```