### PR TITLE
Flush debug messages as they're written.

### DIFF
--- a/lcm/dbg.h
+++ b/lcm/dbg.h
@@ -193,6 +193,7 @@ static void dbg_init()
             printf("%s", DCOLOR(mode)); \
             printf(__VA_ARGS__);        \
             printf(_NORMAL_);           \
+            fflush(stdout);             \
         }                               \
     }
 #define dbg_active(mode) (dbg_modes & (mode))
@@ -210,6 +211,7 @@ static void dbg_init()
         printf(color);       \
         printf(__VA_ARGS__); \
         printf(_NORMAL_);    \
+        fflush(stdout);      \
     }
 
 #ifdef __cplusplus


### PR DESCRIPTION
I have had a [long, confusing day](https://github.com/lcm-proj/lcm/pull/621), during which I've attempted to run lcm in debug mode with other instruments enabled (variously: gdb, valgrind, asan). The `$LCM_DBG` environment variable came in handy, but its output messages got interspersed in the terminal with my other tools (often causing color weirdness thanks to the VT100 color codes in the `dbg` output). Presuming anybody else who's using `LCM_DEBUG` is also having a Confusing Day, this PR adds a `fflush` to the end of the macros in `dbg.h`, `dbg` and `cprintf`, that tamper with the font color.