### PR TITLE
fix segfault during unsubscribe

### DIFF
--- a/lcm-python/module.c
+++ b/lcm-python/module.c
@@ -18,6 +18,7 @@
 extern PyTypeObject pylcmeventlog_type;
 extern PyTypeObject pylcm_type;
 extern PyTypeObject pylcm_subscription_type;
+extern int pylcm_module_init(void);
 
 /* module initialization */
 
@@ -54,6 +55,14 @@ init_lcm(void)
     Py_SET_TYPE(&pylcm_subscription_type, &PyType_Type);
 
     MOD_DEF(m, "_lcm", lcmmod_doc, lcmmod_methods);
+
+    if (pylcm_module_init() != 0) {
+#if PY_MAJOR_VERSION >= 3
+        return NULL;
+#else
+        return;
+#endif
+    }
 
     Py_INCREF(&pylcmeventlog_type);
     if (PyModule_AddObject(m, "EventLog", (PyObject *) &pylcmeventlog_type) != 0) {

--- a/lcm-python/pylcm.c
+++ b/lcm-python/pylcm.c
@@ -84,23 +84,70 @@ and the following usage would publish a message::\n\
 // gives redefinition error in MSVC
 // PyTypeObject pylcm_type;
 
+// Thread-local slot used to pass a suspended PyThreadState* from
+// pylcm_handle / pylcm_handle_timeout down into pylcm_msg_handler. Stored
+// in TSS (keyed by OS thread) rather than on PyLCMObject because the
+// handler runs without the GIL: reading the state from subs_obj->lcm_obj
+// would race with pylcm_unsubscribe nulling that field. TSS lookup is
+// thread-local, so it requires no synchronization with other Python
+// threads. Initialized in pylcm_module_init() (called from PyInit__lcm).
+static Py_tss_t pylcm_thread_state_key = Py_tss_NEEDS_INIT;
+
+int pylcm_module_init(void)
+{
+    // PyThread_tss_create is a no-op when the key is already initialized,
+    // so this is safe across module reloads.
+    if (PyThread_tss_create(&pylcm_thread_state_key) != 0) {
+        PyErr_SetString(PyExc_RuntimeError, "failed to create LCM thread-local storage");
+        return -1;
+    }
+    return 0;
+}
+
 // all LCM messages subscribed to by all LCM objects pass through this
 // handler first.
 static void pylcm_msg_handler(const lcm_recv_buf_t *rbuf, const char *channel, void *userdata)
 {
+    // Restore the GIL *before* touching any PyLCMSubscriptionObject field.
+    // Reading subs_obj->lcm_obj without the GIL was the original bug:
+    // pylcm_unsubscribe could set that field to NULL while we were entering
+    // here. The thread state lives in TSS so we don't have to chase it
+    // through subs_obj.
+    PyThreadState *ts = (PyThreadState *) PyThread_tss_get(&pylcm_thread_state_key);
+    if (ts) {
+        PyEval_RestoreThread(ts);
+        PyThread_tss_set(&pylcm_thread_state_key, NULL);
+    }
+    // From here on the GIL is held. pylcm_unsubscribe also holds the GIL
+    // when it mutates subs_obj->*, so any read below is synchronized.
+
     PyLCMSubscriptionObject *subs_obj = (PyLCMSubscriptionObject *) userdata;
     dbg(DBG_PYTHON, "%s %p %p\n", __FUNCTION__, subs_obj, subs_obj->lcm_obj);
 
-    // Restore the thread state before calling back into Python.
-    if (subs_obj->lcm_obj->saved_thread_state) {
-        PyEval_RestoreThread(subs_obj->lcm_obj->saved_thread_state);
-        subs_obj->lcm_obj->saved_thread_state = NULL;
+    // If unsubscribe already ran, subs_obj->lcm_obj and subs_obj->handler
+    // have been nulled. The C-level marked_for_deletion mechanism will tear
+    // down the lcm_subscription_t safely; we just skip the Python callback.
+    PyLCMObject *lcm_obj = subs_obj->lcm_obj;
+    PyObject *handler = subs_obj->handler;
+    if (!lcm_obj || !handler) {
+        return;
     }
 
     // if an exception has occurred, then abort.
     if (PyErr_Occurred()) {
         return;
     }
+
+    // The user callback may release the GIL (sleep, I/O, ...), allowing
+    // another thread to run pylcm_unsubscribe -- which would Py_DECREF
+    // subs_obj->handler and NULL subs_obj->lcm_obj. Hold local strong refs
+    // across the call so those operations don't free the objects we're
+    // still using.
+    //
+    // INVARIANT: do NOT touch subs_obj->* below this point. Use only the
+    // locals `lcm_obj` and `handler`.
+    Py_INCREF(lcm_obj);
+    Py_INCREF(handler);
 
 #if PY_MAJOR_VERSION >= 3
     PyObject *arglist = Py_BuildValue("sy#", channel,  // build from bytes
@@ -110,14 +157,17 @@ static void pylcm_msg_handler(const lcm_recv_buf_t *rbuf, const char *channel, v
                                       rbuf->data, rbuf->data_size);
 #endif
 
-    PyObject *result = PyObject_CallObject(subs_obj->handler, arglist);
+    PyObject *result = PyObject_CallObject(handler, arglist);
     Py_DECREF(arglist);
 
     if (!result) {
-        subs_obj->lcm_obj->exception_raised = 1;
+        lcm_obj->exception_raised = 1;
     } else {
         Py_DECREF(result);
     }
+
+    Py_DECREF(handler);
+    Py_DECREF(lcm_obj);
 }
 
 // =============== LCM class methods ==============
@@ -270,25 +320,30 @@ static PyObject *pylcm_handle(PyLCMObject *lcm_obj)
 {
     dbg(DBG_PYTHON, "pylcm_handle(%p)\n", lcm_obj);
 
-    if (lcm_obj->saved_thread_state) {
+    if (lcm_obj->handle_in_progress) {
         PyErr_SetString(
             PyExc_RuntimeError,
             "only one thread is allowed to call LCM.handle() or LCM.handle_timeout() at a time");
         return NULL;
     }
-    lcm_obj->saved_thread_state = PyEval_SaveThread();
+    lcm_obj->handle_in_progress = 1;
     lcm_obj->exception_raised = 0;
+
+    PyThreadState *ts = PyEval_SaveThread();
+    PyThread_tss_set(&pylcm_thread_state_key, ts);
 
     dbg(DBG_PYTHON, "calling lcm_handle(%p)\n", lcm_obj->lcm);
     int status = lcm_handle(lcm_obj->lcm);
 
-    // Restore the thread state before returning back to Python.  The thread
-    // state may have already been restored by the callback function
-    // pylcm_msg_handler()
-    if (lcm_obj->saved_thread_state) {
-        PyEval_RestoreThread(lcm_obj->saved_thread_state);
-        lcm_obj->saved_thread_state = NULL;
+    // Restore the thread state before returning back to Python. It may
+    // have already been restored (and the TSS slot cleared) by the
+    // callback function pylcm_msg_handler().
+    ts = (PyThreadState *) PyThread_tss_get(&pylcm_thread_state_key);
+    if (ts) {
+        PyEval_RestoreThread(ts);
+        PyThread_tss_set(&pylcm_thread_state_key, NULL);
     }
+    lcm_obj->handle_in_progress = 0;
 
     if (lcm_obj->exception_raised) {
         return NULL;
@@ -317,24 +372,29 @@ static PyObject *pylcm_handle_timeout(PyLCMObject *lcm_obj, PyObject *arg)
 
     dbg(DBG_PYTHON, "pylcm_handle_timeout(%p, %d)\n", lcm_obj, timeout_millis);
 
-    if (lcm_obj->saved_thread_state) {
+    if (lcm_obj->handle_in_progress) {
         PyErr_SetString(PyExc_RuntimeError,
                         "Simultaneous calls to handle() / handle_timeout() detected");
         return NULL;
     }
-    lcm_obj->saved_thread_state = PyEval_SaveThread();
+    lcm_obj->handle_in_progress = 1;
     lcm_obj->exception_raised = 0;
+
+    PyThreadState *ts = PyEval_SaveThread();
+    PyThread_tss_set(&pylcm_thread_state_key, ts);
 
     dbg(DBG_PYTHON, "calling lcm_handle_timeout(%p, %d)\n", lcm_obj->lcm, timeout_millis);
     int status = lcm_handle_timeout(lcm_obj->lcm, timeout_millis);
 
-    // Restore the thread state before returning back to Python.  The thread
-    // state may have already been restored by the callback function
-    // pylcm_msg_handler()
-    if (lcm_obj->saved_thread_state) {
-        PyEval_RestoreThread(lcm_obj->saved_thread_state);
-        lcm_obj->saved_thread_state = NULL;
+    // Restore the thread state before returning back to Python. It may
+    // have already been restored (and the TSS slot cleared) by the
+    // callback function pylcm_msg_handler().
+    ts = (PyThreadState *) PyThread_tss_get(&pylcm_thread_state_key);
+    if (ts) {
+        PyEval_RestoreThread(ts);
+        PyThread_tss_set(&pylcm_thread_state_key, NULL);
     }
+    lcm_obj->handle_in_progress = 0;
 
     if (lcm_obj->exception_raised) {
         return NULL;
@@ -413,7 +473,7 @@ static int pylcm_initobj(PyObject *self, PyObject *args, PyObject *kwargs)
         PyErr_SetString(PyExc_RuntimeError, "Couldn't create LCM");
         return -1;
     }
-    lcm_obj->saved_thread_state = NULL;
+    lcm_obj->handle_in_progress = 0;
 
     return 0;
 }

--- a/lcm-python/pylcm.h
+++ b/lcm-python/pylcm.h
@@ -14,11 +14,15 @@ typedef struct {
 
     int exception_raised;
 
-    PyObject *all_handlers;
+    // Set while LCM.handle() or LCM.handle_timeout() is active on this LCM.
+    // Read and written only while holding the GIL -- used for the
+    // "simultaneous calls" check. The actual suspended PyThreadState* is
+    // stored in thread-specific storage (see pylcm.c) so that
+    // pylcm_msg_handler can restore the GIL without dereferencing
+    // subs_obj->lcm_obj (which races with pylcm_unsubscribe).
+    int handle_in_progress;
 
-    // Stores the state of the thread that calls LCM.handle() or
-    // LCM.handle_timeout()
-    PyThreadState *saved_thread_state;
+    PyObject *all_handlers;
 } PyLCMObject;
 
 #ifdef __cplusplus

--- a/lcm/lcm.c
+++ b/lcm/lcm.c
@@ -403,20 +403,29 @@ int lcm_dispatch_handlers(lcm_t *lcm, lcm_recv_buf_t *buf, const char *channel)
 
     GPtrArray *handlers = lcm_get_handlers(lcm, channel);
 
-    // ref the handlers to prevent them from being destroyed by an
-    // lcm_unsubscribe.  This guarantees that handlers 0-(nhandlers-1) will not
-    // be destroyed during the callbacks.  Store nhandlers in a local variable
-    // so that we don't iterate over handlers that are added during the
-    // callbacks.
+    // Snapshot the handler list. We'll release lcm->mutex below in order
+    // to call each handler -- at that point another thread can run
+    // lcm_unsubscribe, which calls map_remove_handler_callback on every
+    // per-channel array (including this one), shifting or shrinking it
+    // under us. Setting callback_scheduled=1 on the snapshotted entries
+    // keeps the lcm_subscription_t structs themselves alive (unsubscribe
+    // defers free until callback_scheduled goes back to 0), but does not
+    // prevent the array contents from being mutated. Iterating a local
+    // snapshot avoids out-of-bounds reads and skipped/duplicated
+    // dispatches.
     int nhandlers = handlers->len;
-    for (int i = 0; i < nhandlers; i++) {
-        lcm_subscription_t *subscription = (lcm_subscription_t *) g_ptr_array_index(handlers, i);
-        subscription->callback_scheduled = 1;
+    lcm_subscription_t **snapshot = NULL;
+    if (nhandlers > 0) {
+        snapshot = (lcm_subscription_t **) malloc(sizeof(lcm_subscription_t *) * nhandlers);
+        for (int i = 0; i < nhandlers; i++) {
+            snapshot[i] = (lcm_subscription_t *) g_ptr_array_index(handlers, i);
+            snapshot[i]->callback_scheduled = 1;
+        }
     }
 
     // now, call the handlers.
     for (int i = 0; i < nhandlers; i++) {
-        lcm_subscription_t *subscription = (lcm_subscription_t *) g_ptr_array_index(handlers, i);
+        lcm_subscription_t *subscription = snapshot[i];
 
         if (!subscription->marked_for_deletion && subscription->num_queued_messages > 0) {
             subscription->num_queued_messages--;
@@ -429,13 +438,17 @@ int lcm_dispatch_handlers(lcm_t *lcm, lcm_recv_buf_t *buf, const char *channel)
     // unref the handlers and check if any should be deleted
     GList *to_remove = NULL;
     for (int i = 0; i < nhandlers; i++) {
-        lcm_subscription_t *subscription = (lcm_subscription_t *) g_ptr_array_index(handlers, i);
+        lcm_subscription_t *subscription = snapshot[i];
 
         subscription->callback_scheduled = 0;
         if (subscription->marked_for_deletion)
             to_remove = g_list_prepend(to_remove, subscription);
     }
-    // actually delete handlers marked for deletion
+    free(snapshot);
+    // actually delete handlers marked for deletion. lcm_unsubscribe may
+    // already have removed these from handlers_all / handlers_map while
+    // callback_scheduled was set; g_ptr_array_remove and
+    // map_remove_handler_callback are no-ops in that case.
     for (; to_remove; to_remove = g_list_delete_link(to_remove, to_remove)) {
         lcm_subscription_t *subscription = (lcm_subscription_t *) to_remove->data;
         g_ptr_array_remove(lcm->handlers_all, subscription);

--- a/test/python/lcm_thread_test.py
+++ b/test/python/lcm_thread_test.py
@@ -74,6 +74,88 @@ class TestLcmThreads(unittest.TestCase):
 
         worker.join()
 
+    def test_unsubscribe_during_handle(self):
+        """Regression test for the data race between pylcm_unsubscribe and
+        pylcm_msg_handler's prologue. Previously the handler dereferenced
+        subs_obj->lcm_obj without holding the GIL, racing with unsubscribe
+        nulling that field. The race window is tight and not reachable
+        deterministically from pure Python, so this test stresses it across
+        many iterations.
+        """
+        for iteration in range(50):
+            lcm_obj = lcm.LCM("memq://")
+            stop = threading.Event()
+
+            def loop():
+                while not stop.is_set():
+                    lcm_obj.handle_timeout(10)
+
+            def noop(channel, data):
+                pass
+
+            worker = threading.Thread(target=loop)
+            worker.daemon = True
+            worker.start()
+
+            try:
+                subs = []
+                for i in range(200):
+                    s = lcm_obj.subscribe("channel", noop)
+                    subs.append(s)
+                    lcm_obj.publish("channel", b"x")
+
+                for s in subs:
+                    lcm_obj.unsubscribe(s)
+            finally:
+                stop.set()
+                worker.join(timeout=2.0)
+
+            self.assertFalse(
+                worker.is_alive(),
+                "handle_timeout worker hung at iteration %d" % iteration)
+
+    def test_unsubscribe_during_callback(self):
+        """Deterministic regression: call unsubscribe() while a user
+        callback is actively running in another thread, then let the
+        callback raise. Previously this crashed in pylcm_msg_handler's
+        epilogue, which wrote to subs_obj->lcm_obj->exception_raised after
+        unsubscribe had nulled subs_obj->lcm_obj.
+        """
+        lcm_obj = lcm.LCM("memq://")
+        in_callback = threading.Event()
+        release_callback = threading.Event()
+
+        def handler(channel, data):
+            in_callback.set()
+            release_callback.wait(timeout=5.0)
+            raise ValueError("intentional - exercises epilogue path")
+
+        sub = lcm_obj.subscribe("channel", handler)
+        lcm_obj.publish("channel", b"x")
+
+        def worker():
+            try:
+                lcm_obj.handle_timeout(5000)
+            except ValueError:
+                pass  # expected
+
+        t = threading.Thread(target=worker)
+        t.start()
+
+        # Event.wait releases the GIL, so the main thread can now run.
+        self.assertTrue(in_callback.wait(timeout=5.0),
+                        "callback never reached")
+
+        # Should complete cleanly even though the worker is still inside
+        # PyObject_CallObject (under the broken code, the epilogue would
+        # then deref a NULLed subs_obj->lcm_obj and segfault).
+        lcm_obj.unsubscribe(sub)
+
+        release_callback.set()
+        t.join(timeout=5.0)
+
+        self.assertFalse(t.is_alive())
+
 def main():
     unittest.main()
 


### PR DESCRIPTION
We use LCM in our python codebase and I've noticed a `Segmentation fault` related to the C code for unsubscribing. ([Our logs if you're interested.](https://github.com/dimensionalOS/dimos/actions/runs/24174044062/job/70551592227))

## How to reproduce

Remove my LLM generated fix, rebuild and see the two segfaults:

```bash
git checkout master -- lcm-python/module.c lcm-python/pylcm.c lcm-python/pylcm.h lcm/lcm.c
cmake --build build -j
PYTHONPATH=build/python python3 test/python/lcm_thread_test.py TestLcmThreads.test_unsubscribe_during_handle
PYTHONPATH=build/python python3 test/python/lcm_thread_test.py TestLcmThreads.test_unsubscribe_during_callback
```

Re-add fix, rebuild, and check tests:

```bash
git reset --hard HEAD
cmake --build build -j
PYTHONPATH=build/python python3 test/python/lcm_thread_test.py TestLcmThreads.test_unsubscribe_during_handle
PYTHONPATH=build/python python3 test/python/lcm_thread_test.py TestLcmThreads.test_unsubscribe_during_callback
```

## Fix

I don't know if this is the right approach, but the Python tests reliably reproduce the issue in case you want to try something different.