### PR TITLE
Fix buffer overrun when lcm_unsubscribe is called from a subscription handler

### DIFF
--- a/lcm-python/pylcm.c
+++ b/lcm-python/pylcm.c
@@ -203,9 +203,6 @@ static PyObject *pylcm_unsubscribe(PyLCMObject *lcm_obj, PyObject *args)
 
     lcm_unsubscribe(lcm_obj->lcm, subs_obj->subscription);
     subs_obj->subscription = NULL;
-    Py_DECREF(subs_obj->handler);
-    subs_obj->handler = NULL;
-    subs_obj->lcm_obj = NULL;
 
     Py_RETURN_NONE;
 }

--- a/lcm/lcm.c
+++ b/lcm/lcm.c
@@ -320,8 +320,22 @@ int lcm_unsubscribe(lcm_t *lcm, lcm_subscription_t *subscription)
 {
     g_rec_mutex_lock(&lcm->mutex);
 
+    int foundit = 0;
+
+    // when called from within an lcm_handle callback, tampering with the
+    // handlers_map will throw off the indices in lcm_dispatch_handlers, so
+    // check for the dispatch sentinels and skip the body of this function if
+    // they're present.
+    if (!subscription || subscription->marked_for_deletion)
+        goto done;
+    if (subscription->callback_scheduled) {
+        subscription->marked_for_deletion = 1;
+        foundit = 1;
+        goto done;
+    }
+
     // remove the handler from the master list
-    int foundit = g_ptr_array_remove(lcm->handlers_all, subscription);
+    foundit = g_ptr_array_remove(lcm->handlers_all, subscription);
 
     if (lcm->provider && lcm->vtable->unsubscribe) {
         lcm->vtable->unsubscribe(lcm->provider, subscription->channel);
@@ -336,6 +350,7 @@ int lcm_unsubscribe(lcm_t *lcm, lcm_subscription_t *subscription)
             subscription->marked_for_deletion = 1;
     }
 
+done:
     g_rec_mutex_unlock(&lcm->mutex);
 
     return foundit ? 0 : -1;

--- a/test/c/memq_test.cpp
+++ b/test/c/memq_test.cpp
@@ -121,18 +121,20 @@ void SelfUnsubHandler(const lcm_recv_buf_t *, const char *, void *user_data);
 
 struct SelfUnsubHandlerState {
     lcm_t *lcm;
-    lcm_subscription_t *subscription = nullptr;
-    bool fired = false;
+    lcm_subscription_t *subscription;
+    bool fired;
 
     SelfUnsubHandlerState(lcm_t *_lcm)
-        : lcm(_lcm), subscription(lcm_subscribe(lcm, "channel", SelfUnsubHandler, this))
+        : lcm(_lcm),
+          subscription(lcm_subscribe(lcm, "channel", SelfUnsubHandler, this)),
+          fired(false)
     {
     }
 };
 
 void SelfUnsubHandler(const lcm_recv_buf_t *, const char *, void *user_data)
 {
-    auto &state = *reinterpret_cast<SelfUnsubHandlerState *>(user_data);
+    SelfUnsubHandlerState &state = *(SelfUnsubHandlerState *) (user_data);
     state.fired = true;
     lcm_unsubscribe(state.lcm, state.subscription);
 }

--- a/test/c/memq_test.cpp
+++ b/test/c/memq_test.cpp
@@ -116,3 +116,39 @@ TEST(LCM_C, MemqTimeout)
 
     lcm_destroy(lcm);
 }
+
+void SelfUnsubHandler(const lcm_recv_buf_t *, const char *, void *user_data);
+
+struct SelfUnsubHandlerState {
+    lcm_t *lcm;
+    lcm_subscription_t *subscription = nullptr;
+    bool fired = false;
+
+    SelfUnsubHandlerState(lcm_t *_lcm)
+        : lcm(_lcm), subscription(lcm_subscribe(lcm, "channel", SelfUnsubHandler, this))
+    {
+    }
+};
+
+void SelfUnsubHandler(const lcm_recv_buf_t *, const char *, void *user_data)
+{
+    auto &state = *reinterpret_cast<SelfUnsubHandlerState *>(user_data);
+    state.fired = true;
+    lcm_unsubscribe(state.lcm, state.subscription);
+}
+
+TEST(LCM_C, MemqUnsubWithoutSkippingHandler)
+{
+    // Publish a single message, and make sure that a handler unsubscribing
+    // itself does not mess up delivery for subsequent messages.
+    lcm_t *lcm = lcm_create("memq://");
+
+    SelfUnsubHandlerState handler1(lcm);
+    SelfUnsubHandlerState handler2(lcm);
+    SelfUnsubHandlerState handler3(lcm);
+    lcm_publish(lcm, "channel", "", 0);
+    EXPECT_GE(lcm_handle_timeout(lcm, 1000), 0);
+    EXPECT_TRUE(handler1.fired);
+    EXPECT_TRUE(handler2.fired);
+    EXPECT_TRUE(handler3.fired);
+}

