### PR TITLE
Fix uint32 overflow in UDP fragment offset bounds check

### DIFF
--- a/lcm/lcm_mpudpm.c
+++ b/lcm/lcm_mpudpm.c
@@ -454,7 +454,12 @@ static int recv_message_fragment(lcm_mpudpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz
     }
 #endif
 
-    if (fragment_offset + frag_size > fbuf->data_size) {
+    // fragment_offset and frag_size are both attacker-controlled uint32_t
+    // values taken straight off the wire. The old check
+    // (fragment_offset + frag_size > fbuf->data_size) can wrap around when
+    // fragment_offset is near UINT32_MAX, letting an invalid fragment slip
+    // through and causing memcpy() below to write far outside fbuf->data.
+    if (fragment_offset > fbuf->data_size || frag_size > fbuf->data_size - fragment_offset) {
         dbg(DBG_LCM, "dropping invalid fragment (off: %d, %d / %d)\n", fragment_offset, frag_size,
             fbuf->data_size);
         lcm_frag_buf_store_remove(lcm->frag_bufs, fbuf);

--- a/lcm/lcm_udpm.c
+++ b/lcm/lcm_udpm.c
@@ -302,7 +302,12 @@ static int _recv_message_fragment(lcm_udpm_t *lcm, lcm_buf_t *lcmb, uint32_t sz)
     }
 #endif
 
-    if (fragment_offset + frag_size > fbuf->data_size) {
+    // fragment_offset and frag_size are both attacker-controlled uint32_t
+    // values taken straight off the wire. The old check
+    // (fragment_offset + frag_size > fbuf->data_size) can wrap around when
+    // fragment_offset is near UINT32_MAX, letting an invalid fragment slip
+    // through and causing memcpy() below to write far outside fbuf->data.
+    if (fragment_offset > fbuf->data_size || frag_size > fbuf->data_size - fragment_offset) {
         dbg(DBG_LCM, "dropping invalid fragment (off: %d, %d / %d)\n", fragment_offset, frag_size,
             fbuf->data_size);
         lcm_frag_buf_store_remove(lcm->frag_bufs, fbuf);


### PR DESCRIPTION
The bounds check on incoming UDP fragments in `_recv_message_fragment` (lcm_udpm.c) and `recv_message_fragment` (lcm_mpudpm.c) is:

```c
if (fragment_offset + frag_size > fbuf->data_size) {
```

`fragment_offset` and `frag_size` are both `uint32_t`, and `fragment_offset` comes directly from the packet header (`ntohl(hdr->fragment_offset)`) with no prior range check. If a sender puts a `fragment_offset` close to `UINT32_MAX` and a small `frag_size` in the header, the addition wraps around and produces a small number, so the check passes for a fragment that's nowhere close to being in bounds. Right after that we do:

```c
memcpy(fbuf->data + fragment_offset, data_start, frag_size);
```

`fbuf->data` is a heap buffer only `data_size` bytes long, so this ends up computing a pointer billions of bytes past the allocation and writing attacker-controlled payload bytes there.

I confirmed the mechanism with a small standalone harness that copies the real check and memcpy verbatim against an actual `malloc`'d buffer (not just testing the boolean expression) — feeding it `fragment_offset = 0xFFFFFFF0`, `frag_size = 32` against a 1024-byte buffer reliably segfaults, while the same call with the rewritten check exits cleanly without ever reaching the memcpy.

The fix avoids the overflow by checking bounds without adding the two together:

```c
if (fragment_offset > fbuf->data_size ||
    frag_size > fbuf->data_size - fragment_offset) {
```

Since we only subtract once `fragment_offset` is already known to be `<= data_size`, the subtraction can't underflow either. Legitimate fragments (offset+size within bounds, exact fit) are still accepted the same as before, and oversized ones are still rejected — only the wrapped case changes from accept to reject.

Both `lcm_udpm.c` and `lcm_mpudpm.c` have the identical fragment-reassembly logic copy-pasted, so I applied the same fix in both places. Ran `format_code.sh`'s clang-format style on the changed lines; no other formatting changes needed.

I wasn't able to spin up the full glib/cmake build on this machine to run the existing test suite, so I'd appreciate it if CI/a maintainer could double check against the real fragment-reassembly path, but the arithmetic and the pointer computation are the same in both places regardless of the surrounding plumbing.
