### PR TITLE
Remove unused counting variable

### DIFF
--- a/lcm/lcm_mpudpm.c
+++ b/lcm/lcm_mpudpm.c
@@ -679,8 +679,7 @@ static void *recv_thread(void *user)
         // loop over sockets and receive data on all the ones that have data
         SOCKET recv_fd = -1;
         uint16_t recv_port = -1;
-        int poll_i = 1;
-        for (GSList *it = lcm->recv_sockets; it != NULL; it = it->next, ++poll_i) {
+        for (GSList *it = lcm->recv_sockets; it != NULL; it = it->next) {
             // We should be holding receive_lock at the start of this loop
             mpudpm_socket_t *sub_socket = (mpudpm_socket_t *) it->data;
             if (!FD_ISSET(sub_socket->fd, &fds)) {


### PR DESCRIPTION
This PR fixes a recent CI regression caused by github actions upgrading its compiler.

```
D:\a\_temp\msys64\mingw64\bin\cc.exe -DLCM_STATIC -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_REENTRANT -ID:/a/lcm/lcm/build/lcm -ID:/a/lcm/lcm/lcm -isystem D:/a/_temp/msys64/mingw64/include/glib-2.0 -isystem D:/a/_temp/msys64/mingw64/lib/glib-2.0/include -Werror -std=gnu99 -Wall -Wshadow -Wuninitialized -Wunused-variable -Werror=return-type -Wno-unused-parameter -Wno-format-zero-length -Wno-stringop-truncation -O3 -DNDEBUG -fvisibility=hidden -MD -MT lcm/CMakeFiles/lcm-static.dir/lcm_mpudpm.c.obj -MF lcm\CMakeFiles\lcm-static.dir\lcm_mpudpm.c.obj.d -o lcm/CMakeFiles/lcm-static.dir/lcm_mpudpm.c.obj -c D:/a/lcm/lcm/lcm/lcm_mpudpm.c
D:/a/lcm/lcm/lcm/lcm_mpudpm.c: In function 'recv_thread':
D:/a/lcm/lcm/lcm/lcm_mpudpm.c:682:13: error: variable 'poll_i' set but not used [-Werror=unused-but-set-variable=]
  682 |         int poll_i = 1;
      |             ^~~~~~
cc1.exe: all warnings being treated as errors
```

from https://github.com/lcm-proj/lcm/actions/runs/28674561836/job/85045095213?pr=626#step:5:46