--- a/test/python/lcm_thread_test.py
+++ b/test/python/lcm_thread_test.py
@@ -74,6 +74,88 @@ class TestLcmThreads(unittest.TestCase):
 
         worker.join()
 
+    def test_unsubscribe_during_handle(self):
+        """Regression test for the data race between pylcm_unsubscribe and
+        pylcm_msg_handler's prologue. Previously the handler dereferenced
+        subs_obj->lcm_obj without holding the GIL, racing with unsubscribe
+        nulling that field. The race window is tight and not reachable
+        deterministically from pure Python, so this test stresses it across
+        many iterations.
+        """
+        for iteration in range(50):
+            lcm_obj = lcm.LCM("memq://")
+            stop = threading.Event()
+
+            def loop():
+                while not stop.is_set():
+                    lcm_obj.handle_timeout(10)
+
+            def noop(channel, data):
+                pass
+
+            worker = threading.Thread(target=loop)
+            worker.daemon = True
+            worker.start()
+
+            try:
+                subs = []
+                for i in range(200):
+                    s = lcm_obj.subscribe("channel", noop)
+                    subs.append(s)
+                    lcm_obj.publish("channel", b"x")
+
+                for s in subs:
+                    lcm_obj.unsubscribe(s)
+            finally:
+                stop.set()
+                worker.join(timeout=2.0)
+
+            self.assertFalse(
+                worker.is_alive(),
+                "handle_timeout worker hung at iteration %d" % iteration)
+
+    def test_unsubscribe_during_callback(self):
+        """Deterministic regression: call unsubscribe() while a user
+        callback is actively running in another thread, then let the
+        callback raise. Previously this crashed in pylcm_msg_handler's
+        epilogue, which wrote to subs_obj->lcm_obj->exception_raised after
+        unsubscribe had nulled subs_obj->lcm_obj.
+        """
+        lcm_obj = lcm.LCM("memq://")
+        in_callback = threading.Event()
+        release_callback = threading.Event()
+
+        def handler(channel, data):
+            in_callback.set()
+            release_callback.wait(timeout=5.0)
+            raise ValueError("intentional - exercises epilogue path")
+
+        sub = lcm_obj.subscribe("channel", handler)
+        lcm_obj.publish("channel", b"x")
+
+        def worker():
+            try:
+                lcm_obj.handle_timeout(5000)
+            except ValueError:
+                pass  # expected
+
+        t = threading.Thread(target=worker)
+        t.start()
+
+        # Event.wait releases the GIL, so the main thread can now run.
+        self.assertTrue(in_callback.wait(timeout=5.0),
+                        "callback never reached")
+
+        # Should complete cleanly even though the worker is still inside
+        # PyObject_CallObject (under the broken code, the epilogue would
+        # then deref a NULLed subs_obj->lcm_obj and segfault).
+        lcm_obj.unsubscribe(sub)
+
+        release_callback.set()
+        t.join(timeout=5.0)
+
+        self.assertFalse(t.is_alive())
+
 def main():
     unittest.main()
 

--- a/test/python/lcm_thread_test.py
+++ b/test/python/lcm_thread_test.py
@@ -156,6 +156,14 @@ class TestLcmThreads(unittest.TestCase):
 
         self.assertFalse(t.is_alive())
 
+    def test_python_lcm_lifetime_with_attributeeror(self):
+        # if python reference counts are incorrect, this is enough to trigger
+        # either a SEGV or an ASAN warning from PyType_Ready
+        lcm_obj = lcm.LCM("memq://")
+        with self.assertRaises(AttributeError):
+            lcm_obj.does_not_have_this_attribute
+
+
 def main():
     unittest.main()
 


### PR DESCRIPTION
This PR prevents a buffer overflow that occurs if a registered subscription handler function calls `lcm_unsubscribe` on itself or its neighbors. `lcm_dispatch_handlers` uses a counting loop to access each subscription for a channel, but the current implementation of `lcm_unsubscribe` changes the length of that list, resulting in an attempt to call a function pointer in unallocated space past the end of the newly-shortened GPtrArray.

`lcm_dispatch_handlers` already marks subscriptions as "in use" by setting `callback_scheduled = 1`. `lcm_unsubscribe` knows not to `lcm_handler_free(subscription)` when that flag is set, so this PR broadens the scope of that check to also not modify the subscription lists. 

The fix is partially inspired by the lcm.c changes in #616, but avoids the malloc overhead of copying the entire list. The unit tests added in that PR have been copied in verbatim (with commit author set to @paul-nechifor), along with one more that came up a few times in my own debugging.

The python changes have been tested so far only on Py3.14 but I'll update this thread when I get some time to test on older Pythons.

This PR will close #619 