### PR TITLE
Fix Lua Build for macOS

### DIFF
--- a/lcm-lua/lua_ref_helper.c
+++ b/lcm-lua/lua_ref_helper.c
@@ -3,7 +3,9 @@
 #define FREELIST_REF 0
 
 #if LUA_VERSION_NUM >= 502
+#ifndef lua_objlen
 #define lua_objlen(L, INDEX) lua_rawlen(L, INDEX)
+#endif
 #endif
 
 /* convert a stack index to positive */


### PR DESCRIPTION
It seems that the latest version of lua defines `lua_objlen`, [causing build errors](https://github.com/nosracd/lcm/actions/runs/24630818909/job/72017764092). This PR guards our definition of `lua_objlen` so that it's only defined for older versions of lua which don't provide it.