### PR TITLE
Honor LCM_JVM_OPT in lcm-logplayer-gui

### DIFF
--- a/lcm-java/lcm-logplayer-gui.bat
+++ b/lcm-java/lcm-logplayer-gui.bat
@@ -16,5 +16,7 @@ if exist %mydir%\lcm.jar (
 :: Add user's CLASSPATH, if set
 IF NOT "%CLASSPATH%"=="" set jars=%jars%;%CLASSPATH%
 
+IF "%LCM_JVM_OPT%"=="" set LCM_JVM_OPT=-Xmx128m -Xms64m
+
 :: Launch the applet
-java -server -Djava.net.preferIPv4Stack=true -Xmx64m -Xms32m -ea -cp "%jars%" lcm.logging.LogPlayer %*
+java -server -Djava.net.preferIPv4Stack=true %LCM_JAVA_OPT% -ea -cp "%jars%" lcm.logging.LogPlayer %*

--- a/lcm-java/lcm-logplayer-gui.sh
+++ b/lcm-java/lcm-logplayer-gui.sh
@@ -19,5 +19,7 @@ fi
 # Add user's CLASSPATH, if set
 [ -n "$CLASSPATH" ] && jars="$jars:$CLASSPATH"
 
+[ -z "$LCM_JVM_OPT" ] && LCM_JVM_OPT="-Xmx128m -Xms64m"
+
 # Launch the applet
-exec java -server -Xmx64m -Xms32m -ea -cp "$jars" lcm.logging.LogPlayer "$@"
+exec java -server ${LCM_JVM_OPT} -ea -cp "$jars" lcm.logging.LogPlayer "$@"


### PR DESCRIPTION
A colleague with a new high-dpi screen was unable to get `lcm-logplayer-gui` to render its user interface at scale. Whereas you can work around this issue in `lcm-spy` by setting the `LCM_JVM_OPT` environment variable, `lcm-logplayer-gui` doesn't honor this (and we had to edit the installed copy of the script to hack in `-Dsun.java2d.uiScale=2.0`).

This PR fixes that impedance mismatch by honoring LCM_JVM_OPT when launching the log player.